### PR TITLE
[codex] centralize NuGet package versioning

### DIFF
--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -42,11 +42,9 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Validate tag version
-        if: github.event_name == 'push'
+      - name: Validate package versions
         shell: bash
         run: |
-          tag_version="${GITHUB_REF_NAME#dotnet-sdk-v}"
           projects=(
             "src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj"
             "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
@@ -57,18 +55,41 @@ jobs:
           )
 
           errors=0
+          package_version=""
+
+          get_package_version() {
+            dotnet msbuild "$1" -nologo -getProperty:PackageVersion
+          }
 
           for project in "${projects[@]}"; do
-            version="$(grep '<Version>' "${project}" | sed 's/.*<Version>\(.*\)<\/Version>/\1/' || echo '')"
-            if [[ -n "${version}" && "${tag_version}" != "${version}" ]]; then
-              echo "Tag version (${tag_version}) does not match ${project} version (${version})."
+            version="$(get_package_version "${project}")"
+            if [[ -z "${version}" ]]; then
+              echo "Could not resolve PackageVersion for ${project}."
+              errors=1
+              continue
+            fi
+
+            if [[ -z "${package_version}" ]]; then
+              package_version="${version}"
+            elif [[ "${package_version}" != "${version}" ]]; then
+              echo "Package version mismatch: ${project} has ${version}; expected ${package_version}."
               errors=1
             fi
           done
 
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            tag_version="${GITHUB_REF_NAME#dotnet-sdk-v}"
+            if [[ "${tag_version}" != "${package_version}" ]]; then
+              echo "Tag version (${tag_version}) does not match package version (${package_version})."
+              errors=1
+            fi
+          fi
+
           if [[ ${errors} -ne 0 ]]; then
             exit 1
           fi
+
+          echo "PACKAGE_VERSION=${package_version}" >> "${GITHUB_ENV}"
 
       - name: Build SDK packages
         shell: bash
@@ -169,13 +190,6 @@ jobs:
       - name: Package install smoke
         shell: bash
         run: |
-          abstractions_version="$(grep '<Version>' src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-          admin_version="$(grep '<Version>' src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-          grpc_version="$(grep '<Version>' src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-          wfs_version="$(grep '<Version>' src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-          geoservices_version="$(grep '<Version>' src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-          ogc_features_version="$(grep '<Version>' src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj | sed 's/.*<Version>\(.*\)<\/Version>/\1/')"
-
           smoke_dir="$(mktemp -d)"
           trap 'rm -rf "${smoke_dir}"' EXIT
 
@@ -184,12 +198,12 @@ jobs:
           pushd "${smoke_dir}" >/dev/null
 
           dotnet add package Microsoft.Extensions.Hosting --version 10.0.0
-          dotnet add package Honua.Sdk.Abstractions --version "${abstractions_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
-          dotnet add package Honua.Sdk.Admin --version "${admin_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
-          dotnet add package Honua.Sdk.Grpc --version "${grpc_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
-          dotnet add package Honua.Sdk.Wfs --version "${wfs_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
-          dotnet add package Honua.Sdk.GeoServices --version "${geoservices_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
-          dotnet add package Honua.Sdk.OgcFeatures --version "${ogc_features_version}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Abstractions --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Admin --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Grpc --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.Wfs --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.GeoServices --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
+          dotnet add package Honua.Sdk.OgcFeatures --version "${PACKAGE_VERSION}" --source "${GITHUB_WORKSPACE}/nupkgs"
 
           cat <<'EOF' > Program.cs
           using Honua.Sdk.Abstractions.Features;
@@ -313,7 +327,7 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Publish to GitHub Packages (pre-release)
+      - name: Publish to GitHub Packages
         run: |
           dotnet nuget push ./nupkgs/*.nupkg \
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
@@ -321,8 +335,15 @@ jobs:
             --skip-duplicate
 
       - name: Publish to NuGet.org (stable releases only)
-        if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}
+        if: ${{ github.event_name == 'push' && startsWith(github.ref_name, 'dotnet-sdk-v') }}
+        shell: bash
         run: |
+          version="${GITHUB_REF_NAME#dotnet-sdk-v}"
+          if [[ "${version}" == *-* ]]; then
+            echo "Skipping NuGet.org publish for prerelease ${version}."
+            exit 0
+          fi
+
           dotnet nuget push ./nupkgs/*.nupkg \
             --source "https://api.nuget.org/v3/index.json" \
             --api-key ${{ secrets.NUGET_API_KEY }} \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <HonuaSdkVersionPrefix>0.1.0</HonuaSdkVersionPrefix>
+    <HonuaSdkVersionSuffix>alpha.1</HonuaSdkVersionSuffix>
+    <VersionPrefix>$(HonuaSdkVersionPrefix)</VersionPrefix>
+    <VersionSuffix>$(HonuaSdkVersionSuffix)</VersionSuffix>
+    <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
+    <PackageVersion>$(Version)</PackageVersion>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <InformationalVersion>$(Version)</InformationalVersion>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+</Project>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,6 +38,11 @@ dotnet add package Honua.Sdk.GeoServices --prerelease
 dotnet add package Honua.Sdk.OgcFeatures --prerelease
 ```
 
+All SDK packages share one package version from `Directory.Build.props`.
+Release tags use `dotnet-sdk-v<PackageVersion>`, for example
+`dotnet-sdk-v0.1.0-alpha.1`. See [Release and NuGet Publishing](docs/release.md)
+for the publish workflow and stable/prerelease rules.
+
 ## Install from GitHub Packages (pre-release)
 
 Add the Honua GitHub Packages source:
@@ -89,8 +94,10 @@ public class MyService(IHonuaGrpcClient client)
 
 ## Version Policy
 
-- **Pre-release** (`-alpha.*`, `-beta.*`): Published to GitHub Packages on every tag
-- **Stable** (`1.0.0+`): Published to NuGet.org after validation
+- **Pre-release** (`-*`): Published to GitHub Packages on every release tag
+  and skipped for NuGet.org.
+- **Stable** (`1.0.0+`): Published to GitHub Packages and NuGet.org after
+  validation.
 
 All packages follow [Semantic Versioning](https://semver.org/). Major versions are coordinated across all Honua SDKs.
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ third_party/
 - **[Staging Integration Guide](docs/staging-integration.md)** -- staging
   environment inputs, CI evidence artifacts, common failures, and bounded
   follow-on tickets for shared staging ownership
+- **[Release and NuGet Publishing](docs/release.md)** -- package versioning,
+  release tags, dry runs, GitHub Packages, and NuGet.org publishing
 - **[INSTALL.md](INSTALL.md)** -- NuGet and GitHub Packages setup, version
   policy and server compatibility baseline
 - **[Backlog cadence](docs/backlog-cadence.md)** -- weekly triage, scope gate,

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,64 @@
+# .NET SDK Release and NuGet Publishing
+
+The SDK packages share one version source in `Directory.Build.props`.
+Update `HonuaSdkVersionPrefix` and `HonuaSdkVersionSuffix` there before a
+release. Leave `HonuaSdkVersionSuffix` empty for stable releases.
+
+## Packages
+
+The publish workflow builds and packs:
+
+- `Honua.Sdk.Abstractions`
+- `Honua.Sdk.Admin`
+- `Honua.Sdk.Grpc`
+- `Honua.Sdk.Wfs`
+- `Honua.Sdk.GeoServices`
+- `Honua.Sdk.OgcFeatures`
+
+## Release Flow
+
+1. Update `Directory.Build.props`.
+2. Open a PR with the version bump and release notes.
+3. Run the `Publish .NET SDK Packages` workflow manually with `dry_run=true`.
+   This builds, tests, validates API compatibility, audits dependencies, packs,
+   and runs package install smoke without publishing.
+4. After merge, create and push a tag named `dotnet-sdk-v<PackageVersion>`.
+   Example: `dotnet-sdk-v0.1.0-alpha.1`.
+
+The tag version must match the MSBuild `PackageVersion` resolved from the SDK
+projects. The workflow fails before publishing if they differ.
+
+## Publishing Targets
+
+All tag releases publish package artifacts and push packages to GitHub Packages.
+
+Stable tags also publish to NuGet.org. A stable tag has no prerelease suffix,
+for example `dotnet-sdk-v0.1.0`. Prerelease tags such as
+`dotnet-sdk-v0.1.0-alpha.1`, `dotnet-sdk-v0.1.0-beta.1`, or
+`dotnet-sdk-v0.1.0-rc.1` skip NuGet.org.
+
+NuGet.org publishing requires the repository secret `NUGET_API_KEY`.
+
+## Local Checks
+
+Resolve the package version:
+
+```bash
+dotnet msbuild src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj -nologo -getProperty:PackageVersion
+```
+
+Pack all packages locally:
+
+```bash
+mkdir -p ./nupkgs
+for project in \
+  src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj \
+  src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj \
+  src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj \
+  src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj \
+  src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj \
+  src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
+do
+  dotnet pack "$project" --configuration Release -o ./nupkgs
+done
+```

--- a/src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj
+++ b/src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.Abstractions</PackageId>
     <Description>Shared abstractions for Honua .NET SDK feature clients</Description>
     <RootNamespace>Honua.Sdk.Abstractions</RootNamespace>

--- a/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
+++ b/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.Admin</PackageId>
     <Description>Admin client SDK for Honua Server</Description>
     <RootNamespace>Honua.Sdk.Admin</RootNamespace>

--- a/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
+++ b/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.GeoServices</PackageId>
     <Description>GeoServices FeatureServer client SDK for Honua Server</Description>
     <RootNamespace>Honua.Sdk.GeoServices</RootNamespace>

--- a/src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj
+++ b/src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.Grpc</PackageId>
     <Description>gRPC client SDK for Honua FeatureService</Description>
     <RootNamespace>Honua.Sdk.Grpc</RootNamespace>

--- a/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
+++ b/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.OgcFeatures</PackageId>
     <Description>OGC API Features client SDK for Honua Server</Description>
     <RootNamespace>Honua.Sdk.OgcFeatures</RootNamespace>

--- a/src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj
+++ b/src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.1.0-alpha.1</Version>
     <PackageId>Honua.Sdk.Wfs</PackageId>
     <Description>WFS 2.0 read/query client SDK for Honua Server</Description>
     <RootNamespace>Honua.Sdk.Wfs</RootNamespace>


### PR DESCRIPTION
## Summary

Centralizes .NET SDK package versioning and tightens the NuGet publish flow.

- Adds `Directory.Build.props` as the single SDK package version source.
- Removes duplicate hard-coded `<Version>` values from publishable SDK projects.
- Updates the publish workflow to resolve MSBuild `PackageVersion`, require all packages to share the same version, and validate `dotnet-sdk-v<PackageVersion>` tags before publishing.
- Uses the centralized version for package install smoke.
- Restricts NuGet.org publishing to stable tag pushes while still publishing tag artifacts/GitHub Packages for prereleases.
- Adds release docs covering dry runs, tag naming, GitHub Packages, NuGet.org, and required `NUGET_API_KEY` setup.

Closes #36.

## Validation

- `dotnet build Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true`
- local publish workflow version validation with `GITHUB_REF_NAME=dotnet-sdk-v0.1.0-alpha.1`
- local stable/prerelease NuGet.org gate validation for alpha, beta, rc, and stable tag names
- `dotnet pack` for Abstractions, Admin, gRPC, WFS, GeoServices, and OGC Features packages
- local package install smoke for all six SDK packages