### PR TITLE
[codex] add refreshable SDK credentials

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -143,7 +143,23 @@ and the CI package API compatibility gate used before publish.
 
 ## Authentication Transport
 
-When `ApiKey` or `BearerToken` is configured on the Admin or gRPC clients, the
-SDK only sends those credentials over HTTPS. The only HTTP exception is
-loopback / `localhost` for local development, which is the path used by the
-admin bootstrap sample against local Docker Compose defaults.
+When `ApiKey`, `BearerToken`, `ApiKeyProvider`, or `BearerTokenProvider` is
+configured on any SDK client, the SDK only sends those credentials over HTTPS.
+The only HTTP exception is loopback / `localhost` for local development, which
+is the path used by the admin bootstrap sample against local Docker Compose
+defaults.
+
+Use credential providers for refresh, revocation, and key rotation:
+
+```csharp
+builder.Services.AddHonuaAdmin(o =>
+{
+    o.BaseAddress = new Uri("https://honua.example.com");
+    o.BearerTokenProvider = ct => tokenCache.GetAccessTokenAsync(ct);
+});
+```
+
+Providers run before each request or RPC. Returning null or an empty string
+omits the credential header. Store secrets in your application-owned secure
+store and see [docs/authentication.md](docs/authentication.md) for storage,
+failure, and retry behavior.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ foreach (var feature in response.Features)
     Console.WriteLine($"{feature.Id}: {feature.Attributes["name"]}");
 ```
 
+## Authentication and token refresh
+
+All client packages support static `ApiKey` / `BearerToken` values and
+request-time `ApiKeyProvider` / `BearerTokenProvider` delegates. Use providers
+when credentials can refresh, rotate, or be revoked while the process is
+running:
+
+```csharp
+builder.Services.AddHonuaGrpc(o =>
+{
+    o.Address = "https://localhost:5001";
+    o.BearerTokenProvider = ct => tokenCache.GetAccessTokenAsync(ct);
+});
+```
+
+Credentials are sent only over HTTPS except for loopback HTTP during local
+development. See [docs/authentication.md](docs/authentication.md) for secure
+storage guidance and retry/failure behavior.
+
 ## Apply edits
 
 The gRPC client supports feature edits (adds, updates, deletes):

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,74 @@
+# Authentication
+
+Honua SDK clients accept static credentials for simple deployments and provider
+delegates for production token refresh, key rotation, and revocation.
+
+## Supported Clients
+
+These option types support `ApiKey`, `BearerToken`, `ApiKeyProvider`, and
+`BearerTokenProvider`:
+
+- `HonuaAdminClientOptions` for Admin and Geocoding
+- `HonuaGrpcClientOptions` for gRPC
+- `HonuaWfsClientOptions` for WFS
+- `HonuaGeoServicesClientOptions` for GeoServices FeatureServer
+- `HonuaOgcFeaturesClientOptions` for OGC API Features
+
+Provider delegates are invoked before each SDK request or RPC. When a provider
+is configured, its value takes precedence over the static property. Returning
+null or an empty string omits that credential header, which lets applications
+stop sending revoked credentials without rebuilding the client.
+
+```csharp
+builder.Services.AddHonuaAdmin(o =>
+{
+    o.BaseAddress = new Uri("https://honua.example.com");
+    o.BearerTokenProvider = ct => tokenCache.GetAccessTokenAsync(ct);
+});
+
+builder.Services.AddHonuaGrpc(o =>
+{
+    o.Address = "https://honua.example.com";
+    o.ApiKeyProvider = ct => apiKeyStore.GetCurrentApiKeyAsync(ct);
+});
+```
+
+## Storage Guidance
+
+Do not hard-code long-lived API keys, bearer tokens, or refresh tokens in
+source, project files, or checked-in configuration. Prefer one of these
+application-owned stores:
+
+- Cloud secret managers or managed identity flows in hosted services
+- OS-backed secure stores such as Windows Credential Manager, macOS Keychain,
+  Linux Secret Service/libsecret, or platform-specific mobile secure storage
+- ASP.NET Core user-secrets for local development only
+- Environment variables injected by deployment tooling, not committed `.env`
+  files
+
+The SDK does not persist credentials. Provider delegates should read from your
+secure store or token cache and return the current API key or bearer token.
+
+## Rotation and Revocation
+
+Use providers when credentials can change while the process is running. A
+provider can refresh an expiring bearer token before returning it, read the
+latest API key after rotation, or return null after revocation.
+
+Static `ApiKey` and `BearerToken` values remain useful for tests and short-lived
+tools, but changing those properties after client registration is not the
+recommended rotation mechanism.
+
+## Transport and Failure Behavior
+
+The SDK refuses to send credentials over remote plain HTTP. HTTPS is required
+whenever static credentials or credential providers are configured. The only
+HTTP exception is loopback or `localhost` for local development.
+
+If a provider throws or its cancellation token is canceled, the current SDK call
+fails before the transport request is sent. Authentication failures from the
+server, such as `401` or `403`, are not retried by the SDK retry policy. HTTP
+clients retry only `429`, `502`, and `503`; the gRPC client retries only
+`Unavailable` and `Internal` according to its configured retry policy. Treat the
+provider as the place to refresh before a request, not as a response-time
+recovery hook for expired credentials.

--- a/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
@@ -24,26 +24,43 @@ internal sealed class HonuaAdminAuthHandler : DelegatingHandler
     }
 
     /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hasCredentials = !string.IsNullOrEmpty(_options.ApiKey) || !string.IsNullOrEmpty(_options.BearerToken);
-        if (hasCredentials && HonuaAdminClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HasCredentialSource() && HonuaAdminClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
             throw new InvalidOperationException(
                 "Refusing to send admin credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        if (!string.IsNullOrEmpty(_options.ApiKey))
+        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(apiKey))
         {
-            request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
-        if (!string.IsNullOrEmpty(_options.BearerToken))
+        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(bearerToken))
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.BearerToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
         }
 
-        return base.SendAsync(request, cancellationToken);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
+
+    private bool HasCredentialSource()
+        => !string.IsNullOrEmpty(_options.ApiKey) ||
+           !string.IsNullOrEmpty(_options.BearerToken) ||
+           _options.ApiKeyProvider is not null ||
+           _options.BearerTokenProvider is not null;
+
+    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
+        => _options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.ApiKey);
+
+    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
+        => _options.BearerTokenProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
@@ -19,9 +19,23 @@ public sealed class HonuaAdminClientOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
+    /// Optional API key provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="ApiKey"/>; returning null or
+    /// an empty string omits the API key header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; set; }
+
+    /// <summary>
     /// Bearer token for authentication.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// Optional bearer token provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="BearerToken"/>; returning null or
+    /// an empty string omits the authorization header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
+++ b/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
@@ -24,26 +24,43 @@ internal sealed class HonuaGeoServicesAuthHandler : DelegatingHandler
     }
 
     /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hasCredentials = !string.IsNullOrEmpty(_options.ApiKey) || !string.IsNullOrEmpty(_options.BearerToken);
-        if (hasCredentials && HonuaGeoServicesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HasCredentialSource() && HonuaGeoServicesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
             throw new InvalidOperationException(
                 "Refusing to send credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        if (!string.IsNullOrEmpty(_options.ApiKey))
+        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(apiKey))
         {
-            request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
-        if (!string.IsNullOrEmpty(_options.BearerToken))
+        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(bearerToken))
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.BearerToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
         }
 
-        return base.SendAsync(request, cancellationToken);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
+
+    private bool HasCredentialSource()
+        => !string.IsNullOrEmpty(_options.ApiKey) ||
+           !string.IsNullOrEmpty(_options.BearerToken) ||
+           _options.ApiKeyProvider is not null ||
+           _options.BearerTokenProvider is not null;
+
+    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
+        => _options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.ApiKey);
+
+    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
+        => _options.BearerTokenProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -19,9 +19,23 @@ public sealed class HonuaGeoServicesClientOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
+    /// Optional API key provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="ApiKey"/>; returning null or
+    /// an empty string omits the API key header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; set; }
+
+    /// <summary>
     /// Bearer token for authentication.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// Optional bearer token provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="BearerToken"/>; returning null or
+    /// an empty string omits the authorization header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -57,8 +57,14 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     /// <param name="options">Optional client options for authentication.</param>
     public HonuaGrpcClient(GrpcChannel channel, HonuaGrpcClientOptions? options = null)
     {
+        var opts = options ?? new HonuaGrpcClientOptions();
+        if (HasCredentials(opts))
+        {
+            ValidateAuthenticationTransport(opts, ResolveChannelAddress(channel));
+        }
+
         _client = new Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient(channel);
-        _options = options ?? new HonuaGrpcClientOptions();
+        _options = opts;
     }
 
     // For testing - inject the generated client stub directly
@@ -265,6 +271,32 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
            !string.IsNullOrWhiteSpace(opts.BearerToken) ||
            opts.ApiKeyProvider is not null ||
            opts.BearerTokenProvider is not null;
+
+    private static Uri ResolveChannelAddress(GrpcChannel channel)
+    {
+        if (Uri.TryCreate(channel.Target, UriKind.Absolute, out var targetAddress) &&
+            IsHttpOrHttps(targetAddress))
+        {
+            return targetAddress;
+        }
+
+        // GrpcChannel.Target omits the scheme; Address preserves the original URI.
+        var originalAddress = typeof(GrpcChannel)
+            .GetProperty("Address", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)?
+            .GetValue(channel) as Uri;
+
+        if (originalAddress is not null && IsHttpOrHttps(originalAddress))
+        {
+            return originalAddress;
+        }
+
+        throw new InvalidOperationException(
+            "Honua gRPC preconfigured channel target must expose an HTTP or HTTPS address when credentials are configured.");
+    }
+
+    private static bool IsHttpOrHttps(Uri uri)
+        => string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
 
     private static Models.QueryFeaturesRequest BuildGrpcQuery(FeatureQueryRequest request)
     {

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -25,7 +25,8 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
 
     private readonly Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient _client;
     private readonly GrpcChannel? _ownedChannel;
-    private readonly Metadata _metadata;
+    private readonly HonuaGrpcClientOptions _options;
+    private readonly Metadata? _metadataOverride;
 
     /// <summary>
     /// Creates a new gRPC client using the provided options.
@@ -46,7 +47,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
 
         _ownedChannel = GrpcChannel.ForAddress(address, channelOptions);
         _client = new Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient(_ownedChannel);
-        _metadata = BuildMetadata(opts);
+        _options = opts;
     }
 
     /// <summary>
@@ -57,14 +58,22 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     public HonuaGrpcClient(GrpcChannel channel, HonuaGrpcClientOptions? options = null)
     {
         _client = new Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient(channel);
-        _metadata = BuildMetadata(options ?? new HonuaGrpcClientOptions());
+        _options = options ?? new HonuaGrpcClientOptions();
     }
 
     // For testing - inject the generated client stub directly
     internal HonuaGrpcClient(Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient client, Metadata? metadata = null)
     {
         _client = client;
-        _metadata = metadata ?? new Metadata();
+        _options = new HonuaGrpcClientOptions();
+        _metadataOverride = metadata ?? new Metadata();
+    }
+
+    // For testing - inject the generated client stub directly with live options
+    internal HonuaGrpcClient(Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient client, HonuaGrpcClientOptions options)
+    {
+        _client = client;
+        _options = options;
     }
 
     /// <inheritdoc />
@@ -77,7 +86,8 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         var protoRequest = ProtoAdapter.ToProtoRequest(request);
         try
         {
-            var protoResponse = await _client.QueryFeaturesAsync(protoRequest, _metadata, cancellationToken: ct);
+            var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+            var protoResponse = await _client.QueryFeaturesAsync(protoRequest, metadata, cancellationToken: ct);
             return ProtoAdapter.FromProtoResponse(protoResponse);
         }
         catch (RpcException ex)
@@ -112,7 +122,8 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         var protoRequest = ProtoAdapter.ToProtoApplyEditsRequest(request);
         try
         {
-            var protoResponse = await _client.ApplyEditsAsync(protoRequest, _metadata, cancellationToken: ct);
+            var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+            var protoResponse = await _client.ApplyEditsAsync(protoRequest, metadata, cancellationToken: ct);
             return ProtoAdapter.FromProtoApplyEditsResponse(protoResponse);
         }
         catch (RpcException ex)
@@ -126,7 +137,8 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         Models.QueryFeaturesRequest request, [EnumeratorCancellation] CancellationToken ct = default)
     {
         var protoRequest = ProtoAdapter.ToProtoRequest(request);
-        var call = _client.QueryFeaturesStream(protoRequest, _metadata, cancellationToken: ct);
+        var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+        var call = _client.QueryFeaturesStream(protoRequest, metadata, cancellationToken: ct);
         try
         {
             while (true)
@@ -195,17 +207,43 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         return serviceConfig;
     }
 
-    private static Metadata BuildMetadata(HonuaGrpcClientOptions opts)
+    private async Task<Metadata> BuildMetadataAsync(CancellationToken cancellationToken)
     {
+        if (_metadataOverride is not null)
+        {
+            return _metadataOverride;
+        }
+
         var metadata = new Metadata();
-        if (!string.IsNullOrEmpty(opts.ApiKey))
-            metadata.Add("x-api-key", opts.ApiKey);
-        if (!string.IsNullOrEmpty(opts.BearerToken))
-            metadata.Add("authorization", $"Bearer {opts.BearerToken}");
-        if (opts.EnableCompressionNegotiation && !string.IsNullOrWhiteSpace(opts.AcceptedCompressionEncodings))
-            metadata.Add("grpc-accept-encoding", opts.AcceptedCompressionEncodings);
+        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(apiKey))
+        {
+            metadata.Add("x-api-key", apiKey);
+        }
+
+        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(bearerToken))
+        {
+            metadata.Add("authorization", $"Bearer {bearerToken}");
+        }
+
+        if (_options.EnableCompressionNegotiation && !string.IsNullOrWhiteSpace(_options.AcceptedCompressionEncodings))
+        {
+            metadata.Add("grpc-accept-encoding", _options.AcceptedCompressionEncodings);
+        }
+
         return metadata;
     }
+
+    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
+        => _options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.ApiKey);
+
+    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
+        => _options.BearerTokenProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.BearerToken);
 
     private static void ValidateAuthenticationTransport(HonuaGrpcClientOptions opts, Uri address)
     {
@@ -223,7 +261,10 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     }
 
     private static bool HasCredentials(HonuaGrpcClientOptions opts)
-        => !string.IsNullOrWhiteSpace(opts.ApiKey) || !string.IsNullOrWhiteSpace(opts.BearerToken);
+        => !string.IsNullOrWhiteSpace(opts.ApiKey) ||
+           !string.IsNullOrWhiteSpace(opts.BearerToken) ||
+           opts.ApiKeyProvider is not null ||
+           opts.BearerTokenProvider is not null;
 
     private static Models.QueryFeaturesRequest BuildGrpcQuery(FeatureQueryRequest request)
     {

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
@@ -19,9 +19,23 @@ public sealed class HonuaGrpcClientOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
+    /// Optional API key provider invoked before each RPC. When configured,
+    /// its value takes precedence over <see cref="ApiKey"/>; returning null or
+    /// an empty string omits the API key metadata entry.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; set; }
+
+    /// <summary>
     /// Bearer token for authentication.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// Optional bearer token provider invoked before each RPC. When configured,
+    /// its value takes precedence over <see cref="BearerToken"/>; returning null or
+    /// an empty string omits the authorization metadata entry.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
 
     /// <summary>
     /// Enables gRPC compression negotiation for responses.

--- a/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
+++ b/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
@@ -24,26 +24,43 @@ internal sealed class HonuaOgcFeaturesAuthHandler : DelegatingHandler
     }
 
     /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hasCredentials = !string.IsNullOrEmpty(_options.ApiKey) || !string.IsNullOrEmpty(_options.BearerToken);
-        if (hasCredentials && HonuaOgcFeaturesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HasCredentialSource() && HonuaOgcFeaturesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
             throw new InvalidOperationException(
                 "Refusing to send credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        if (!string.IsNullOrEmpty(_options.ApiKey))
+        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(apiKey))
         {
-            request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
-        if (!string.IsNullOrEmpty(_options.BearerToken))
+        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(bearerToken))
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.BearerToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
         }
 
-        return base.SendAsync(request, cancellationToken);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
+
+    private bool HasCredentialSource()
+        => !string.IsNullOrEmpty(_options.ApiKey) ||
+           !string.IsNullOrEmpty(_options.BearerToken) ||
+           _options.ApiKeyProvider is not null ||
+           _options.BearerTokenProvider is not null;
+
+    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
+        => _options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.ApiKey);
+
+    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
+        => _options.BearerTokenProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
@@ -19,9 +19,23 @@ public sealed class HonuaOgcFeaturesClientOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
+    /// Optional API key provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="ApiKey"/>; returning null or
+    /// an empty string omits the API key header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; set; }
+
+    /// <summary>
     /// Bearer token for authentication.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// Optional bearer token provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="BearerToken"/>; returning null or
+    /// an empty string omits the authorization header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.Wfs/HonuaWfsAuthHandler.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsAuthHandler.cs
@@ -24,26 +24,43 @@ internal sealed class HonuaWfsAuthHandler : DelegatingHandler
     }
 
     /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hasCredentials = !string.IsNullOrEmpty(_options.ApiKey) || !string.IsNullOrEmpty(_options.BearerToken);
-        if (hasCredentials && HonuaWfsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HasCredentialSource() && HonuaWfsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
             throw new InvalidOperationException(
                 "Refusing to send WFS credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        if (!string.IsNullOrEmpty(_options.ApiKey))
+        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(apiKey))
         {
-            request.Headers.TryAddWithoutValidation("X-API-Key", _options.ApiKey);
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
         }
 
-        if (!string.IsNullOrEmpty(_options.BearerToken))
+        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(bearerToken))
         {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.BearerToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
         }
 
-        return base.SendAsync(request, cancellationToken);
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
+
+    private bool HasCredentialSource()
+        => !string.IsNullOrEmpty(_options.ApiKey) ||
+           !string.IsNullOrEmpty(_options.BearerToken) ||
+           _options.ApiKeyProvider is not null ||
+           _options.BearerTokenProvider is not null;
+
+    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
+        => _options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.ApiKey);
+
+    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
+        => _options.BearerTokenProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
@@ -19,9 +19,23 @@ public sealed class HonuaWfsClientOptions
     public string? ApiKey { get; set; }
 
     /// <summary>
+    /// Optional API key provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="ApiKey"/>; returning null or
+    /// an empty string omits the API key header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; set; }
+
+    /// <summary>
     /// Bearer token for authentication.
     /// </summary>
     public string? BearerToken { get; set; }
+
+    /// <summary>
+    /// Optional bearer token provider invoked before each request. When configured,
+    /// its value takes precedence over <see cref="BearerToken"/>; returning null or
+    /// an empty string omits the authorization header.
+    /// </summary>
+    public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/tests/Honua.Sdk.Admin.Tests/HonuaAdminClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaAdminClientTests.cs
@@ -130,6 +130,92 @@ public sealed class HonuaAdminClientTests
     }
 
     [Fact]
+    public async Task AuthHandler_UsesCredentialProvidersPerRequest()
+    {
+        var apiKeyCalls = 0;
+        var bearerTokenCalls = 0;
+        var capturedCredentials = new List<(string? ApiKey, string? Authorization)>();
+
+        var options = Options.Create(new HonuaAdminClientOptions
+        {
+            ApiKeyProvider = _ => Task.FromResult<string?>($"admin-key-{++apiKeyCalls}"),
+            BearerTokenProvider = _ => Task.FromResult<string?>($"admin-token-{++bearerTokenCalls}")
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            req.Headers.TryGetValues("X-API-Key", out var apiValues);
+            capturedCredentials.Add((apiValues?.SingleOrDefault(), req.Headers.Authorization?.ToString()));
+            return Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>()));
+        });
+
+        var authHandler = new HonuaAdminAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        var client = new HonuaAdminClient(httpClient);
+        await client.ListServicesAsync();
+        await client.ListServicesAsync();
+
+        Assert.Collection(
+            capturedCredentials,
+            first =>
+            {
+                Assert.Equal("admin-key-1", first.ApiKey);
+                Assert.Equal("Bearer admin-token-1", first.Authorization);
+            },
+            second =>
+            {
+                Assert.Equal("admin-key-2", second.ApiKey);
+                Assert.Equal("Bearer admin-token-2", second.Authorization);
+            });
+    }
+
+    [Fact]
+    public async Task AuthHandler_ProviderReturningNullOrEmpty_OmitsCredentials()
+    {
+        var capturedApiKeyHeader = true;
+        var capturedAuthHeader = true;
+
+        var options = Options.Create(new HonuaAdminClientOptions
+        {
+            ApiKey = "fallback-key",
+            BearerToken = "fallback-token",
+            ApiKeyProvider = _ => Task.FromResult<string?>(null),
+            BearerTokenProvider = _ => Task.FromResult<string?>(string.Empty)
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            capturedApiKeyHeader = req.Headers.Contains("X-API-Key");
+            capturedAuthHeader = req.Headers.Authorization is not null;
+            return Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>()));
+        });
+
+        var authHandler = new HonuaAdminAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        var client = new HonuaAdminClient(httpClient);
+        await client.ListServicesAsync();
+
+        Assert.False(capturedApiKeyHeader);
+        Assert.False(capturedAuthHeader);
+    }
+
+    [Fact]
     public async Task AuthHandler_RejectsCredentialsOverRemoteHttp()
     {
         var options = Options.Create(new HonuaAdminClientOptions
@@ -151,6 +237,36 @@ public sealed class HonuaAdminClientTests
         var client = new HonuaAdminClient(httpClient);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => client.ListServicesAsync());
+    }
+
+    [Fact]
+    public async Task AuthHandler_RejectsCredentialProvidersOverRemoteHttp()
+    {
+        var providerCalled = false;
+        var options = Options.Create(new HonuaAdminClientOptions
+        {
+            BaseAddress = new Uri("http://example.com"),
+            ApiKeyProvider = _ =>
+            {
+                providerCalled = true;
+                return Task.FromResult<string?>("admin-key");
+            },
+        });
+
+        var authHandler = new HonuaAdminAuthHandler(options)
+        {
+            InnerHandler = new MockHttpHandler(_ => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())))
+        };
+
+        var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://example.com")
+        };
+
+        var client = new HonuaAdminClient(httpClient);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => client.ListServicesAsync());
+        Assert.False(providerCalled);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/HonuaGeoServicesAuthHandlerTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/HonuaGeoServicesAuthHandlerTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.GeoServices.Tests;
+
+public sealed class HonuaGeoServicesAuthHandlerTests
+{
+    [Fact]
+    public async Task AuthHandler_UsesCredentialProvidersPerRequest()
+    {
+        var apiKeyCalls = 0;
+        var bearerTokenCalls = 0;
+        var capturedCredentials = new List<(string? ApiKey, string? Authorization)>();
+
+        var options = Options.Create(new HonuaGeoServicesClientOptions
+        {
+            ApiKeyProvider = _ => Task.FromResult<string?>($"geoservices-key-{++apiKeyCalls}"),
+            BearerTokenProvider = _ => Task.FromResult<string?>($"geoservices-token-{++bearerTokenCalls}")
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            req.Headers.TryGetValues("X-API-Key", out var apiValues);
+            capturedCredentials.Add((apiValues?.SingleOrDefault(), req.Headers.Authorization?.ToString()));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        });
+
+        var authHandler = new HonuaGeoServicesAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        using var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        await httpClient.GetAsync("/FeatureServer");
+        await httpClient.GetAsync("/FeatureServer");
+
+        Assert.Collection(
+            capturedCredentials,
+            first =>
+            {
+                Assert.Equal("geoservices-key-1", first.ApiKey);
+                Assert.Equal("Bearer geoservices-token-1", first.Authorization);
+            },
+            second =>
+            {
+                Assert.Equal("geoservices-key-2", second.ApiKey);
+                Assert.Equal("Bearer geoservices-token-2", second.Authorization);
+            });
+    }
+}

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -264,12 +264,132 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task Metadata_IncludesStaticCredentials_WhenConfiguredInOptions()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        Metadata? capturedMetadata = null;
+
+        var protoResponse = new Proto.QueryFeaturesResponse();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (_, metadata, _, _) => capturedMetadata = metadata)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+        {
+            EnableCompressionNegotiation = false,
+            ApiKey = "my-key",
+            BearerToken = "my-token"
+        });
+
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "svc" });
+
+        Assert.NotNull(capturedMetadata);
+        Assert.Equal("my-key", GetMetadataValue(capturedMetadata!, "x-api-key"));
+        Assert.Equal("Bearer my-token", GetMetadataValue(capturedMetadata!, "authorization"));
+    }
+
+    [Fact]
+    public async Task Metadata_UsesCredentialProvidersPerCall()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        var capturedMetadata = new List<Metadata>();
+        var apiKeyCalls = 0;
+        var bearerTokenCalls = 0;
+
+        var protoResponse = new Proto.QueryFeaturesResponse();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (_, metadata, _, _) => capturedMetadata.Add(metadata))
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+        {
+            EnableCompressionNegotiation = false,
+            ApiKeyProvider = _ => Task.FromResult<string?>($"grpc-key-{++apiKeyCalls}"),
+            BearerTokenProvider = _ => Task.FromResult<string?>($"grpc-token-{++bearerTokenCalls}")
+        });
+
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "svc" });
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "svc" });
+
+        Assert.Collection(
+            capturedMetadata,
+            first =>
+            {
+                Assert.Equal("grpc-key-1", GetMetadataValue(first, "x-api-key"));
+                Assert.Equal("Bearer grpc-token-1", GetMetadataValue(first, "authorization"));
+            },
+            second =>
+            {
+                Assert.Equal("grpc-key-2", GetMetadataValue(second, "x-api-key"));
+                Assert.Equal("Bearer grpc-token-2", GetMetadataValue(second, "authorization"));
+            });
+    }
+
+    [Fact]
+    public async Task Metadata_ProviderReturningNullOrEmpty_OmitsCredentials()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        Metadata? capturedMetadata = null;
+
+        var protoResponse = new Proto.QueryFeaturesResponse();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (_, metadata, _, _) => capturedMetadata = metadata)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+        {
+            EnableCompressionNegotiation = false,
+            ApiKey = "fallback-key",
+            BearerToken = "fallback-token",
+            ApiKeyProvider = _ => Task.FromResult<string?>(null),
+            BearerTokenProvider = _ => Task.FromResult<string?>(string.Empty)
+        });
+
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "svc" });
+
+        Assert.NotNull(capturedMetadata);
+        Assert.Null(GetMetadataValue(capturedMetadata!, "x-api-key"));
+        Assert.Null(GetMetadataValue(capturedMetadata!, "authorization"));
+    }
+
+    [Fact]
     public void Constructor_WithCredentialsAndRemoteHttpAddress_Throws()
     {
         var options = Options.Create(new HonuaGrpcClientOptions
         {
             Address = "http://example.com:5000",
             ApiKey = "my-key"
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new HonuaGrpcClient(options));
+        Assert.Contains("Refusing to send gRPC credentials over an insecure connection", ex.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithCredentialProviderAndRemoteHttpAddress_Throws()
+    {
+        var options = Options.Create(new HonuaGrpcClientOptions
+        {
+            Address = "http://example.com:5000",
+            BearerTokenProvider = _ => Task.FromResult<string?>("my-token")
         });
 
         var ex = Assert.Throws<InvalidOperationException>(() => new HonuaGrpcClient(options));
@@ -307,6 +427,9 @@ public class HonuaGrpcClientTests
             () => new Metadata(),
             () => { });
     }
+
+    private static string? GetMetadataValue(Metadata metadata, string key)
+        => metadata.FirstOrDefault(entry => entry.Key == key)?.Value;
 
     private static AsyncServerStreamingCall<T> CreateAsyncServerStreamingCall<T>(IEnumerable<T> responses)
     {

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Grpc.Core;
+using Grpc.Net.Client;
 using Honua.Sdk.Abstractions.Features;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -394,6 +395,31 @@ public class HonuaGrpcClientTests
 
         var ex = Assert.Throws<InvalidOperationException>(() => new HonuaGrpcClient(options));
         Assert.Contains("Refusing to send gRPC credentials over an insecure connection", ex.Message);
+    }
+
+    [Fact]
+    public void ChannelConstructor_WithCredentialProviderAndRemoteHttpAddress_Throws()
+    {
+        using var channel = GrpcChannel.ForAddress("http://example.com:5000");
+        var options = new HonuaGrpcClientOptions
+        {
+            BearerTokenProvider = _ => Task.FromResult<string?>("my-token")
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => new HonuaGrpcClient(channel, options));
+        Assert.Contains("Refusing to send gRPC credentials over an insecure connection", ex.Message);
+    }
+
+    [Fact]
+    public void ChannelConstructor_WithCredentialProviderAndLoopbackHttpAddress_DoesNotThrow()
+    {
+        using var channel = GrpcChannel.ForAddress("http://localhost:5000");
+        var options = new HonuaGrpcClientOptions
+        {
+            ApiKeyProvider = _ => Task.FromResult<string?>("my-key")
+        };
+
+        using var client = new HonuaGrpcClient(channel, options);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
+++ b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/Honua.Sdk.OgcFeatures.Tests/HonuaOgcFeaturesAuthHandlerTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/HonuaOgcFeaturesAuthHandlerTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.OgcFeatures.Tests.Fixtures;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.OgcFeatures.Tests;
+
+public sealed class HonuaOgcFeaturesAuthHandlerTests
+{
+    [Fact]
+    public async Task AuthHandler_UsesCredentialProvidersPerRequest()
+    {
+        var apiKeyCalls = 0;
+        var bearerTokenCalls = 0;
+        var capturedCredentials = new List<(string? ApiKey, string? Authorization)>();
+
+        var options = Options.Create(new HonuaOgcFeaturesClientOptions
+        {
+            ApiKeyProvider = _ => Task.FromResult<string?>($"ogc-key-{++apiKeyCalls}"),
+            BearerTokenProvider = _ => Task.FromResult<string?>($"ogc-token-{++bearerTokenCalls}")
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            req.Headers.TryGetValues("X-API-Key", out var apiValues);
+            capturedCredentials.Add((apiValues?.SingleOrDefault(), req.Headers.Authorization?.ToString()));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        });
+
+        var authHandler = new HonuaOgcFeaturesAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        using var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        await httpClient.GetAsync("/ogc/features/v1");
+        await httpClient.GetAsync("/ogc/features/v1");
+
+        Assert.Collection(
+            capturedCredentials,
+            first =>
+            {
+                Assert.Equal("ogc-key-1", first.ApiKey);
+                Assert.Equal("Bearer ogc-token-1", first.Authorization);
+            },
+            second =>
+            {
+                Assert.Equal("ogc-key-2", second.ApiKey);
+                Assert.Equal("Bearer ogc-token-2", second.Authorization);
+            });
+    }
+}

--- a/tests/Honua.Sdk.Wfs.Tests/HonuaWfsAuthHandlerTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/HonuaWfsAuthHandlerTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.Wfs.Tests.Fixtures;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.Wfs.Tests;
+
+public sealed class HonuaWfsAuthHandlerTests
+{
+    [Fact]
+    public async Task AuthHandler_UsesCredentialProvidersPerRequest()
+    {
+        var apiKeyCalls = 0;
+        var bearerTokenCalls = 0;
+        var capturedCredentials = new List<(string? ApiKey, string? Authorization)>();
+
+        var options = Options.Create(new HonuaWfsClientOptions
+        {
+            ApiKeyProvider = _ => Task.FromResult<string?>($"wfs-key-{++apiKeyCalls}"),
+            BearerTokenProvider = _ => Task.FromResult<string?>($"wfs-token-{++bearerTokenCalls}")
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            req.Headers.TryGetValues("X-API-Key", out var apiValues);
+            capturedCredentials.Add((apiValues?.SingleOrDefault(), req.Headers.Authorization?.ToString()));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        });
+
+        var authHandler = new HonuaWfsAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        using var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        await httpClient.GetAsync("/wfs");
+        await httpClient.GetAsync("/wfs");
+
+        Assert.Collection(
+            capturedCredentials,
+            first =>
+            {
+                Assert.Equal("wfs-key-1", first.ApiKey);
+                Assert.Equal("Bearer wfs-token-1", first.Authorization);
+            },
+            second =>
+            {
+                Assert.Equal("wfs-key-2", second.ApiKey);
+                Assert.Equal("Bearer wfs-token-2", second.Authorization);
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- Add per-request/RPC `ApiKeyProvider` and `BearerTokenProvider` options across Admin, gRPC, WFS, GeoServices, and OGC API Features clients.
- Keep HTTPS enforcement for static and provider-backed credentials, with null or empty provider results omitting auth headers for revocation.
- Document secure storage, rotation, revocation, failure, and retry behavior.
- Normalize remaining `Microsoft.Extensions.*` package versions that were causing restore downgrades in solution tests.

## Validation
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true`
- `git diff --check`

Closes #5