### PR TITLE
feat: .NET SDK sample app and staging integration test suite (#honua-sdk-dotnet-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -35,6 +43,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -45,3 +61,28 @@ jobs:
 
       - name: Test
         run: dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release
+
+  dotnet-admin-bootstrap-sample:
+    name: Admin Bootstrap Sample
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build canonical sample
+        run: dotnet build examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj --configuration Release /p:TreatWarningsAsErrors=true
+
+      - name: Test canonical sample workflow
+        run: dotnet test tests/AdminBootstrapConsole.Tests/AdminBootstrapConsole.Tests.csproj --configuration Release

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -18,77 +18,265 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
-  publish-dotnet-packages:
+  release-smoke:
+    name: Release Smoke
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Build Admin SDK
-        run: dotnet build src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj --configuration Release /p:TreatWarningsAsErrors=true
-
-      - name: Test Admin SDK
-        run: dotnet test tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj --configuration Release
-
-      - name: Build gRPC SDK
-        run: dotnet build src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release /p:TreatWarningsAsErrors=true
-
-      - name: Test gRPC SDK
-        run: dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release
-
       - name: Validate tag version
         if: github.event_name == 'push'
+        shell: bash
         run: |
           tag_version="${GITHUB_REF_NAME#dotnet-sdk-v}"
-
-          admin_version="$(grep '<Version>' src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/' || echo '')"
-          grpc_version="$(grep '<Version>' src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/' || echo '')"
+          projects=(
+            "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
+            "src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj"
+            "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
+            "src/Honua.Sdk.Features/Honua.Sdk.Features.csproj"
+          )
 
           errors=0
-          if [[ -n "$admin_version" && "$tag_version" != "$admin_version" ]]; then
-            echo "Tag version ($tag_version) does not match Honua.Sdk.Admin version ($admin_version)."
-            errors=1
-          fi
-          if [[ -n "$grpc_version" && "$tag_version" != "$grpc_version" ]]; then
-            echo "Tag version ($tag_version) does not match Honua.Sdk.Grpc version ($grpc_version)."
-            errors=1
-          fi
-          if [[ $errors -ne 0 ]]; then
+
+          for project in "${projects[@]}"; do
+            version="$(grep '<Version>' "${project}" | sed 's/.*<Version>\(.*\)<\/Version>/\1/' || echo '')"
+            if [[ -n "${version}" && "${tag_version}" != "${version}" ]]; then
+              echo "Tag version (${tag_version}) does not match ${project} version (${version})."
+              errors=1
+            fi
+          done
+
+          if [[ ${errors} -ne 0 ]]; then
             exit 1
           fi
 
-      - name: Security audit (NuGet dependencies)
+      - name: Build SDK packages
+        shell: bash
         run: |
-          dotnet list src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj package --vulnerable --include-transitive 2>&1 | tee /tmp/audit-admin.txt
-          dotnet list src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj package --vulnerable --include-transitive 2>&1 | tee /tmp/audit-grpc.txt
-          if grep -qi "has the following vulnerable packages" /tmp/audit-admin.txt /tmp/audit-grpc.txt; then
-            echo "::error::Vulnerable NuGet dependencies detected. Fix before publishing."
+          projects=(
+            "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
+            "src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj"
+            "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
+            "src/Honua.Sdk.Features/Honua.Sdk.Features.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            dotnet build "${project}" --configuration Release /p:TreatWarningsAsErrors=true
+          done
+
+      - name: Test SDK packages
+        shell: bash
+        run: |
+          projects=(
+            "tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj"
+            "tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj"
+            "tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj"
+            "tests/Honua.Sdk.Features.Tests/Honua.Sdk.Features.Tests.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            dotnet test "${project}" --configuration Release
+          done
+
+      - name: Build canonical sample
+        run: dotnet build examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj --configuration Release /p:TreatWarningsAsErrors=true
+
+      - name: Test canonical sample workflow
+        run: dotnet test tests/AdminBootstrapConsole.Tests/AdminBootstrapConsole.Tests.csproj --configuration Release
+
+      - name: Security audit (NuGet dependencies)
+        shell: bash
+        run: |
+          projects=(
+            "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
+            "src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj"
+            "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
+            "src/Honua.Sdk.Features/Honua.Sdk.Features.csproj"
+          )
+
+          errors=0
+
+          for project in "${projects[@]}"; do
+            output_file="/tmp/$(basename "${project}").audit.txt"
+            dotnet list "${project}" package --vulnerable --include-transitive 2>&1 | tee "${output_file}"
+
+            if grep -qi "has the following vulnerable packages" "${output_file}"; then
+              echo "::error::Vulnerable NuGet dependencies detected in ${project}. Fix before publishing."
+              errors=1
+            fi
+          done
+
+          if [[ ${errors} -ne 0 ]]; then
             exit 1
           fi
 
       - name: Pack NuGet packages
+        shell: bash
         run: |
-          dotnet pack src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj --configuration Release --no-build -o ./nupkgs
-          dotnet pack src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release --no-build -o ./nupkgs
+          mkdir -p ./nupkgs
+          projects=(
+            "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
+            "src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj"
+            "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
+            "src/Honua.Sdk.Features/Honua.Sdk.Features.csproj"
+          )
+
+          for project in "${projects[@]}"; do
+            dotnet pack "${project}" --configuration Release --no-build -o ./nupkgs
+          done
+
+      - name: Package install smoke
+        shell: bash
+        run: |
+          admin_version="$(grep '<Version>' src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
+          grpc_version="$(grep '<Version>' src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
+          wfs_version="$(grep '<Version>' src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
+          features_version="$(grep '<Version>' src/Honua.Sdk.Features/Honua.Sdk.Features.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
+
+          smoke_dir="$(mktemp -d)"
+          trap 'rm -rf "${smoke_dir}"' EXIT
+
+          dotnet new console --framework net10.0 --output "${smoke_dir}"
+
+          pushd "${smoke_dir}" >/dev/null
+
+          dotnet add package Microsoft.Extensions.Hosting --version 10.0.0
+          dotnet add package Honua.Sdk.Admin --version "${admin_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Grpc --version "${grpc_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Wfs --version "${wfs_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Features --version "${features_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
+
+          cat <<'EOF' > Program.cs
+          using Honua.Sdk.Admin;
+          using Honua.Sdk.Admin.Extensions;
+          using Honua.Sdk.Admin.Geocoding;
+          using Honua.Sdk.Features.Extensions;
+          using Honua.Sdk.Features.FeatureServer;
+          using Honua.Sdk.Features.FeatureServer.Models;
+          using Honua.Sdk.Features.OgcFeatures;
+          using Honua.Sdk.Features.OgcFeatures.Models;
+          using Honua.Sdk.Grpc;
+          using Honua.Sdk.Grpc.Extensions;
+          using Honua.Sdk.Grpc.Models;
+          using Honua.Sdk.Wfs;
+          using Honua.Sdk.Wfs.Extensions;
+          using Honua.Sdk.Wfs.Models;
+          using Microsoft.Extensions.DependencyInjection;
+          using Microsoft.Extensions.Hosting;
+
+          var builder = Host.CreateApplicationBuilder(args);
+          var baseUri = new Uri("https://example.honua.test");
+
+          builder.Services.AddHonuaAdmin(options => options.BaseAddress = baseUri);
+          builder.Services.AddHonuaGeocoding(options => options.BaseAddress = baseUri);
+          builder.Services.AddHonuaGrpc(options => options.Address = baseUri.ToString());
+          builder.Services.AddHonuaWfs(options => options.BaseAddress = baseUri);
+          builder.Services.AddHonuaFeatureServer(options => options.BaseAddress = baseUri);
+          builder.Services.AddHonuaOgcFeatures(options => options.BaseAddress = baseUri);
+
+          using var host = builder.Build();
+
+          _ = host.Services.GetRequiredService<IHonuaAdminClient>();
+          _ = host.Services.GetRequiredService<IHonuaGeocodingClient>();
+          _ = host.Services.GetRequiredService<IHonuaGrpcClient>();
+          _ = host.Services.GetRequiredService<IHonuaWfsClient>();
+          _ = host.Services.GetRequiredService<IHonuaFeatureServerClient>();
+          _ = host.Services.GetRequiredService<IHonuaOgcFeaturesClient>();
+
+          _ = new QueryFeaturesRequest
+          {
+              ServiceId = "sdk_demo",
+              LayerId = 0,
+              ResultRecordCount = 1,
+              ReturnGeometry = false
+          };
+
+          _ = new GetFeaturesRequest
+          {
+              TypeNames = "sdk_demo_points",
+              Count = 1
+          };
+
+          _ = new FeatureServerQueryParams
+          {
+              Where = "1=1",
+              ResultRecordCount = 1,
+              ReturnGeometry = false
+          };
+
+          _ = new OgcItemsParams
+          {
+              Limit = 1
+          };
+          EOF
+
+          dotnet build --configuration Release
+
+          popd >/dev/null
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: dotnet-sdk-nupkgs-${{ github.run_id }}
+          name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-packages
           path: ./nupkgs/*.nupkg
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 90
+
+      - name: Dry-run summary
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
+        shell: bash
+        run: |
+          echo "Dry run complete. Built packages:" >> "${GITHUB_STEP_SUMMARY}"
+          ls -1 ./nupkgs/*.nupkg >> "${GITHUB_STEP_SUMMARY}"
+
+  release-staging-integration:
+    name: Release Staging Integration
+    needs: release-smoke
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
+    uses: ./.github/workflows/staging-integration.yml
+    with:
+      artifact-retention: 90
+    secrets: inherit
+
+  publish-dotnet-packages:
+    name: Publish Packages
+    needs:
+      - release-smoke
+      - release-staging-integration
+    if: >-
+      ${{
+        needs.release-smoke.result == 'success' &&
+        (needs.release-staging-integration.result == 'success' || needs.release-staging-integration.result == 'skipped') &&
+        !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true')
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-packages
+          path: ./nupkgs
 
       - name: Publish to GitHub Packages (pre-release)
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') }}
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
@@ -96,15 +284,9 @@ jobs:
             --skip-duplicate
 
       - name: Publish to NuGet.org (stable releases only)
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}
+        if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
             --source "https://api.nuget.org/v3/index.json" \
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --skip-duplicate
-
-      - name: Dry-run summary
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' }}
-        run: |
-          echo "Dry run complete. Built packages:"
-          ls -la ./nupkgs/

--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -1,0 +1,175 @@
+name: .NET SDK Staging Integration
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 14 * * *"
+  workflow_call:
+    inputs:
+      artifact-retention:
+        description: Artifact retention window in days.
+        required: false
+        default: 30
+        type: number
+
+env:
+  DOTNET_VERSION: "10.0.x"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  staging-integration:
+    name: Staging Read-Only Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: staging
+    env:
+      HONUA_STAGING_BASE_URL: ${{ vars.HONUA_STAGING_BASE_URL }}
+      HONUA_STAGING_API_KEY: ${{ secrets.HONUA_STAGING_API_KEY }}
+      HONUA_STAGING_BEARER_TOKEN: ${{ secrets.HONUA_STAGING_BEARER_TOKEN }}
+      HONUA_STAGING_SERVICE_NAME: ${{ vars.HONUA_STAGING_SERVICE_NAME }}
+      HONUA_STAGING_LAYER_ID: ${{ vars.HONUA_STAGING_LAYER_ID }}
+      HONUA_STAGING_WFS_TYPENAME: ${{ vars.HONUA_STAGING_WFS_TYPENAME }}
+      HONUA_STAGING_OGC_COLLECTION_ID: ${{ vars.HONUA_STAGING_OGC_COLLECTION_ID }}
+      HONUA_STAGING_EVIDENCE_PATH: ${{ github.workspace }}/artifacts/evidence/ci-report.json
+      HONUA_STAGING_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+      TEST_RESULTS_DIR: ${{ github.workspace }}/artifacts/test-results
+      TEST_RESULTS_FILE: staging-integration.trx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Validate staging configuration
+        id: validate-config
+        shell: bash
+        run: |
+          missing=()
+
+          require_value() {
+            local value="$1"
+            local key="$2"
+            if [[ -z "${value}" ]]; then
+              missing+=("${key}")
+            fi
+          }
+
+          require_value "${HONUA_STAGING_BASE_URL}" "HONUA_STAGING_BASE_URL"
+          require_value "${HONUA_STAGING_SERVICE_NAME}" "HONUA_STAGING_SERVICE_NAME"
+          require_value "${HONUA_STAGING_LAYER_ID}" "HONUA_STAGING_LAYER_ID"
+          require_value "${HONUA_STAGING_WFS_TYPENAME}" "HONUA_STAGING_WFS_TYPENAME"
+          require_value "${HONUA_STAGING_OGC_COLLECTION_ID}" "HONUA_STAGING_OGC_COLLECTION_ID"
+
+          if [[ -z "${HONUA_STAGING_API_KEY}" && -z "${HONUA_STAGING_BEARER_TOKEN}" ]]; then
+            missing+=("HONUA_STAGING_API_KEY or HONUA_STAGING_BEARER_TOKEN")
+          fi
+
+          mkdir -p "${TEST_RESULTS_DIR}" "$(dirname "${HONUA_STAGING_EVIDENCE_PATH}")"
+
+          if (( ${#missing[@]} > 0 )); then
+            {
+              echo "## Staging Integration"
+              echo
+              echo "Missing staging configuration: ${missing[*]}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 1
+          fi
+
+      - name: Run staging integration suite
+        id: run-tests
+        shell: bash
+        run: |
+          dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj \
+            --configuration Release \
+            --logger "trx;LogFileName=${TEST_RESULTS_FILE}" \
+            --results-directory "${TEST_RESULTS_DIR}"
+
+      - name: Write staging summary
+        if: always()
+        env:
+          PRECHECK_OUTCOME: ${{ steps.validate-config.outcome }}
+          TEST_OUTCOME: ${{ steps.run-tests.outcome }}
+        shell: bash
+        run: |
+          if [[ -f "${HONUA_STAGING_EVIDENCE_PATH}" ]]; then
+            python3 - <<'PY'
+import json
+import os
+
+evidence_path = os.environ["HONUA_STAGING_EVIDENCE_PATH"]
+summary_path = os.environ["GITHUB_STEP_SUMMARY"]
+precheck_outcome = os.environ.get("PRECHECK_OUTCOME", "unknown")
+test_outcome = os.environ.get("TEST_OUTCOME", "not-run")
+
+with open(evidence_path, encoding="utf-8") as evidence_file:
+    report = json.load(evidence_file)
+
+summary = report.get("Summary", {})
+checks = report.get("Checks", [])
+
+with open(summary_path, "a", encoding="utf-8") as summary_file:
+    summary_file.write("## Staging Integration\n\n")
+    summary_file.write(f"- Precheck: `{precheck_outcome}`\n")
+    summary_file.write(f"- Test step: `{test_outcome}`\n")
+    summary_file.write(f"- Base URL: `{report.get('BaseUrl', 'unknown')}`\n")
+    summary_file.write(f"- Service: `{report.get('ServiceName', 'unknown')}`\n")
+    summary_file.write(f"- Layer ID: `{report.get('LayerId', 'unknown')}`\n")
+    summary_file.write(f"- WFS type: `{report.get('WfsTypeName', 'unknown')}`\n")
+    summary_file.write(f"- OGC collection: `{report.get('OgcCollectionId', 'unknown')}`\n")
+    summary_file.write(
+        f"- Summary: {summary.get('Passed', 0)} passed, "
+        f"{summary.get('Failed', 0)} failed, "
+        f"{summary.get('NotRun', 0)} not run\n\n"
+    )
+    summary_file.write("| Check | Status | Details |\n")
+    summary_file.write("| --- | --- | --- |\n")
+
+    for check in checks:
+        details = str(check.get("Details", "")).replace("\n", " ").strip()
+        if len(details) > 160:
+            details = details[:157] + "..."
+        summary_file.write(
+            f"| `{check.get('Name', 'unknown')}` | "
+            f"{check.get('Status', 'unknown')} | "
+            f"{details} |\n"
+        )
+PY
+          else
+            {
+              echo "## Staging Integration"
+              echo
+              echo "- Precheck: \`${PRECHECK_OUTCOME}\`"
+              echo "- Test step: \`${TEST_OUTCOME:-not-run}\`"
+              echo "- Evidence file: not produced."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload staging test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.event.repository.name }}-staging-integration-${{ github.run_id }}-test-results
+          path: ${{ github.workspace }}/artifacts/test-results/
+          if-no-files-found: warn
+          retention-days: ${{ github.event_name == 'workflow_call' && inputs['artifact-retention'] || 30 }}
+
+      - name: Upload staging evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.event.repository.name }}-staging-integration-${{ github.run_id }}-evidence
+          path: ${{ github.workspace }}/artifacts/evidence/
+          if-no-files-found: warn
+          retention-days: ${{ github.event_name == 'workflow_call' && inputs['artifact-retention'] || 30 }}

--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -41,6 +41,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdminBootstrapConsole.Tests", "tests\AdminBootstrapConsole.Tests\AdminBootstrapConsole.Tests.csproj", "{C1234567-89AB-4DEF-8ABC-1234567890AB}"
 EndProject
 
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.IntegrationTests", "tests\Honua.Sdk.IntegrationTests\Honua.Sdk.IntegrationTests.csproj", "{D1234567-89AB-4DEF-8BCD-1234567890AB}"
+EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +90,10 @@ Global
 		{C1234567-89AB-4DEF-8ABC-1234567890AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C1234567-89AB-4DEF-8ABC-1234567890AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C1234567-89AB-4DEF-8ABC-1234567890AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1234567-89AB-4DEF-8BCD-1234567890AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1234567-89AB-4DEF-8BCD-1234567890AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1234567-89AB-4DEF-8BCD-1234567890AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1234567-89AB-4DEF-8BCD-1234567890AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A1B1C1D1-E1F1-1111-1111-111111111111} = {2F8F8F8F-8F8F-8F8F-8F8F-8F8F8F8F8F8F}
@@ -99,5 +106,6 @@ Global
 		{A6B6C6D6-E6F6-6666-6666-666666666666} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{B1234567-89AB-4CDE-8FAB-1234567890AB} = {4E4E4E4E-4E4E-4E4E-4E4E-4E4E4E4E4E4E}
 		{C1234567-89AB-4DEF-8ABC-1234567890AB} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
+		{D1234567-89AB-4DEF-8BCD-1234567890AB} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ if (!compatibility.IsSupported)
 
 ## Admin bootstrap flow
 
-For a runnable publish-and-verify operator path, see
+For the canonical runnable sample app for this repo's bootstrap and publish
+operator flow, see
 [examples/AdminBootstrapConsole](examples/AdminBootstrapConsole/).
 
 - `CheckCompatibilityAsync()` is the first remote call. It validates server
@@ -185,23 +186,29 @@ tests/
   Honua.Sdk.Admin.Tests/    Admin + Geocoding tests (81 tests)
   Honua.Sdk.Wfs.Tests/      WFS client tests (52 tests)
 examples/
-  AdminBootstrapConsole/     Console sample for admin bootstrap + gRPC verification
-  FieldDataCollection/      .NET MAUI field-data-collection app
+  AdminBootstrapConsole/     Canonical console sample for admin bootstrap + gRPC verification
+  FieldDataCollection/      Advanced .NET MAUI reference app (not the primary onboarding sample)
 docs/
   quickstart.md             5-minute quickstart tutorial
+  staging-integration.md    Staging CI inputs, evidence, and troubleshooting
 ```
 
 ## Documentation
 
+- **[Admin Bootstrap Console](examples/AdminBootstrapConsole/)** -- the
+  canonical sample app for this repo; bootstrap a PostGIS table with
+  `Honua.Sdk.Admin`, preserve existing protocols while enabling `Grpc`, verify
+  it with a bounded `Honua.Sdk.Grpc` query, and troubleshoot the exact error
+  surfaces returned by the sample
 - **[Quickstart](docs/quickstart.md)** -- build a console app that queries
   features via gRPC and WFS, lists services, and geocodes an address in 5 minutes
-- **[Admin Bootstrap Console](examples/AdminBootstrapConsole/)** -- bootstrap a
-  PostGIS table with `Honua.Sdk.Admin`, preserve existing protocols while
-  enabling `Grpc`, and verify it with a bounded `Honua.Sdk.Grpc` query
+- **[Staging Integration Guide](docs/staging-integration.md)** -- staging
+  environment inputs, CI evidence artifacts, common failures, and bounded
+  follow-on tickets for shared staging ownership
 - **[INSTALL.md](INSTALL.md)** -- NuGet and GitHub Packages setup, version
   policy and server compatibility baseline
 - **[Field Data Collection](examples/FieldDataCollection/)** -- full MAUI
-  example with offline sync and map views
+  reference app with offline sync and map views
 
 ## License
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -264,14 +264,18 @@ WFS 2.0.0: 4 feature types
 
 ## What's Next
 
-- **[Admin Bootstrap Console](../examples/AdminBootstrapConsole/)** -- bootstrap
-  a PostGIS table with `Honua.Sdk.Admin`, requiring geometry metadata and a
+- **[Admin Bootstrap Console](../examples/AdminBootstrapConsole/)** -- the
+  canonical sample app for this repo's operator/bootstrap flow; bootstrap a
+  PostGIS table with `Honua.Sdk.Admin`, requiring geometry metadata and a
   single primary key; reuse or publish the layer safely, preserve existing
   protocols while enabling `Grpc`, and verify the published layer with a
   bounded query
+- **[Staging Integration Guide](staging-integration.md)** -- required staging
+  environment variables, CI evidence artifacts, and troubleshooting for the
+  read-only staging suite
 - **[INSTALL.md](../INSTALL.md)** -- package sources, GitHub Packages setup,
   and version policy
 - **[Field Data Collection example](../examples/FieldDataCollection/)** -- a
-  full .NET MAUI app with offline sync, forms, and map views
+  full .NET MAUI reference app with offline sync, forms, and map views
 - **[gRPC vs Forms comparison](../examples/FieldDataCollection/GRPC_FORMS_COMPARISON.md)**
   -- when to use gRPC queries versus OpenRosa/XForms for data collection

--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -1,0 +1,110 @@
+# Staging Integration Guide
+
+The staging suite for this repository lives in
+`tests/Honua.Sdk.IntegrationTests` and runs through
+`.github/workflows/staging-integration.yml`. It is intentionally read-only and
+does not execute the mutating bootstrap sample against shared staging.
+
+## What The Suite Covers
+
+- Admin compatibility and service settings through `IHonuaAdminClient`
+- A bounded gRPC `QueryFeaturesAsync()` call with `ReturnGeometry = false`
+- WFS `GetCapabilitiesAsync()` and bounded `GetFeaturesAsync()`
+- FeatureServer metadata plus a bounded `QueryAsync()`
+- OGC API Features collections, bounded items, and a single item lookup
+
+Each request uses a small row limit and deterministic fixture identifiers so the
+lane stays low-overhead and does not mutate shared staging state.
+
+## Workflow Triggers
+
+- `pull_request` is intentionally out of scope. External staging checks do not
+  run on the PR-blocking path.
+- `.github/workflows/staging-integration.yml` runs on `schedule` and
+  `workflow_dispatch`.
+- `.github/workflows/publish-dotnet-sdk.yml` reuses the same staging workflow on
+  the release path before package publish.
+
+## Required Configuration
+
+Configure the GitHub `staging` environment with these values.
+
+Repository or environment variables:
+
+- `HONUA_STAGING_BASE_URL`
+- `HONUA_STAGING_SERVICE_NAME`
+- `HONUA_STAGING_LAYER_ID`
+- `HONUA_STAGING_WFS_TYPENAME`
+- `HONUA_STAGING_OGC_COLLECTION_ID`
+
+Environment secrets:
+
+- `HONUA_STAGING_API_KEY` or `HONUA_STAGING_BEARER_TOKEN`
+
+Workflow-managed values:
+
+- `HONUA_STAGING_EVIDENCE_PATH`
+- `HONUA_STAGING_RUN_ID`
+
+Local execution uses the same environment variables. Example:
+
+```bash
+export HONUA_STAGING_BASE_URL=https://staging.example.honua.test
+export HONUA_STAGING_API_KEY=replace-me
+export HONUA_STAGING_SERVICE_NAME=sdk_demo
+export HONUA_STAGING_LAYER_ID=0
+export HONUA_STAGING_WFS_TYPENAME=public:sdk_demo_points
+export HONUA_STAGING_OGC_COLLECTION_ID=sdk_demo_points
+
+dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release
+```
+
+## Evidence And Artifacts
+
+Successful workflow runs emit all of the following:
+
+- TRX results under the `...-test-results` artifact
+- JSON evidence at `artifacts/evidence/ci-report.json`, uploaded as the
+  `...-evidence` artifact
+- A concise `GITHUB_STEP_SUMMARY` section with the endpoint, fixture
+  identifiers, and per-check pass/fail details
+
+The JSON evidence includes:
+
+- base URL
+- service/layer/type/collection identifiers
+- per-check status, duration, and detail string
+- a total passed / failed / not-run summary
+
+## Troubleshooting
+
+- Missing environment configuration fails the workflow before `dotnet test`
+  starts. Fix the missing `HONUA_STAGING_*` variable or auth secret in the
+  GitHub `staging` environment first.
+- `HonuaAdminApiException` usually means auth, routing, or status-code failures
+  on the admin REST surface. Re-check the base URL, credentials, and that the
+  target service exists.
+- `HonuaAdminOperationException` indicates a read contract or compatibility
+  issue surfaced by the admin client, including unsupported server baselines.
+- `HonuaGrpcException` on the bounded query usually means the configured
+  service/layer pair is wrong or the gRPC endpoint is unavailable.
+- `HonuaWfsException` usually means WFS is disabled, the configured type name is
+  wrong, or the server is returning a WFS exception report.
+- `HonuaFeatureServerException` and `HonuaOgcFeaturesException` usually mean the
+  configured FeatureServer or OGC API fixture identifiers are wrong, or those
+  protocol surfaces are disabled on staging.
+- xUnit assertion failures with messages such as "expected 1 to 3 rows" usually
+  mean the shared staging fixture is empty, changed names, or no longer exposes
+  the expected protocols.
+
+## Bounded Cross-Repo Follow-Ons
+
+This SDK ticket stays single-repo. If staging prerequisites are missing, track
+them as separate child tickets in `honua-server` or the environment-owning repo
+instead of expanding this repository's scope.
+
+- Provide a stable staging certification fixture with known non-empty data,
+  protocol availability, and durable identifiers for service, layer, WFS type,
+  and OGC collection.
+- Wire the `staging` GitHub environment with the required variables and auth
+  secret if that configuration does not already exist.

--- a/examples/AdminBootstrapConsole/README.md
+++ b/examples/AdminBootstrapConsole/README.md
@@ -1,6 +1,8 @@
 # Admin Bootstrap Console
 
-Runnable console sample that bootstraps a PostGIS table through `Honua.Sdk.Admin` and then verifies the published layer through `Honua.Sdk.Grpc`.
+Canonical runnable sample app for this repository. It bootstraps a PostGIS
+table through `Honua.Sdk.Admin` and then verifies the published layer through
+`Honua.Sdk.Grpc`.
 
 ## What It Does
 
@@ -178,3 +180,37 @@ were already enabled on the target service.
 
 If the sample reports an existing connection or layer that points somewhere
 else, change the configured name instead of overwriting shared resources.
+
+## Troubleshooting
+
+- Compatibility gate failures surface as `[Compatibility] Server ... is not supported...`.
+  Re-check the target server version, release channel, and that the admin API is
+  reachable at `/api/v1/admin` before retrying.
+- Non-loopback HTTP plus `HONUA_BOOTSTRAP_API_KEY` or
+  `HONUA_BOOTSTRAP_BEARER_TOKEN` fails before credentials are sent. The process
+  exits with an insecure-transport message telling you to use HTTPS or loopback
+  HTTP only for local development.
+- Invalid database credential combinations surface as `[Configuration] ...`.
+  The sample requires exactly one of `HONUA_BOOTSTRAP_DB_PASSWORD` or
+  `HONUA_BOOTSTRAP_DB_SECRET_REFERENCE`, and secret references also require
+  `HONUA_BOOTSTRAP_DB_SECRET_TYPE`.
+- Same-name connection collisions surface as `[CreateConnection] Connection ... already exists but points to ...`.
+  Keep the configured name unique for the target host, port, database, user,
+  and SSL settings instead of reusing a shared name for a different database.
+- Same-name layer collisions surface as `[PublishLayer] Layer name ... already exists in service ...`.
+  Change `HONUA_BOOTSTRAP_LAYER_NAME` or target the existing source table
+  instead of overwriting a different published layer.
+- Missing geometry metadata, missing primary keys, and composite primary keys
+  all fail during discovery or publish as `[DiscoverTables] ...`. The sample
+  only publishes tables with a geometry column, geometry type, SRID, and a
+  single primary key.
+- Verification failures surface as `[gRPC] ...` when the bounded
+  `QueryFeaturesAsync()` call cannot read the published layer. Check that `Grpc`
+  is enabled for the target service and that the server exposes the configured
+  service/layer pair.
+- A zero-row verify result is still success. The sample prints that the layer is
+  queryable but currently has no rows, which means the publish/enable path
+  worked and only the fixture data is empty.
+
+For the read-only staging CI lane that validates the SDK against a shared Honua
+deployment, see [the staging integration guide](../../docs/staging-integration.md).

--- a/tests/Honua.Sdk.IntegrationTests/GlobalUsings.cs
+++ b/tests/Honua.Sdk.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using Honua.Sdk.Admin;
+global using Honua.Sdk.Features.FeatureServer;
+global using Honua.Sdk.Features.OgcFeatures;
+global using Honua.Sdk.Grpc;
+global using Honua.Sdk.Wfs;
+global using Microsoft.Extensions.DependencyInjection;
+global using Xunit;

--- a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
+++ b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Admin\Honua.Sdk.Admin.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Grpc\Honua.Sdk.Grpc.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Wfs\Honua.Sdk.Wfs.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Features\Honua.Sdk.Features.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Sdk.IntegrationTests/StagingConfiguredFactAttribute.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingConfiguredFactAttribute.cs
@@ -1,0 +1,13 @@
+namespace Honua.Sdk.IntegrationTests;
+
+public sealed class StagingConfiguredFactAttribute : FactAttribute
+{
+    public StagingConfiguredFactAttribute()
+    {
+        var missing = StagingIntegrationOptions.GetMissingEnvironmentVariables();
+        if (missing.Count > 0)
+        {
+            Skip = $"Set staging integration environment variables to run. Missing: {string.Join(", ", missing)}.";
+        }
+    }
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
@@ -1,0 +1,226 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Honua.Sdk.Admin.Extensions;
+using Honua.Sdk.Features.Extensions;
+using Honua.Sdk.Grpc.Extensions;
+using Honua.Sdk.Wfs.Extensions;
+
+namespace Honua.Sdk.IntegrationTests;
+
+[CollectionDefinition("StagingIntegration", DisableParallelization = true)]
+public sealed class StagingIntegrationCollection : ICollectionFixture<StagingIntegrationFixture>
+{
+}
+
+public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
+{
+    private static readonly string[] KnownChecks =
+    [
+        "admin-compatibility",
+        "admin-service-settings",
+        "grpc-query",
+        "wfs-capabilities",
+        "wfs-get-features",
+        "features-service-info",
+        "features-query",
+        "ogc-collections",
+        "ogc-items",
+        "ogc-item"
+    ];
+
+    private readonly Dictionary<string, StagingCheckResult> _results =
+        KnownChecks.ToDictionary(name => name, StagingCheckResult.NotRun);
+
+    public StagingIntegrationFixture()
+    {
+        Options = StagingIntegrationOptions.LoadFromEnvironment();
+
+        var services = new ServiceCollection();
+        services.AddHonuaAdmin(options =>
+        {
+            options.BaseAddress = Options.BaseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaGrpc(options =>
+        {
+            options.Address = Options.BaseUri.ToString();
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaWfs(options =>
+        {
+            options.BaseAddress = Options.BaseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = Options.BaseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = Options.BaseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+
+        Services = services.BuildServiceProvider();
+    }
+
+    public StagingIntegrationOptions Options { get; }
+
+    public ServiceProvider Services { get; }
+
+    public IHonuaAdminClient AdminClient => Services.GetRequiredService<IHonuaAdminClient>();
+
+    public IHonuaGrpcClient GrpcClient => Services.GetRequiredService<IHonuaGrpcClient>();
+
+    public IHonuaWfsClient WfsClient => Services.GetRequiredService<IHonuaWfsClient>();
+
+    public IHonuaFeatureServerClient FeatureServerClient => Services.GetRequiredService<IHonuaFeatureServerClient>();
+
+    public IHonuaOgcFeaturesClient OgcFeaturesClient => Services.GetRequiredService<IHonuaOgcFeaturesClient>();
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        await WriteEvidenceAsync().ConfigureAwait(false);
+    }
+
+    public CancellationTokenSource CreateTimeoutScope(TimeSpan? timeout = null)
+        => new(timeout ?? TimeSpan.FromSeconds(45));
+
+    public async Task RecordCheckAsync(
+        string name,
+        Func<CancellationToken, Task<string>> action,
+        CancellationToken ct)
+    {
+        var startedAt = DateTimeOffset.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var detail = await action(ct).ConfigureAwait(false);
+            _results[name] = new StagingCheckResult(
+                name,
+                "pass",
+                startedAt,
+                stopwatch.ElapsedMilliseconds,
+                detail);
+        }
+        catch (Exception ex)
+        {
+            _results[name] = new StagingCheckResult(
+                name,
+                "fail",
+                startedAt,
+                stopwatch.ElapsedMilliseconds,
+                $"{ex.GetType().Name}: {ex.Message}");
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        Services.Dispose();
+    }
+
+    private async Task WriteEvidenceAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Options.EvidencePath))
+        {
+            return;
+        }
+
+        var evidenceDirectory = Path.GetDirectoryName(Options.EvidencePath);
+        if (!string.IsNullOrWhiteSpace(evidenceDirectory))
+        {
+            Directory.CreateDirectory(evidenceDirectory);
+        }
+
+        var checks = KnownChecks.Select(name => _results[name]).ToArray();
+        var report = new StagingEvidenceReport
+        {
+            SchemaVersion = "1.0",
+            RunId = Options.RunId,
+            RunDateUtc = DateTimeOffset.UtcNow,
+            Environment = "staging",
+            BaseUrl = Options.BaseUri.ToString(),
+            ServiceName = Options.ServiceName,
+            LayerId = Options.LayerId,
+            WfsTypeName = Options.WfsTypeName,
+            OgcCollectionId = Options.OgcCollectionId,
+            Checks = checks,
+            Summary = new StagingEvidenceSummary
+            {
+                Total = checks.Length,
+                Passed = checks.Count(check => string.Equals(check.Status, "pass", StringComparison.Ordinal)),
+                Failed = checks.Count(check => string.Equals(check.Status, "fail", StringComparison.Ordinal)),
+                NotRun = checks.Count(check => string.Equals(check.Status, "not-run", StringComparison.Ordinal))
+            }
+        };
+
+        var json = JsonSerializer.Serialize(report, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        await File.WriteAllTextAsync(Options.EvidencePath, json).ConfigureAwait(false);
+    }
+
+    public sealed record StagingCheckResult(
+        string Name,
+        string Status,
+        DateTimeOffset StartedAtUtc,
+        long DurationMs,
+        string Details)
+    {
+        public static StagingCheckResult NotRun(string name)
+            => new(
+                name,
+                "not-run",
+                DateTimeOffset.UtcNow,
+                0,
+                "Check did not execute.");
+    }
+
+    public sealed class StagingEvidenceReport
+    {
+        public string SchemaVersion { get; init; } = string.Empty;
+
+        public string RunId { get; init; } = string.Empty;
+
+        public DateTimeOffset RunDateUtc { get; init; }
+
+        public string Environment { get; init; } = string.Empty;
+
+        public string BaseUrl { get; init; } = string.Empty;
+
+        public string ServiceName { get; init; } = string.Empty;
+
+        public int LayerId { get; init; }
+
+        public string WfsTypeName { get; init; } = string.Empty;
+
+        public string OgcCollectionId { get; init; } = string.Empty;
+
+        public IReadOnlyList<StagingCheckResult> Checks { get; init; } = [];
+
+        public StagingEvidenceSummary Summary { get; init; } = new();
+    }
+
+    public sealed class StagingEvidenceSummary
+    {
+        public int Total { get; init; }
+
+        public int Passed { get; init; }
+
+        public int Failed { get; init; }
+
+        public int NotRun { get; init; }
+    }
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
@@ -1,0 +1,112 @@
+namespace Honua.Sdk.IntegrationTests;
+
+public sealed class StagingIntegrationOptions
+{
+    private const string BaseUrlKey = "HONUA_STAGING_BASE_URL";
+    private const string ApiKeyKey = "HONUA_STAGING_API_KEY";
+    private const string BearerTokenKey = "HONUA_STAGING_BEARER_TOKEN";
+    private const string ServiceNameKey = "HONUA_STAGING_SERVICE_NAME";
+    private const string LayerIdKey = "HONUA_STAGING_LAYER_ID";
+    private const string WfsTypeNameKey = "HONUA_STAGING_WFS_TYPENAME";
+    private const string OgcCollectionIdKey = "HONUA_STAGING_OGC_COLLECTION_ID";
+    private const string EvidencePathKey = "HONUA_STAGING_EVIDENCE_PATH";
+    private const string RunIdKey = "HONUA_STAGING_RUN_ID";
+
+    public Uri BaseUri { get; init; } = new("https://localhost");
+
+    public string? ApiKey { get; init; }
+
+    public string? BearerToken { get; init; }
+
+    public string ServiceName { get; init; } = string.Empty;
+
+    public int LayerId { get; init; }
+
+    public string WfsTypeName { get; init; } = string.Empty;
+
+    public string OgcCollectionId { get; init; } = string.Empty;
+
+    public string? EvidencePath { get; init; }
+
+    public string RunId { get; init; } = string.Empty;
+
+    public static IReadOnlyList<string> GetMissingEnvironmentVariables()
+    {
+        var missing = new List<string>();
+
+        RequireValue(BaseUrlKey, missing);
+        RequireValue(ServiceNameKey, missing);
+        RequireValue(LayerIdKey, missing);
+        RequireValue(WfsTypeNameKey, missing);
+        RequireValue(OgcCollectionIdKey, missing);
+
+        if (string.IsNullOrWhiteSpace(Read(ApiKeyKey)) &&
+            string.IsNullOrWhiteSpace(Read(BearerTokenKey)))
+        {
+            missing.Add($"{ApiKeyKey} or {BearerTokenKey}");
+        }
+
+        return missing;
+    }
+
+    public static StagingIntegrationOptions LoadFromEnvironment()
+    {
+        var missing = GetMissingEnvironmentVariables();
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Missing staging integration environment variables: {string.Join(", ", missing)}.");
+        }
+
+        var baseUrl = ReadRequired(BaseUrlKey);
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+        {
+            throw new InvalidOperationException(
+                $"{BaseUrlKey} must be an absolute HTTP or HTTPS URI. Value: '{baseUrl}'.");
+        }
+
+        if (!string.Equals(baseUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(baseUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"{BaseUrlKey} must use the http or https scheme.");
+        }
+
+        var layerIdValue = ReadRequired(LayerIdKey);
+        if (!int.TryParse(layerIdValue, out var layerId) || layerId < 0)
+        {
+            throw new InvalidOperationException(
+                $"{LayerIdKey} must be a non-negative integer. Value: '{layerIdValue}'.");
+        }
+
+        return new StagingIntegrationOptions
+        {
+            BaseUri = baseUri,
+            ApiKey = Read(ApiKeyKey),
+            BearerToken = Read(BearerTokenKey),
+            ServiceName = ReadRequired(ServiceNameKey),
+            LayerId = layerId,
+            WfsTypeName = ReadRequired(WfsTypeNameKey),
+            OgcCollectionId = ReadRequired(OgcCollectionIdKey),
+            EvidencePath = Read(EvidencePathKey),
+            RunId = Read(RunIdKey) ?? DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmssZ", System.Globalization.CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static string? Read(string key)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string ReadRequired(string key)
+        => Read(key) ?? throw new InvalidOperationException($"{key} must be set.");
+
+    private static void RequireValue(string key, ICollection<string> missing)
+    {
+        if (Read(key) is null)
+        {
+            missing.Add(key);
+        }
+    }
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
@@ -1,0 +1,252 @@
+using System.Text.Json;
+using Honua.Sdk.Features.FeatureServer.Models;
+using Honua.Sdk.Features.OgcFeatures.Models;
+using Honua.Sdk.Grpc.Models;
+using Honua.Sdk.Wfs.Models;
+
+namespace Honua.Sdk.IntegrationTests;
+
+[Collection("StagingIntegration")]
+[Trait("Category", "Integration")]
+[Trait("Scope", "Staging")]
+public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fixture)
+{
+    private readonly StagingIntegrationFixture _fixture = fixture;
+
+    [StagingConfiguredFact]
+    public async Task AdminCompatibility_AndServiceSettings_AreReadable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "admin-compatibility",
+            async ct =>
+            {
+                var compatibility = await _fixture.AdminClient.CheckCompatibilityAsync(ct).ConfigureAwait(false);
+
+                Assert.True(
+                    compatibility.IsSupported,
+                    compatibility.UnsupportedReason ?? "Staging server did not meet the admin compatibility baseline.");
+
+                return
+                    $"serverVersion={compatibility.ServerVersion}; " +
+                    $"releaseChannel={compatibility.ReleaseChannel}; " +
+                    $"minimumVersion={compatibility.MinimumSupportedServerVersion}";
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        await _fixture.RecordCheckAsync(
+            "admin-service-settings",
+            async ct =>
+            {
+                var settings = await _fixture.AdminClient.GetServiceSettingsAsync(
+                    _fixture.Options.ServiceName,
+                    ct).ConfigureAwait(false);
+
+                Assert.Equal(_fixture.Options.ServiceName, settings.ServiceName);
+                Assert.Contains(settings.EnabledProtocols, protocol => string.Equals(protocol, "Grpc", StringComparison.OrdinalIgnoreCase));
+                Assert.Contains(settings.EnabledProtocols, protocol => string.Equals(protocol, "FeatureServer", StringComparison.OrdinalIgnoreCase));
+
+                return
+                    $"enabledProtocols={string.Join(",", settings.EnabledProtocols)}; " +
+                    $"availableProtocols={string.Join(",", settings.AvailableProtocols)}";
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    [StagingConfiguredFact]
+    public async Task GrpcQuery_IsBounded_AndReadOnly()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "grpc-query",
+            async ct =>
+            {
+                var response = await _fixture.GrpcClient.QueryFeaturesAsync(
+                    new QueryFeaturesRequest
+                    {
+                        ServiceId = _fixture.Options.ServiceName,
+                        LayerId = _fixture.Options.LayerId,
+                        Where = "1=1",
+                        ReturnGeometry = false,
+                        ResultRecordCount = 3
+                    },
+                    ct).ConfigureAwait(false);
+
+                Assert.InRange(response.Features.Count, 1, 3);
+                Assert.All(response.Features, feature => Assert.Null(feature.Geometry));
+
+                return $"rows={response.Features.Count}; returnGeometry=false; resultRecordCount=3";
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    [StagingConfiguredFact]
+    public async Task WfsCapabilities_AndBoundedGetFeature_AreReadable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "wfs-capabilities",
+            async ct =>
+            {
+                var capabilities = await _fixture.WfsClient.GetCapabilitiesAsync(ct).ConfigureAwait(false);
+
+                Assert.False(string.IsNullOrWhiteSpace(capabilities.Version));
+                Assert.Contains(
+                    capabilities.FeatureTypes,
+                    featureType => string.Equals(featureType.Name, _fixture.Options.WfsTypeName, StringComparison.OrdinalIgnoreCase));
+
+                return $"version={capabilities.Version}; featureTypes={capabilities.FeatureTypes.Count}";
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        await _fixture.RecordCheckAsync(
+            "wfs-get-features",
+            async ct =>
+            {
+                var features = await _fixture.WfsClient.GetFeaturesAsync(
+                    new GetFeaturesRequest
+                    {
+                        TypeNames = _fixture.Options.WfsTypeName,
+                        Count = 2
+                    },
+                    ct).ConfigureAwait(false);
+
+                Assert.InRange(features.Features.Count, 1, 2);
+
+                return
+                    $"numberReturned={features.NumberReturned}; " +
+                    $"numberMatched={features.NumberMatched?.ToString() ?? "unknown"}";
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    [StagingConfiguredFact]
+    public async Task FeatureServerMetadata_AndBoundedQuery_AreReadable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "features-service-info",
+            async ct =>
+            {
+                var serviceInfo = await _fixture.FeatureServerClient.GetServiceInfoAsync(
+                    _fixture.Options.ServiceName,
+                    ct).ConfigureAwait(false);
+
+                Assert.Contains(
+                    serviceInfo.Layers ?? [],
+                    layer => layer.Id == _fixture.Options.LayerId);
+
+                return
+                    $"layers={serviceInfo.Layers?.Count ?? 0}; " +
+                    $"capabilities={serviceInfo.Capabilities}";
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        await _fixture.RecordCheckAsync(
+            "features-query",
+            async ct =>
+            {
+                var response = await _fixture.FeatureServerClient.QueryAsync(
+                    _fixture.Options.ServiceName,
+                    _fixture.Options.LayerId,
+                    new FeatureServerQueryParams
+                    {
+                        Where = "1=1",
+                        ReturnGeometry = false,
+                        ResultRecordCount = 3
+                    },
+                    ct).ConfigureAwait(false);
+
+                var features = response.Features ?? [];
+                Assert.InRange(features.Count, 1, 3);
+                Assert.All(
+                    features,
+                    feature => Assert.True(
+                        !feature.Geometry.HasValue || feature.Geometry.Value.ValueKind == JsonValueKind.Null,
+                        "FeatureServer query unexpectedly returned geometry for a returnGeometry=false request."));
+
+                return $"rows={features.Count}; returnGeometry=false; resultRecordCount=3";
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    [StagingConfiguredFact]
+    public async Task OgcCollections_Items_AndSingleItem_AreReadable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "ogc-collections",
+            async ct =>
+            {
+                var collections = await _fixture.OgcFeaturesClient.ListCollectionsAsync(ct).ConfigureAwait(false);
+
+                Assert.Contains(
+                    collections,
+                    collection => string.Equals(collection.Id, _fixture.Options.OgcCollectionId, StringComparison.OrdinalIgnoreCase));
+
+                return $"collections={collections.Count}";
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        string? firstItemId = null;
+
+        await _fixture.RecordCheckAsync(
+            "ogc-items",
+            async ct =>
+            {
+                var items = await _fixture.OgcFeaturesClient.GetItemsAsync(
+                    _fixture.Options.OgcCollectionId,
+                    new OgcItemsParams
+                    {
+                        Limit = 2
+                    },
+                    ct).ConfigureAwait(false);
+
+                var features = items.Features ?? [];
+                Assert.InRange(features.Count, 1, 2);
+
+                firstItemId = GetFeatureId(features[0]);
+                Assert.False(string.IsNullOrWhiteSpace(firstItemId));
+
+                return
+                    $"numberReturned={items.NumberReturned?.ToString() ?? features.Count.ToString(System.Globalization.CultureInfo.InvariantCulture)}; " +
+                    $"firstItemId={firstItemId}";
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        await _fixture.RecordCheckAsync(
+            "ogc-item",
+            async ct =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(firstItemId));
+
+                var item = await _fixture.OgcFeaturesClient.GetItemAsync(
+                    _fixture.Options.OgcCollectionId,
+                    firstItemId!,
+                    ct).ConfigureAwait(false);
+
+                Assert.Equal("Feature", item.Type);
+                Assert.True(item.Id.HasValue);
+
+                return $"itemId={firstItemId}";
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    private static string GetFeatureId(OgcFeature feature)
+    {
+        var id = feature.Id ?? throw new Xunit.Sdk.XunitException("OGC items response did not include a feature ID.");
+
+        return id.ValueKind switch
+        {
+            JsonValueKind.String => id.GetString() ?? throw new Xunit.Sdk.XunitException("OGC feature ID was empty."),
+            JsonValueKind.Number => id.GetRawText(),
+            _ => throw new Xunit.Sdk.XunitException($"Unsupported OGC feature ID kind: {id.ValueKind}.")
+        };
+    }
+}


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #3
## Summary

+- Invalid database credential combinations surface as `[Configuration] ...`.
+  The sample requires exactly one of `HONUA_BOOTSTRAP_DB_PASSWORD` or
+  `HONUA_BOOTSTRAP_DB_SECRET_REFERENCE`, and secret references also require
+  `HONUA_BOOTSTRAP_DB_SECRET_TYPE`.
+- Same-name connection collisions surface as `[CreateConnection] Connection ... already exists but points to ...`.
+  Keep the configured name unique for the target host, port, database, user,
+  and SSL settings instead of reusing a shared name for a different database.
+- Same-name layer collisions surface as `[PublishLayer] Layer name ... already exists in service ...`.
+  Change `HONUA_BOOTSTRAP_LAYER_NAME` or target the existing source table
+  instead of overwriting a different published layer.
+- Missing geometry metadata, missing primary keys, and composite primary keys
+  all fail during discovery or publish as `[DiscoverTables] ...`. The sample
+  only publishes tables with a geometry column, geometry type, SRID, and a
+  single primary key.
+- Verification failures surface as `[gRPC] ...` when the bounded
+  `QueryFeaturesAsync()` call cannot read the published layer. Check that `Grpc`
+  is enabled for the target service and that the server exposes the configured
+  service/layer pair.
+- A zero-row verify result is still success. The sample prints that the layer is
+  queryable but currently has no rows, which means the publish/enable path
+  worked and only the fixture data is empty.
+
+For the read-only staging CI lane that validates the SDK against a shared Honua
+deployment, see [the staging integration guide](../../docs/staging-integration.md).
diff --git a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
index dd22c915cc262d909522cc61d859664a47d1464e..ddb13bd7a9d5e32a2592bac5627c62f9356fb35d
--- a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
+++ b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

tokens used
449,078
## Changes Made

- +- Invalid database credential combinations surface as `[Configuration] ...`.
- +  The sample requires exactly one of `HONUA_BOOTSTRAP_DB_PASSWORD` or
- +  `HONUA_BOOTSTRAP_DB_SECRET_REFERENCE`, and secret references also require
- +  `HONUA_BOOTSTRAP_DB_SECRET_TYPE`.
- +- Same-name connection collisions surface as `[CreateConnection] Connection ... already exists but points to ...`.
- +  Keep the configured name unique for the target host, port, database, user,
- +  and SSL settings instead of reusing a shared name for a different database.
- +- Same-name layer collisions surface as `[PublishLayer] Layer name ... already exists in service ...`.
- +  Change `HONUA_BOOTSTRAP_LAYER_NAME` or target the existing source table
- +  instead of overwriting a different published layer.
- +- Missing geometry metadata, missing primary keys, and composite primary keys
- +  all fail during discovery or publish as `[DiscoverTables] ...`. The sample
- +  only publishes tables with a geometry column, geometry type, SRID, and a
- +  single primary key.
- +- Verification failures surface as `[gRPC] ...` when the bounded
- +  `QueryFeaturesAsync()` call cannot read the published layer. Check that `Grpc`
- +  is enabled for the target service and that the server exposes the configured
- +  service/layer pair.
- +- A zero-row verify result is still success. The sample prints that the layer is
- +  queryable but currently has no rows, which means the publish/enable path
- +  worked and only the fixture data is empty.
- +
- +For the read-only staging CI lane that validates the SDK against a shared Honua
- +deployment, see [the staging integration guide](../../docs/staging-integration.md).
- diff --git a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
- index dd22c915cc262d909522cc61d859664a47d1464e..ddb13bd7a9d5e32a2592bac5627c62f9356fb35d
- --- a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
- +++ b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
- @@ -9,7 +9,7 @@
- </PropertyGroup>
- <ItemGroup>
- <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
- +    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
- <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
- <PackageReference Include="xunit" Version="2.9.3" />
- <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
- tokens used
- 449,078
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Breaking Changes

None
## Additional Context

Decisions:
- Pending

Follow-ons:
- Pending

Code kaizen:
Skipped by kaizen policy.
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review

## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact

## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact

## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
