### PR TITLE
[codex] record staging integration evidence metadata

### DIFF
--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -31,6 +31,9 @@ jobs:
       HONUA_STAGING_LAYER_ID: ${{ vars.HONUA_STAGING_LAYER_ID }}
       HONUA_STAGING_WFS_TYPENAME: ${{ vars.HONUA_STAGING_WFS_TYPENAME }}
       HONUA_STAGING_OGC_COLLECTION_ID: ${{ vars.HONUA_STAGING_OGC_COLLECTION_ID }}
+      HONUA_STAGING_SERVER_COMMIT: ${{ vars.HONUA_STAGING_SERVER_COMMIT }}
+      HONUA_STAGING_SERVER_IMAGE: ${{ vars.HONUA_STAGING_SERVER_IMAGE }}
+      HONUA_STAGING_SEED_PROFILE: ${{ vars.HONUA_STAGING_SEED_PROFILE }}
       HONUA_STAGING_EVIDENCE_PATH: ${{ github.workspace }}/artifacts/evidence/ci-report.json
       HONUA_STAGING_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       TEST_RESULTS_DIR: ${{ github.workspace }}/artifacts/test-results
@@ -118,6 +121,8 @@ with open(evidence_path, encoding="utf-8") as evidence_file:
 
 summary = report.get("Summary", {})
 checks = report.get("Checks", [])
+sdk_packages = report.get("SdkPackages", [])
+protocol_surfaces = report.get("ProtocolSurfaces", [])
 
 with open(summary_path, "a", encoding="utf-8") as summary_file:
     summary_file.write("## Staging Integration\n\n")
@@ -128,6 +133,18 @@ with open(summary_path, "a", encoding="utf-8") as summary_file:
     summary_file.write(f"- Layer ID: `{report.get('LayerId', 'unknown')}`\n")
     summary_file.write(f"- WFS type: `{report.get('WfsTypeName', 'unknown')}`\n")
     summary_file.write(f"- OGC collection: `{report.get('OgcCollectionId', 'unknown')}`\n")
+    summary_file.write(f"- Server commit: `{report.get('ServerCommit') or 'unknown'}`\n")
+    summary_file.write(f"- Server image: `{report.get('ServerImage') or 'unknown'}`\n")
+    summary_file.write(f"- Seed profile: `{report.get('SeedProfile') or 'unknown'}`\n")
+    summary_file.write(f"- Protocol surfaces: `{', '.join(protocol_surfaces) or 'unknown'}`\n")
+    summary_file.write(
+        "- SDK packages: `" +
+        ", ".join(
+            f"{package.get('Package', 'unknown')} {package.get('Version', 'unknown')}"
+            for package in sdk_packages
+        ) +
+        "`\n"
+    )
     summary_file.write(
         f"- Summary: {summary.get('Passed', 0)} passed, "
         f"{summary.get('Failed', 0)} failed, "

--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -46,6 +46,12 @@ Workflow-managed values:
 - `HONUA_STAGING_EVIDENCE_PATH`
 - `HONUA_STAGING_RUN_ID`
 
+Optional evidence metadata:
+
+- `HONUA_STAGING_SERVER_COMMIT`
+- `HONUA_STAGING_SERVER_IMAGE`
+- `HONUA_STAGING_SEED_PROFILE`
+
 Local execution uses the same environment variables. Example:
 
 ```bash
@@ -72,7 +78,11 @@ Successful workflow runs emit all of the following:
 The JSON evidence includes:
 
 - base URL
+- SDK package versions
+- server commit and image when configured
+- seed profile when configured
 - service/layer/type/collection identifiers
+- protocol surfaces under test
 - per-check status, duration, and detail string
 - a total passed / failed / not-run summary
 

--- a/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
+++ b/tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+namespace Honua.Sdk.IntegrationTests;
+
+public sealed class StagingEvidenceTests
+{
+    [Fact]
+    public async Task DisposeAsync_WritesSdkAndServerMetadata()
+    {
+        var evidencePath = Path.Combine(Path.GetTempPath(), $"honua-sdk-evidence-{Guid.NewGuid():N}.json");
+
+        using var environment = new EnvironmentScope();
+        environment.Set("HONUA_STAGING_BASE_URL", "https://localhost:5001");
+        environment.Set("HONUA_STAGING_API_KEY", "test-key");
+        environment.Set("HONUA_STAGING_SERVICE_NAME", "sdk-demo");
+        environment.Set("HONUA_STAGING_LAYER_ID", "0");
+        environment.Set("HONUA_STAGING_WFS_TYPENAME", "public:sdk_demo");
+        environment.Set("HONUA_STAGING_OGC_COLLECTION_ID", "sdk-demo");
+        environment.Set("HONUA_STAGING_EVIDENCE_PATH", evidencePath);
+        environment.Set("HONUA_STAGING_RUN_ID", "run-1");
+        environment.Set("HONUA_STAGING_SERVER_COMMIT", "server-sha");
+        environment.Set("HONUA_STAGING_SERVER_IMAGE", "ghcr.io/honua/server:test");
+        environment.Set("HONUA_STAGING_SEED_PROFILE", "sdk-readonly");
+
+        var fixture = new StagingIntegrationFixture();
+        try
+        {
+            await fixture.DisposeAsync();
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(evidencePath));
+        var root = doc.RootElement;
+
+        Assert.Equal("run-1", root.GetProperty("RunId").GetString());
+        Assert.Equal("server-sha", root.GetProperty("ServerCommit").GetString());
+        Assert.Equal("ghcr.io/honua/server:test", root.GetProperty("ServerImage").GetString());
+        Assert.Equal("sdk-readonly", root.GetProperty("SeedProfile").GetString());
+
+        var packages = root.GetProperty("SdkPackages").EnumerateArray().ToArray();
+        Assert.Contains(packages, package => HasPackage(package, "Honua.Sdk.Admin"));
+        Assert.Contains(packages, package => HasPackage(package, "Honua.Sdk.Grpc"));
+        Assert.All(packages, package => Assert.False(string.IsNullOrWhiteSpace(package.GetProperty("Version").GetString())));
+
+        var surfaces = root.GetProperty("ProtocolSurfaces").EnumerateArray()
+            .Select(surface => surface.GetString())
+            .ToArray();
+        Assert.Contains("grpc", surfaces);
+        Assert.Contains("geoservices-featureserver", surfaces);
+
+        File.Delete(evidencePath);
+    }
+
+    private static bool HasPackage(JsonElement package, string packageName)
+        => string.Equals(package.GetProperty("Package").GetString(), packageName, StringComparison.Ordinal);
+
+    private sealed class EnvironmentScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalValues = [];
+
+        public void Set(string key, string value)
+        {
+            _originalValues.TryAdd(key, Environment.GetEnvironmentVariable(key));
+            Environment.SetEnvironmentVariable(key, value);
+        }
+
+        public void Dispose()
+        {
+            foreach (var (key, value) in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 using Honua.Sdk.Admin.Extensions;
 using Honua.Sdk.GeoServices.Extensions;
@@ -27,6 +28,15 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         "ogc-collections",
         "ogc-items",
         "ogc-item"
+    ];
+
+    private static readonly string[] ProtocolSurfaces =
+    [
+        "admin",
+        "grpc",
+        "wfs",
+        "geoservices-featureserver",
+        "ogc-api-features"
     ];
 
     private readonly Dictionary<string, StagingCheckResult> _results =
@@ -155,6 +165,11 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
             LayerId = Options.LayerId,
             WfsTypeName = Options.WfsTypeName,
             OgcCollectionId = Options.OgcCollectionId,
+            ServerCommit = Options.ServerCommit,
+            ServerImage = Options.ServerImage,
+            SeedProfile = Options.SeedProfile,
+            ProtocolSurfaces = ProtocolSurfaces,
+            SdkPackages = GetSdkPackageVersions(),
             Checks = checks,
             Summary = new StagingEvidenceSummary
             {
@@ -172,6 +187,24 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
 
         await File.WriteAllTextAsync(Options.EvidencePath, json).ConfigureAwait(false);
     }
+
+    private static IReadOnlyList<SdkPackageVersion> GetSdkPackageVersions()
+        =>
+        [
+            CreateSdkPackageVersion("Honua.Sdk.Abstractions", typeof(Honua.Sdk.Abstractions.Features.IHonuaFeatureQueryClient).Assembly),
+            CreateSdkPackageVersion("Honua.Sdk.Admin", typeof(HonuaAdminClient).Assembly),
+            CreateSdkPackageVersion("Honua.Sdk.Grpc", typeof(HonuaGrpcClient).Assembly),
+            CreateSdkPackageVersion("Honua.Sdk.Wfs", typeof(HonuaWfsClient).Assembly),
+            CreateSdkPackageVersion("Honua.Sdk.GeoServices", typeof(HonuaFeatureServerClient).Assembly),
+            CreateSdkPackageVersion("Honua.Sdk.OgcFeatures", typeof(HonuaOgcFeaturesClient).Assembly)
+        ];
+
+    private static SdkPackageVersion CreateSdkPackageVersion(string packageName, Assembly assembly)
+        => new(
+            packageName,
+            assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
+            assembly.GetName().Version?.ToString() ??
+            "unknown");
 
     public sealed record StagingCheckResult(
         string Name,
@@ -209,10 +242,22 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
 
         public string OgcCollectionId { get; init; } = string.Empty;
 
+        public string? ServerCommit { get; init; }
+
+        public string? ServerImage { get; init; }
+
+        public string? SeedProfile { get; init; }
+
+        public IReadOnlyList<string> ProtocolSurfaces { get; init; } = [];
+
+        public IReadOnlyList<SdkPackageVersion> SdkPackages { get; init; } = [];
+
         public IReadOnlyList<StagingCheckResult> Checks { get; init; } = [];
 
         public StagingEvidenceSummary Summary { get; init; } = new();
     }
+
+    public sealed record SdkPackageVersion(string Package, string Version);
 
     public sealed class StagingEvidenceSummary
     {

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
@@ -11,6 +11,9 @@ public sealed class StagingIntegrationOptions
     private const string OgcCollectionIdKey = "HONUA_STAGING_OGC_COLLECTION_ID";
     private const string EvidencePathKey = "HONUA_STAGING_EVIDENCE_PATH";
     private const string RunIdKey = "HONUA_STAGING_RUN_ID";
+    private const string ServerCommitKey = "HONUA_STAGING_SERVER_COMMIT";
+    private const string ServerImageKey = "HONUA_STAGING_SERVER_IMAGE";
+    private const string SeedProfileKey = "HONUA_STAGING_SEED_PROFILE";
 
     public Uri BaseUri { get; init; } = new("https://localhost");
 
@@ -29,6 +32,12 @@ public sealed class StagingIntegrationOptions
     public string? EvidencePath { get; init; }
 
     public string RunId { get; init; } = string.Empty;
+
+    public string? ServerCommit { get; init; }
+
+    public string? ServerImage { get; init; }
+
+    public string? SeedProfile { get; init; }
 
     public static IReadOnlyList<string> GetMissingEnvironmentVariables()
     {
@@ -89,7 +98,10 @@ public sealed class StagingIntegrationOptions
             WfsTypeName = ReadRequired(WfsTypeNameKey),
             OgcCollectionId = ReadRequired(OgcCollectionIdKey),
             EvidencePath = Read(EvidencePathKey),
-            RunId = Read(RunIdKey) ?? DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmssZ", System.Globalization.CultureInfo.InvariantCulture)
+            RunId = Read(RunIdKey) ?? DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmssZ", System.Globalization.CultureInfo.InvariantCulture),
+            ServerCommit = Read(ServerCommitKey),
+            ServerImage = Read(ServerImageKey),
+            SeedProfile = Read(SeedProfileKey)
         };
     }
 


### PR DESCRIPTION
## Summary
- Record SDK package versions, protocol surfaces, server commit/image, and seed profile in staging integration evidence.
- Pass optional staging metadata variables through the scheduled/workflow-call lane and surface them in the GitHub step summary.
- Add a no-network evidence serialization test and bump the integration test DI package to avoid restore downgrade.

## Validation
- `dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `git diff --check`

Refs #31