### PR TITLE
feat: add .NET compatibility baseline (#14)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,3 +75,35 @@ public class MyService(IHonuaGrpcClient client)
 - **Stable** (`1.0.0+`): Published to NuGet.org after validation
 
 All packages follow [Semantic Versioning](https://semver.org/). Major versions are coordinated across all Honua SDKs.
+
+## Server Compatibility Baseline
+
+`Honua.Sdk.Admin` currently requires Honua Server
+`HonuaAdminCompatibility.MinimumSupportedServerVersion` or newer and a minimum
+server release channel baseline of `preview`. The admin client checks this
+baseline against `GET /api/v1/admin/capabilities`, which also advertises coarse
+feature flags for metadata and manifest workflows.
+
+Typical startup flow:
+
+```csharp
+using Honua.Sdk.Admin;
+
+var compatibility = await adminClient.CheckCompatibilityAsync();
+
+if (!compatibility.IsSupported)
+{
+    throw new InvalidOperationException(
+        compatibility.UnsupportedReason ??
+        "The connected Honua Server is not supported by this SDK.");
+}
+
+if (compatibility.Features.ManifestExport)
+{
+    var manifest = await adminClient.GetManifestAsync();
+}
+```
+
+Use `GetCapabilitiesAsync()` directly when you need the raw compatibility
+metadata, including `releaseChannel`, `metadataSchemas`, and the
+`manifestDryRun` / `manifestPrune` feature flags.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,51 @@ foreach (var feature in response.Features)
     Console.WriteLine($"{feature.Id}: {feature.Attributes["name"]}");
 ```
 
+## Admin compatibility checks
+
+`Honua.Sdk.Admin` declares a minimum supported server version through
+`HonuaAdminCompatibility.MinimumSupportedServerVersion`, requires at least the
+`preview` server release channel, and can validate a connected server against
+`GET /api/v1/admin/capabilities`.
+
+```csharp
+using Honua.Sdk.Admin;
+using Honua.Sdk.Admin.Models;
+
+var compatibility = await adminClient.CheckCompatibilityAsync();
+
+if (!compatibility.IsSupported)
+{
+    throw new InvalidOperationException(
+        $"Honua Server {compatibility.ServerVersion} is not supported. " +
+        $"Minimum supported version: {compatibility.MinimumSupportedServerVersion}. " +
+        $"{compatibility.UnsupportedReason}");
+}
+
+if (compatibility.Features.ManifestApply && compatibility.Features.ManifestDryRun)
+{
+    var preview = await adminClient.ApplyManifestAsync(new ManifestApplyRequest
+    {
+        DryRun = true,
+        Resources = []
+    });
+}
+
+if (compatibility.Features.MetadataResources)
+{
+    var resources = await adminClient.ListMetadataResourcesAsync();
+}
+```
+
+`CheckCompatibilityAsync()` uses the server's compatibility metadata to verify:
+- the advertised server version is at or above the SDK baseline
+- the advertised release channel is at or above `preview`
+- the control-plane API major version is compatible
+- the control-plane base path still matches `/api/v1/admin`
+
+For lower-level inspection, call `GetCapabilitiesAsync()` directly and read the
+coarse-grained feature flags from `result.Features`.
+
 ## Repository layout
 
 ```
@@ -69,7 +114,7 @@ docs/
 - **[Quickstart](docs/quickstart.md)** -- build a console app that queries
   features, lists services, and geocodes an address in 5 minutes
 - **[INSTALL.md](INSTALL.md)** -- NuGet and GitHub Packages setup, version
-  policy
+  policy and server compatibility baseline
 - **[Field Data Collection](examples/FieldDataCollection/)** -- full MAUI
   example with offline sync and map views
 - **[gRPC vs Forms](examples/FieldDataCollection/GRPC_FORMS_COMPARISON.md)**

--- a/src/Honua.Sdk.Admin/HonuaAdminClient.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClient.cs
@@ -218,6 +218,13 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     }
 
     /// <inheritdoc />
+    public async Task<ServerCompatibilityResult> CheckCompatibilityAsync(CancellationToken ct = default)
+    {
+        var capabilities = await GetCapabilitiesAsync(ct).ConfigureAwait(false);
+        return HonuaAdminCompatibility.Evaluate(capabilities);
+    }
+
+    /// <inheritdoc />
     public async Task<MetadataManifest> GetManifestAsync(string? ns = null, CancellationToken ct = default)
     {
         var query = BuildQuery(("namespace", ns));

--- a/src/Honua.Sdk.Admin/HonuaAdminCompatibility.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminCompatibility.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Admin.Models;
+
+namespace Honua.Sdk.Admin;
+
+/// <summary>
+/// Compatibility helpers and baselines for the Honua Admin SDK.
+/// </summary>
+public static class HonuaAdminCompatibility
+{
+    /// <summary>
+    /// Minimum Honua Server version supported by this SDK baseline.
+    /// </summary>
+    public const string MinimumSupportedServerVersion = "0.1.0";
+
+    /// <summary>
+    /// Control-plane API major version expected by this SDK.
+    /// </summary>
+    public const int SupportedControlPlaneApiMajor = 1;
+
+    /// <summary>
+    /// Control-plane API base path expected by this SDK.
+    /// </summary>
+    public const string SupportedControlPlaneApiBasePath = "/api/v1/admin";
+
+    /// <summary>
+    /// Minimum server release channel expected by this SDK baseline.
+    /// </summary>
+    public const string MinimumSupportedReleaseChannel = "preview";
+
+    /// <summary>
+    /// Evaluates whether a server capabilities payload is supported by this SDK.
+    /// </summary>
+    /// <param name="capabilities">Capabilities payload returned by the server.</param>
+    /// <returns>A compatibility result with support status and coarse feature metadata.</returns>
+    public static ServerCompatibilityResult Evaluate(AdminCapabilitiesResponse capabilities)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+
+        if (string.IsNullOrWhiteSpace(capabilities.ServerVersion))
+        {
+            return Unsupported(capabilities, "Server did not return compatibility metadata.");
+        }
+
+        if (!SemanticVersion.TryParse(capabilities.ServerVersion, out var serverVersion))
+        {
+            return Unsupported(
+                capabilities,
+                $"Server version '{capabilities.ServerVersion}' could not be parsed.");
+        }
+
+        if (!SemanticVersion.TryParse(MinimumSupportedServerVersion, out var minimumVersion))
+        {
+            throw new InvalidOperationException(
+                $"Configured minimum supported server version '{MinimumSupportedServerVersion}' is invalid.");
+        }
+
+        if (serverVersion.CompareTo(minimumVersion) < 0)
+        {
+            return Unsupported(
+                capabilities,
+                $"Server version '{capabilities.ServerVersion}' is below the minimum supported server version '{MinimumSupportedServerVersion}'.");
+        }
+
+        if (capabilities.ControlPlaneApi.Major != SupportedControlPlaneApiMajor)
+        {
+            return Unsupported(
+                capabilities,
+                $"Control-plane API major '{capabilities.ControlPlaneApi.Major}' is not supported. Expected '{SupportedControlPlaneApiMajor}'.");
+        }
+
+        var normalizedBasePath = NormalizePath(capabilities.ControlPlaneApi.BasePath);
+        if (!string.Equals(normalizedBasePath, SupportedControlPlaneApiBasePath, StringComparison.OrdinalIgnoreCase))
+        {
+            return Unsupported(
+                capabilities,
+                $"Control-plane API base path '{capabilities.ControlPlaneApi.BasePath}' is not supported. Expected '{SupportedControlPlaneApiBasePath}'.");
+        }
+
+        if (capabilities.ControlPlaneApi.Deprecated)
+        {
+            return Unsupported(
+                capabilities,
+                "The advertised control-plane API major is deprecated.");
+        }
+
+        var actualReleaseChannelRank = GetReleaseChannelRank(capabilities.ReleaseChannel);
+        var minimumReleaseChannelRank = GetReleaseChannelRank(MinimumSupportedReleaseChannel);
+        if (actualReleaseChannelRank < 0)
+        {
+            return Unsupported(
+                capabilities,
+                $"Release channel '{capabilities.ReleaseChannel}' is not recognized by this SDK baseline.");
+        }
+
+        if (actualReleaseChannelRank < minimumReleaseChannelRank)
+        {
+            return Unsupported(
+                capabilities,
+                $"Release channel '{capabilities.ReleaseChannel}' is below the minimum supported release channel '{MinimumSupportedReleaseChannel}'.");
+        }
+
+        return new ServerCompatibilityResult
+        {
+            Capabilities = capabilities,
+            IsSupported = true
+        };
+    }
+
+    private static ServerCompatibilityResult Unsupported(AdminCapabilitiesResponse capabilities, string reason)
+        => new()
+        {
+            Capabilities = capabilities,
+            IsSupported = false,
+            UnsupportedReason = reason
+        };
+
+    private static string NormalizePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return string.Empty;
+        }
+
+        var normalized = path.Trim();
+        if (!normalized.StartsWith('/'))
+        {
+            normalized = "/" + normalized;
+        }
+
+        return normalized.TrimEnd('/');
+    }
+
+    private static int GetReleaseChannelRank(string releaseChannel)
+        => releaseChannel.Trim().ToLowerInvariant() switch
+        {
+            "nightly" => 0,
+            "dev" => 1,
+            "alpha" => 2,
+            "preview" => 3,
+            "beta" => 4,
+            "rc" => 5,
+            "stable" => 6,
+            "lts" => 7,
+            _ => -1
+        };
+
+    private readonly record struct SemanticVersion(int Major, int Minor, int Patch) : IComparable<SemanticVersion>
+    {
+        public int CompareTo(SemanticVersion other)
+        {
+            var major = Major.CompareTo(other.Major);
+            if (major != 0)
+            {
+                return major;
+            }
+
+            var minor = Minor.CompareTo(other.Minor);
+            if (minor != 0)
+            {
+                return minor;
+            }
+
+            return Patch.CompareTo(other.Patch);
+        }
+
+        public static bool TryParse(string? value, out SemanticVersion version)
+        {
+            version = default;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var normalized = value.Trim();
+            if (normalized.StartsWith('v') || normalized.StartsWith('V'))
+            {
+                normalized = normalized[1..];
+            }
+
+            var preReleaseIndex = normalized.IndexOf('-');
+            var buildIndex = normalized.IndexOf('+');
+            var endIndex = normalized.Length;
+
+            if (preReleaseIndex >= 0)
+            {
+                endIndex = Math.Min(endIndex, preReleaseIndex);
+            }
+
+            if (buildIndex >= 0)
+            {
+                endIndex = Math.Min(endIndex, buildIndex);
+            }
+
+            normalized = normalized[..endIndex];
+            var parts = normalized.Split('.');
+            if (parts.Length is < 2 or > 3)
+            {
+                return false;
+            }
+
+            if (!int.TryParse(parts[0], out var major) ||
+                !int.TryParse(parts[1], out var minor))
+            {
+                return false;
+            }
+
+            var patch = 0;
+            if (parts.Length == 3 && !int.TryParse(parts[2], out patch))
+            {
+                return false;
+            }
+
+            version = new SemanticVersion(major, minor, patch);
+            return true;
+        }
+    }
+}

--- a/src/Honua.Sdk.Admin/IHonuaAdminClient.cs
+++ b/src/Honua.Sdk.Admin/IHonuaAdminClient.cs
@@ -142,6 +142,13 @@ public interface IHonuaAdminClient
     Task<AdminCapabilitiesResponse> GetCapabilitiesAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Checks whether the connected server is supported by this SDK baseline.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A compatibility result containing support status and coarse feature metadata.</returns>
+    Task<ServerCompatibilityResult> CheckCompatibilityAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Exports the metadata manifest.
     /// </summary>
     /// <param name="ns">Optional namespace filter.</param>

--- a/src/Honua.Sdk.Admin/Models/Compatibility.cs
+++ b/src/Honua.Sdk.Admin/Models/Compatibility.cs
@@ -1,0 +1,248 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Admin.Models;
+
+/// <summary>
+/// Admin capabilities response payload exposing server compatibility metadata.
+/// </summary>
+public sealed class AdminCapabilitiesResponse
+{
+    /// <summary>
+    /// Supported metadata API versions.
+    /// </summary>
+    [JsonPropertyName("metadataApiVersions")]
+    public IReadOnlyList<string> MetadataApiVersions { get; init; } = [];
+
+    /// <summary>
+    /// Supported resource kinds.
+    /// </summary>
+    [JsonPropertyName("resourceKinds")]
+    public IReadOnlyList<string> ResourceKinds { get; init; } = [];
+
+    /// <summary>
+    /// Indicates manifest export/apply support.
+    /// </summary>
+    [JsonPropertyName("manifestSupported")]
+    public bool ManifestSupported { get; init; }
+
+    /// <summary>
+    /// Indicates whether dry-run is supported for manifest apply.
+    /// </summary>
+    [JsonPropertyName("manifestDryRunSupported")]
+    public bool ManifestDryRunSupported { get; init; }
+
+    /// <summary>
+    /// Indicates whether prune is supported for manifest apply.
+    /// </summary>
+    [JsonPropertyName("manifestPruneSupported")]
+    public bool ManifestPruneSupported { get; init; }
+
+    /// <summary>
+    /// Compatibility metadata advertised by the server.
+    /// </summary>
+    [JsonPropertyName("compatibility")]
+    public AdminCompatibilityInfo? Compatibility { get; init; }
+
+    /// <summary>
+    /// Server version string reported by the compatibility contract.
+    /// </summary>
+    [JsonIgnore]
+    public string ServerVersion => Compatibility?.ServerVersion ?? string.Empty;
+
+    /// <summary>
+    /// Release channel reported by the server.
+    /// </summary>
+    [JsonIgnore]
+    public string ReleaseChannel => Compatibility?.ReleaseChannel ?? string.Empty;
+
+    /// <summary>
+    /// Control-plane API compatibility metadata.
+    /// </summary>
+    [JsonIgnore]
+    public ControlPlaneApiCompatibility ControlPlaneApi => Compatibility?.ControlPlaneApi ?? new();
+
+    /// <summary>
+    /// Metadata schema compatibility information.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<MetadataSchemaCompatibility> MetadataSchemas => Compatibility?.MetadataSchemas ?? [];
+
+    /// <summary>
+    /// Coarse-grained feature support advertised by the server.
+    /// </summary>
+    [JsonIgnore]
+    public AdminFeatureCompatibility Features => Compatibility?.Features ?? new();
+}
+
+/// <summary>
+/// Compatibility metadata returned by the admin capabilities contract.
+/// </summary>
+public sealed class AdminCompatibilityInfo
+{
+    /// <summary>
+    /// Server version string.
+    /// </summary>
+    [JsonPropertyName("serverVersion")]
+    public string ServerVersion { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Release channel string such as stable, beta, or preview.
+    /// </summary>
+    [JsonPropertyName("releaseChannel")]
+    public string ReleaseChannel { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Control-plane API compatibility metadata.
+    /// </summary>
+    [JsonPropertyName("controlPlaneApi")]
+    public ControlPlaneApiCompatibility ControlPlaneApi { get; init; } = new();
+
+    /// <summary>
+    /// Metadata schema compatibility metadata.
+    /// </summary>
+    [JsonPropertyName("metadataSchemas")]
+    public IReadOnlyList<MetadataSchemaCompatibility> MetadataSchemas { get; init; } = [];
+
+    /// <summary>
+    /// Coarse-grained feature flags advertised by the server.
+    /// </summary>
+    [JsonPropertyName("features")]
+    public AdminFeatureCompatibility Features { get; init; } = new();
+}
+
+/// <summary>
+/// Control-plane API compatibility metadata.
+/// </summary>
+public sealed class ControlPlaneApiCompatibility
+{
+    /// <summary>
+    /// Control-plane API major version.
+    /// </summary>
+    [JsonPropertyName("major")]
+    public int Major { get; init; }
+
+    /// <summary>
+    /// Control-plane API base path served by the server.
+    /// </summary>
+    [JsonPropertyName("basePath")]
+    public string BasePath { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the control-plane API surface is deprecated.
+    /// </summary>
+    [JsonPropertyName("deprecated")]
+    public bool Deprecated { get; init; }
+}
+
+/// <summary>
+/// Metadata schema compatibility metadata.
+/// </summary>
+public sealed class MetadataSchemaCompatibility
+{
+    /// <summary>
+    /// Schema version string.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the schema version is deprecated.
+    /// </summary>
+    [JsonPropertyName("deprecated")]
+    public bool Deprecated { get; init; }
+}
+
+/// <summary>
+/// Coarse-grained feature flags advertised by the server.
+/// </summary>
+public sealed class AdminFeatureCompatibility
+{
+    /// <summary>
+    /// Whether metadata resource endpoints are available.
+    /// </summary>
+    [JsonPropertyName("metadataResources")]
+    public bool MetadataResources { get; init; }
+
+    /// <summary>
+    /// Whether metadata manifest export is available.
+    /// </summary>
+    [JsonPropertyName("manifestExport")]
+    public bool ManifestExport { get; init; }
+
+    /// <summary>
+    /// Whether metadata manifest apply is available.
+    /// </summary>
+    [JsonPropertyName("manifestApply")]
+    public bool ManifestApply { get; init; }
+
+    /// <summary>
+    /// Whether metadata manifest dry-run is available.
+    /// </summary>
+    [JsonPropertyName("manifestDryRun")]
+    public bool ManifestDryRun { get; init; }
+
+    /// <summary>
+    /// Whether metadata manifest prune is available.
+    /// </summary>
+    [JsonPropertyName("manifestPrune")]
+    public bool ManifestPrune { get; init; }
+}
+
+/// <summary>
+/// Result of evaluating whether a server is supported by this SDK.
+/// </summary>
+public sealed class ServerCompatibilityResult
+{
+    /// <summary>
+    /// Minimum server version supported by this SDK.
+    /// </summary>
+    public string MinimumSupportedServerVersion { get; init; } = HonuaAdminCompatibility.MinimumSupportedServerVersion;
+
+    /// <summary>
+    /// Minimum server release channel supported by this SDK baseline.
+    /// </summary>
+    public string MinimumSupportedReleaseChannel { get; init; } = HonuaAdminCompatibility.MinimumSupportedReleaseChannel;
+
+    /// <summary>
+    /// The capabilities payload returned by the server.
+    /// </summary>
+    public AdminCapabilitiesResponse Capabilities { get; init; } = new();
+
+    /// <summary>
+    /// Whether the connected server is supported by this SDK baseline.
+    /// </summary>
+    public bool IsSupported { get; init; }
+
+    /// <summary>
+    /// Optional reason explaining why the server is unsupported.
+    /// </summary>
+    public string? UnsupportedReason { get; init; }
+
+    /// <summary>
+    /// Server version string reported by the compatibility contract.
+    /// </summary>
+    public string ServerVersion => Capabilities.ServerVersion;
+
+    /// <summary>
+    /// Release channel reported by the server.
+    /// </summary>
+    public string ReleaseChannel => Capabilities.ReleaseChannel;
+
+    /// <summary>
+    /// Control-plane API compatibility metadata.
+    /// </summary>
+    public ControlPlaneApiCompatibility ControlPlaneApi => Capabilities.ControlPlaneApi;
+
+    /// <summary>
+    /// Metadata schema compatibility metadata.
+    /// </summary>
+    public IReadOnlyList<MetadataSchemaCompatibility> MetadataSchemas => Capabilities.MetadataSchemas;
+
+    /// <summary>
+    /// Coarse-grained feature support advertised by the server.
+    /// </summary>
+    public AdminFeatureCompatibility Features => Capabilities.Features;
+}

--- a/src/Honua.Sdk.Admin/Models/Manifests.cs
+++ b/src/Honua.Sdk.Admin/Models/Manifests.cs
@@ -166,39 +166,3 @@ public sealed class AdminVersionResponse
     [JsonPropertyName("serverTime")]
     public DateTimeOffset ServerTime { get; init; }
 }
-
-/// <summary>
-/// Admin capabilities response payload.
-/// </summary>
-public sealed class AdminCapabilitiesResponse
-{
-    /// <summary>
-    /// Supported metadata API versions.
-    /// </summary>
-    [JsonPropertyName("metadataApiVersions")]
-    public IReadOnlyList<string> MetadataApiVersions { get; init; } = [];
-
-    /// <summary>
-    /// Supported resource kinds.
-    /// </summary>
-    [JsonPropertyName("resourceKinds")]
-    public IReadOnlyList<string> ResourceKinds { get; init; } = [];
-
-    /// <summary>
-    /// Indicates manifest export/apply support.
-    /// </summary>
-    [JsonPropertyName("manifestSupported")]
-    public bool ManifestSupported { get; init; }
-
-    /// <summary>
-    /// Indicates whether dry-run is supported for manifest apply.
-    /// </summary>
-    [JsonPropertyName("manifestDryRunSupported")]
-    public bool ManifestDryRunSupported { get; init; }
-
-    /// <summary>
-    /// Indicates whether prune is supported for manifest apply.
-    /// </summary>
-    [JsonPropertyName("manifestPruneSupported")]
-    public bool ManifestPruneSupported { get; init; }
-}

--- a/tests/Honua.Sdk.Admin.Tests/CompatibilityTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/CompatibilityTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Admin;
+using Honua.Sdk.Admin.Tests.Fixtures;
+
+namespace Honua.Sdk.Admin.Tests;
+
+public sealed class CompatibilityTests
+{
+    [Fact]
+    public async Task CheckCompatibilityAsync_ReturnsSupportedResult_AndFeatures()
+    {
+        var client = TestHelpers.CreateClient(req =>
+        {
+            Assert.Contains("/admin/capabilities", req.RequestUri!.PathAndQuery);
+            return Task.FromResult(TestHelpers.CreateJsonResponse(new
+            {
+                compatibility = new
+                {
+                    serverVersion = "0.1.0",
+                    releaseChannel = "beta",
+                    controlPlaneApi = new
+                    {
+                        major = 1,
+                        basePath = "/api/v1/admin",
+                        deprecated = false
+                    },
+                    metadataSchemas = new[]
+                    {
+                        new
+                        {
+                            version = "honua.io/v1alpha1",
+                            deprecated = false
+                        }
+                    },
+                    features = new
+                    {
+                        metadataResources = true,
+                        manifestExport = true,
+                        manifestApply = true,
+                        manifestDryRun = true,
+                        manifestPrune = false
+                    }
+                }
+            }));
+        });
+
+        var result = await client.CheckCompatibilityAsync();
+
+        Assert.True(result.IsSupported);
+        Assert.Null(result.UnsupportedReason);
+        Assert.Equal(HonuaAdminCompatibility.MinimumSupportedServerVersion, result.MinimumSupportedServerVersion);
+        Assert.Equal("0.1.0", result.ServerVersion);
+        Assert.Equal("beta", result.ReleaseChannel);
+        Assert.True(result.Features.MetadataResources);
+        Assert.True(result.Features.ManifestApply);
+        Assert.True(result.Features.ManifestDryRun);
+        Assert.False(result.Features.ManifestPrune);
+    }
+
+    [Fact]
+    public async Task CheckCompatibilityAsync_ReturnsUnsupportedResult_WhenServerVersionBelowBaseline()
+    {
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateJsonResponse(new
+            {
+                compatibility = new
+                {
+                    serverVersion = "0.0.9",
+                    releaseChannel = "preview",
+                    controlPlaneApi = new
+                    {
+                        major = 1,
+                        basePath = "/api/v1/admin",
+                        deprecated = false
+                    },
+                    metadataSchemas = new[]
+                    {
+                        new
+                        {
+                            version = "honua.io/v1alpha1",
+                            deprecated = false
+                        }
+                    },
+                    features = new
+                    {
+                        metadataResources = true,
+                        manifestExport = true,
+                        manifestApply = true,
+                        manifestDryRun = false,
+                        manifestPrune = false
+                    }
+                }
+            })));
+
+        var result = await client.CheckCompatibilityAsync();
+
+        Assert.False(result.IsSupported);
+        Assert.Contains(HonuaAdminCompatibility.MinimumSupportedServerVersion, result.UnsupportedReason);
+        Assert.Equal("0.0.9", result.ServerVersion);
+    }
+
+    [Fact]
+    public async Task CheckCompatibilityAsync_ReturnsUnsupportedResult_WhenCompatibilityMetadataMissing()
+    {
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateJsonResponse(new
+            {
+                metadataApiVersions = new[] { "honua.io/v1alpha1" },
+                manifestSupported = true
+            })));
+
+        var result = await client.CheckCompatibilityAsync();
+
+        Assert.False(result.IsSupported);
+        Assert.Equal("Server did not return compatibility metadata.", result.UnsupportedReason);
+        Assert.Equal(string.Empty, result.ServerVersion);
+    }
+
+    [Fact]
+    public async Task CheckCompatibilityAsync_ReturnsUnsupportedResult_WhenReleaseChannelBelowBaseline()
+    {
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateJsonResponse(new
+            {
+                compatibility = new
+                {
+                    serverVersion = "0.1.0",
+                    releaseChannel = "alpha",
+                    controlPlaneApi = new
+                    {
+                        major = 1,
+                        basePath = "/api/v1/admin",
+                        deprecated = false
+                    },
+                    metadataSchemas = Array.Empty<object>(),
+                    features = new
+                    {
+                        metadataResources = true,
+                        manifestExport = true,
+                        manifestApply = true,
+                        manifestDryRun = true,
+                        manifestPrune = true
+                    }
+                }
+            })));
+
+        var result = await client.CheckCompatibilityAsync();
+
+        Assert.False(result.IsSupported);
+        Assert.Contains(HonuaAdminCompatibility.MinimumSupportedReleaseChannel, result.UnsupportedReason);
+    }
+}

--- a/tests/Honua.Sdk.Admin.Tests/ManifestTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/ManifestTests.cs
@@ -40,7 +40,34 @@ public sealed class ManifestTests
             resourceKinds = new[] { "Layer", "Service" },
             manifestSupported = true,
             manifestDryRunSupported = true,
-            manifestPruneSupported = true
+            manifestPruneSupported = true,
+            compatibility = new
+            {
+                serverVersion = "0.1.0",
+                releaseChannel = "beta",
+                controlPlaneApi = new
+                {
+                    major = 1,
+                    basePath = "/api/v1/admin",
+                    deprecated = false
+                },
+                metadataSchemas = new[]
+                {
+                    new
+                    {
+                        version = "honua.io/v1alpha1",
+                        deprecated = false
+                    }
+                },
+                features = new
+                {
+                    metadataResources = true,
+                    manifestExport = true,
+                    manifestApply = true,
+                    manifestDryRun = true,
+                    manifestPrune = true
+                }
+            }
         };
 
         var client = TestHelpers.CreateClient(req =>
@@ -51,9 +78,17 @@ public sealed class ManifestTests
 
         var result = await client.GetCapabilitiesAsync();
 
+        Assert.Equal("0.1.0", result.ServerVersion);
+        Assert.Equal("beta", result.ReleaseChannel);
         Assert.True(result.ManifestSupported);
         Assert.True(result.ManifestDryRunSupported);
+        Assert.True(result.ManifestPruneSupported);
         Assert.Contains("Layer", result.ResourceKinds);
+        Assert.Equal(1, result.ControlPlaneApi.Major);
+        Assert.True(result.Features.ManifestApply);
+        Assert.True(result.Features.ManifestDryRun);
+        Assert.Single(result.MetadataSchemas);
+        Assert.Equal("honua.io/v1alpha1", result.MetadataSchemas[0].Version);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add admin compatibility models and a `CheckCompatibilityAsync()` helper
- preserve legacy top-level capability fields while wiring the new compatibility contract
- document the compatibility handshake and cover supported/unsupported cases in tests

## Validation
- `dotnet test tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj --configuration Release`

Closes #14
