### PR TITLE
[codex] complete client behavior basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,15 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
 
 The gRPC, WFS, GeoServices, and OGC API Features clients retry automatically on transient failures with
 exponential backoff and jitter. gRPC retries on `Unavailable` / `Internal`;
-HTTP clients retry on `429`, `502`, `503`. Configurable on each client:
+HTTP clients retry on `429`, `502`, `503`. Each DI client also exposes a
+`Timeout` option that defaults to 100 seconds and accepts any value greater
+than 10 milliseconds and less than 24 hours. Configurable on each client:
 
 ```csharp
 builder.Services.AddHonuaGrpc(o =>
 {
     o.Address = "https://localhost:5001";
+    o.Timeout = TimeSpan.FromSeconds(30);
     o.EnableRetry = true;       // default
     o.MaxRetryAttempts = 3;     // default, range 2-5
 });
@@ -151,10 +154,14 @@ builder.Services.AddHonuaGrpc(o =>
 builder.Services.AddHonuaWfs(o =>
 {
     o.BaseAddress = new Uri("https://localhost:5001");
+    o.Timeout = TimeSpan.FromSeconds(30);
     o.EnableRetry = true;       // default
     o.MaxRetryAttempts = 3;     // default, range 2-5
 });
 ```
+
+Timeout, retry, error, pagination, and endpoint coverage behavior is documented
+in [docs/client-behavior.md](docs/client-behavior.md).
 
 ## WFS 2.0 queries
 
@@ -268,6 +275,8 @@ third_party/
 - **[Staging Integration Guide](docs/staging-integration.md)** -- staging
   environment inputs, CI evidence artifacts, common failures, and bounded
   follow-on tickets for shared staging ownership
+- **[Client Behavior](docs/client-behavior.md)** -- timeout, retry, error,
+  pagination, and typed endpoint coverage behavior across packages
 - **[Release and NuGet Publishing](docs/release.md)** -- package versioning,
   release tags, dry runs, GitHub Packages, and NuGet.org publishing
 - **[INSTALL.md](INSTALL.md)** -- NuGet and GitHub Packages setup, version

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -1,0 +1,90 @@
+# Client Behavior
+
+This page documents the cross-cutting behavior that applies to the Honua SDK
+clients: timeouts, retries, errors, pagination, and current endpoint coverage.
+
+## Timeouts and cancellation
+
+Every DI-registered client exposes a `Timeout` option. The default is 100
+seconds, matching the .NET `HttpClient` default. The value must be greater than
+10 milliseconds and less than 24 hours.
+
+```csharp
+builder.Services.AddHonuaGrpc(options =>
+{
+    options.Address = "https://localhost:5001";
+    options.Timeout = TimeSpan.FromSeconds(30);
+});
+
+builder.Services.AddHonuaWfs(options =>
+{
+    options.BaseAddress = new Uri("https://localhost:5001");
+    options.Timeout = TimeSpan.FromSeconds(30);
+});
+```
+
+For HTTP clients, `Timeout` is applied to the underlying `HttpClient`. When
+automatic retry is enabled, it is also applied to the standard resilience
+pipeline as both the total request timeout and the per-attempt timeout. For
+gRPC, `Timeout` is converted to a per-call deadline. All public async methods
+also accept a `CancellationToken`; use it for caller-driven cancellation.
+
+## Retries
+
+Retries are enabled by default and can be disabled per client with
+`EnableRetry = false`. `MaxRetryAttempts` is clamped to the supported range of
+2 to 5.
+
+| Client family | Retried failures |
+|---------------|------------------|
+| gRPC | `Unavailable`, `Internal` |
+| Admin, Geocoding, WFS, GeoServices, OGC API Features | HTTP `429`, `502`, `503` |
+
+Authentication failures, validation errors, unsupported operations, parser
+failures, and application-level protocol errors are not retried by the SDK.
+
+## Error handling
+
+Each package exposes protocol-specific exception types so callers can catch the
+right failure surface without parsing strings.
+
+| Package | Exception | Notes |
+|---------|-----------|-------|
+| `Honua.Sdk.Admin` | `HonuaAdminApiException` | Non-success HTTP status codes. Includes status code and response body. |
+| `Honua.Sdk.Admin` | `HonuaAdminOperationException` | Successful HTTP responses that fail the expected Admin contract, such as null envelopes or compatibility failures. |
+| `Honua.Sdk.Wfs` | `HonuaWfsException` | HTTP failures, OGC `ExceptionReport` responses, and content-format mismatches. Includes the OGC exception code when available. |
+| `Honua.Sdk.GeoServices` | `HonuaFeatureServerException` | HTTP failures and GeoServices JSON error envelopes, including 200 responses that carry an error payload. |
+| `Honua.Sdk.OgcFeatures` | `HonuaOgcFeaturesException` | HTTP failures, JSON contract failures, and rejected cross-origin next-page links. |
+| `Honua.Sdk.Grpc` | `HonuaGrpcException` | Wraps `RpcException` and preserves the gRPC status code. |
+
+`ArgumentNullException`, `ArgumentException`, `InvalidOperationException`, and
+`NotSupportedException` are used for local input/configuration problems before
+or instead of a remote request.
+
+## Pagination
+
+Native clients expose provider-specific pagination helpers, and read clients
+also implement `IHonuaFeatureQueryClient.QueryPagesAsync` from
+`Honua.Sdk.Abstractions` for provider-neutral paging.
+
+| Client | Pagination behavior |
+|--------|---------------------|
+| WFS | `GetFeaturesAsyncEnumerable` advances `STARTINDEX`; shared queries advance `FeatureQueryRequest.Offset`. Paging stops when `numberMatched` is reached or a page is empty, with a 100-page safety limit. |
+| GeoServices FeatureServer | `QueryPagesAsync` advances `resultOffset` while the server reports `exceededTransferLimit`. |
+| OGC API Features | `GetItemsPagesAsync` follows same-origin `rel=next` links. Cross-origin next links are rejected. |
+| gRPC | `QueryFeaturesStreamAsync` returns server-streamed pages until `IsLastPage`; `QueryPagesAsync` maps those pages to the shared abstraction. |
+
+## Endpoint coverage
+
+Current typed endpoint coverage is:
+
+| Package | Covered surfaces |
+|---------|------------------|
+| `Honua.Sdk.Admin` | Service listing/settings/protocols, MapServer/access/time/layer metadata settings, metadata resources and manifests, version/capabilities/compatibility/config, secure connections/encryption, layer publishing/table discovery/styles, observability, migrations, deploy preflight/plans/operations, and geocoding. |
+| `Honua.Sdk.Grpc` | Feature query, streaming feature query, and feature edits. |
+| `Honua.Sdk.Wfs` | `GetCapabilities`, `DescribeFeatureType`, `GetFeature`, feature count via hits, custom output handlers, and auto-pagination. |
+| `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, and auto-pagination. |
+| `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, and next-link pagination. |
+
+Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
+WFS, GeoServices FeatureServer, and OGC API Features.

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,9 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             HonuaAdminClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaAdminClientOptions.ValidateTimeout(options.Timeout);
             client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
         ConfigureResilience(services, httpBuilder, configure);
@@ -52,13 +54,16 @@ public static class ServiceCollectionExtensions
     {
         services.Configure(configure);
         services.AddTransient<HonuaAdminAuthHandler>();
-        var httpBuilder = services.AddHttpClient<IHonuaGeocodingClient, HonuaGeocodingClient>((sp, client) =>
+        var httpBuilder = services.AddHttpClient(nameof(HonuaGeocodingClient), (sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             HonuaAdminClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaAdminClientOptions.ValidateTimeout(options.Timeout);
             client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
+        httpBuilder.AddTypedClient<IHonuaGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
         ConfigureResilience(services, httpBuilder, configure);
         return services;
     }
@@ -70,6 +75,7 @@ public static class ServiceCollectionExtensions
     {
         var opts = new HonuaAdminClientOptions();
         configure(opts);
+        HonuaAdminClientOptions.ValidateTimeout(opts.Timeout);
 
         if (!opts.EnableRetry)
         {
@@ -78,6 +84,8 @@ public static class ServiceCollectionExtensions
 
         httpBuilder.AddStandardResilienceHandler(options =>
         {
+            options.TotalRequestTimeout.Timeout = opts.Timeout;
+            options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
             options.Retry.ShouldHandle = args => ValueTask.FromResult(
                 args.Outcome.Result?.StatusCode is

--- a/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
@@ -44,6 +44,12 @@ public sealed class HonuaAdminClientOptions
     public bool EnableRetry { get; set; } = true;
 
     /// <summary>
+    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
     /// Maximum number of retry attempts (default: 3, range 2-5).
     /// Only applies when <see cref="EnableRetry"/> is true.
     /// </summary>
@@ -71,6 +77,15 @@ public sealed class HonuaAdminClientOptions
             !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException("Honua admin base address must use HTTP or HTTPS.");
+        }
+    }
+
+    internal static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
+        {
+            throw new InvalidOperationException(
+                "Honua admin timeout must be greater than 10 milliseconds and less than 24 hours.");
         }
     }
 

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -31,7 +31,9 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
             HonuaGeoServicesClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaGeoServicesClientOptions.ValidateTimeout(options.Timeout);
             client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaFeatureServerClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
@@ -46,6 +48,7 @@ public static class ServiceCollectionExtensions
     {
         var opts = new HonuaGeoServicesClientOptions();
         configure(opts);
+        HonuaGeoServicesClientOptions.ValidateTimeout(opts.Timeout);
 
         if (!opts.EnableRetry)
         {
@@ -54,6 +57,8 @@ public static class ServiceCollectionExtensions
 
         httpBuilder.AddStandardResilienceHandler(options =>
         {
+            options.TotalRequestTimeout.Timeout = opts.Timeout;
+            options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
             options.Retry.ShouldHandle = args => ValueTask.FromResult(
                 args.Outcome.Result?.StatusCode is

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -44,6 +44,12 @@ public sealed class HonuaGeoServicesClientOptions
     public bool EnableRetry { get; set; } = true;
 
     /// <summary>
+    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
     /// Maximum number of retry attempts (default: 3, range 2-5).
     /// Only applies when <see cref="EnableRetry"/> is true.
     /// </summary>
@@ -71,6 +77,15 @@ public sealed class HonuaGeoServicesClientOptions
             !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException("Honua GeoServices base address must use HTTP or HTTPS.");
+        }
+    }
+
+    internal static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
+        {
+            throw new InvalidOperationException(
+                "Honua GeoServices timeout must be greater than 10 milliseconds and less than 24 hours.");
         }
     }
 

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -36,6 +36,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     {
         var opts = options.Value;
         var address = HonuaGrpcClientOptions.ParseAndValidateAddress(opts.Address);
+        HonuaGrpcClientOptions.ValidateTimeout(opts.Timeout);
         ValidateAuthenticationTransport(opts, address);
 
         var channelOptions = new GrpcChannelOptions
@@ -58,6 +59,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     public HonuaGrpcClient(GrpcChannel channel, HonuaGrpcClientOptions? options = null)
     {
         var opts = options ?? new HonuaGrpcClientOptions();
+        HonuaGrpcClientOptions.ValidateTimeout(opts.Timeout);
         if (HasCredentials(opts))
         {
             ValidateAuthenticationTransport(opts, ResolveChannelAddress(channel));
@@ -79,6 +81,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     internal HonuaGrpcClient(Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient client, HonuaGrpcClientOptions options)
     {
         _client = client;
+        HonuaGrpcClientOptions.ValidateTimeout(options.Timeout);
         _options = options;
     }
 
@@ -93,7 +96,11 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         try
         {
             var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
-            var protoResponse = await _client.QueryFeaturesAsync(protoRequest, metadata, cancellationToken: ct);
+            var protoResponse = await _client.QueryFeaturesAsync(
+                protoRequest,
+                metadata,
+                deadline: CreateDeadline(),
+                cancellationToken: ct);
             return ProtoAdapter.FromProtoResponse(protoResponse);
         }
         catch (RpcException ex)
@@ -129,7 +136,11 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         try
         {
             var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
-            var protoResponse = await _client.ApplyEditsAsync(protoRequest, metadata, cancellationToken: ct);
+            var protoResponse = await _client.ApplyEditsAsync(
+                protoRequest,
+                metadata,
+                deadline: CreateDeadline(),
+                cancellationToken: ct);
             return ProtoAdapter.FromProtoApplyEditsResponse(protoResponse);
         }
         catch (RpcException ex)
@@ -144,7 +155,11 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     {
         var protoRequest = ProtoAdapter.ToProtoRequest(request);
         var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
-        var call = _client.QueryFeaturesStream(protoRequest, metadata, cancellationToken: ct);
+        var call = _client.QueryFeaturesStream(
+            protoRequest,
+            metadata,
+            deadline: CreateDeadline(),
+            cancellationToken: ct);
         try
         {
             while (true)
@@ -240,6 +255,9 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
 
         return metadata;
     }
+
+    private DateTime CreateDeadline()
+        => DateTime.UtcNow.Add(_options.Timeout);
 
     private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
         => _options.ApiKeyProvider is { } provider

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
@@ -54,6 +54,12 @@ public sealed class HonuaGrpcClientOptions
     public bool EnableRetry { get; set; } = true;
 
     /// <summary>
+    /// Overall deadline applied to each gRPC call, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
     /// Maximum number of retry attempts (including the original call).
     /// Only used when <see cref="EnableRetry"/> is <c>true</c>. Defaults to 3.
     /// Must be between 2 and 5 inclusive.
@@ -79,6 +85,15 @@ public sealed class HonuaGrpcClientOptions
         }
 
         return uri;
+    }
+
+    internal static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
+        {
+            throw new InvalidOperationException(
+                "Honua gRPC timeout must be greater than 10 milliseconds and less than 24 hours.");
+        }
     }
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,9 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaOgcFeaturesClientOptions>>().Value;
             HonuaOgcFeaturesClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaOgcFeaturesClientOptions.ValidateTimeout(options.Timeout);
             client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcFeaturesClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
@@ -45,6 +47,7 @@ public static class ServiceCollectionExtensions
     {
         var opts = new HonuaOgcFeaturesClientOptions();
         configure(opts);
+        HonuaOgcFeaturesClientOptions.ValidateTimeout(opts.Timeout);
 
         if (!opts.EnableRetry)
         {
@@ -53,6 +56,8 @@ public static class ServiceCollectionExtensions
 
         httpBuilder.AddStandardResilienceHandler(options =>
         {
+            options.TotalRequestTimeout.Timeout = opts.Timeout;
+            options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
             options.Retry.ShouldHandle = args => ValueTask.FromResult(
                 args.Outcome.Result?.StatusCode is

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
@@ -44,6 +44,12 @@ public sealed class HonuaOgcFeaturesClientOptions
     public bool EnableRetry { get; set; } = true;
 
     /// <summary>
+    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
     /// Maximum number of retry attempts (default: 3, range 2-5).
     /// Only applies when <see cref="EnableRetry"/> is true.
     /// </summary>
@@ -71,6 +77,15 @@ public sealed class HonuaOgcFeaturesClientOptions
             !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException("Honua OGC Features base address must use HTTP or HTTPS.");
+        }
+    }
+
+    internal static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
+        {
+            throw new InvalidOperationException(
+                "Honua OGC Features timeout must be greater than 10 milliseconds and less than 24 hours.");
         }
     }
 

--- a/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -30,7 +30,9 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaWfsClientOptions>>().Value;
             HonuaWfsClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaWfsClientOptions.ValidateTimeout(options.Timeout);
             client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaWfsAuthHandler>();
         services.AddTransient<IHonuaWfsClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
@@ -46,6 +48,7 @@ public static class ServiceCollectionExtensions
     {
         var opts = new HonuaWfsClientOptions();
         configure(opts);
+        HonuaWfsClientOptions.ValidateTimeout(opts.Timeout);
 
         if (!opts.EnableRetry)
         {
@@ -54,6 +57,8 @@ public static class ServiceCollectionExtensions
 
         httpBuilder.AddStandardResilienceHandler(options =>
         {
+            options.TotalRequestTimeout.Timeout = opts.Timeout;
+            options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
             options.Retry.ShouldHandle = args => ValueTask.FromResult(
                 args.Outcome.Result?.StatusCode is

--- a/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
@@ -44,6 +44,12 @@ public sealed class HonuaWfsClientOptions
     public bool EnableRetry { get; set; } = true;
 
     /// <summary>
+    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
     /// Maximum number of retry attempts (default: 3, range 2-5).
     /// Only applies when <see cref="EnableRetry"/> is true.
     /// </summary>
@@ -71,6 +77,15 @@ public sealed class HonuaWfsClientOptions
             !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
             throw new InvalidOperationException("Honua WFS base address must use HTTP or HTTPS.");
+        }
+    }
+
+    internal static void ValidateTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
+        {
+            throw new InvalidOperationException(
+                "Honua WFS timeout must be greater than 10 milliseconds and less than 24 hours.");
         }
     }
 

--- a/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using Honua.Sdk.Admin.Extensions;
+using Honua.Sdk.Admin.Geocoding;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.Admin.Tests;
+
+public sealed class ClientOptionsTests
+{
+    [Fact]
+    public void DefaultTimeout_IsOneHundredSeconds()
+    {
+        var options = new HonuaAdminClientOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(100), options.Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaAdmin_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(42);
+        var services = new ServiceCollection();
+        services.AddHonuaAdmin(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHonuaAdminClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client, "_http").Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaGeocoding_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(37);
+        var services = new ServiceCollection();
+        services.AddHonuaGeocoding(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHonuaGeocodingClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client, "_http").Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaAdmin_InvalidTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddHonuaAdmin(options => options.Timeout = TimeSpan.FromMilliseconds(10)));
+
+        Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static HttpClient GetHttpClient(object client, string fieldName)
+    {
+        var field = client.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var value = field!.GetValue(client);
+        return Assert.IsType<HttpClient>(value);
+    }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.Tests;
+
+public sealed class ClientOptionsTests
+{
+    [Fact]
+    public void DefaultTimeout_IsOneHundredSeconds()
+    {
+        var options = new HonuaGeoServicesClientOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(100), options.Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaFeatureServer_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(44);
+        var services = new ServiceCollection();
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<HonuaFeatureServerClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaFeatureServer_InvalidTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddHonuaFeatureServer(options => options.Timeout = TimeSpan.FromMilliseconds(10)));
+
+        Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static HttpClient GetHttpClient(HonuaFeatureServerClient client)
+    {
+        var field = typeof(HonuaFeatureServerClient).GetField("_http", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var value = field!.GetValue(client);
+        return Assert.IsType<HttpClient>(value);
+    }
+}

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -44,6 +44,51 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task QueryFeaturesAsync_AppliesConfiguredDeadline()
+    {
+        var timeout = TimeSpan.FromSeconds(30);
+        DateTime? capturedDeadline = null;
+        var protoResponse = new Proto.QueryFeaturesResponse();
+
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (_, _, deadline, _) => capturedDeadline = deadline)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+        {
+            EnableCompressionNegotiation = false,
+            Timeout = timeout
+        });
+        var before = DateTime.UtcNow;
+
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "test-svc" });
+
+        Assert.NotNull(capturedDeadline);
+        Assert.InRange(capturedDeadline.Value, before.Add(timeout).AddSeconds(-1), DateTime.UtcNow.Add(timeout).AddSeconds(1));
+    }
+
+    [Fact]
+    public void Constructor_InvalidTimeout_Throws()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+            {
+                Timeout = TimeSpan.FromMilliseconds(10)
+            }));
+
+        Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task QueryAsync_SharedAbstraction_DelegatesToGrpcQuery()
     {
         Proto.QueryFeaturesRequest? capturedRequest = null;

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using Honua.Sdk.OgcFeatures.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.OgcFeatures.Tests;
+
+public sealed class ClientOptionsTests
+{
+    [Fact]
+    public void DefaultTimeout_IsOneHundredSeconds()
+    {
+        var options = new HonuaOgcFeaturesClientOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(100), options.Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaOgcFeatures_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(45);
+        var services = new ServiceCollection();
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<HonuaOgcFeaturesClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaOgcFeatures_InvalidTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddHonuaOgcFeatures(options => options.Timeout = TimeSpan.FromMilliseconds(10)));
+
+        Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static HttpClient GetHttpClient(HonuaOgcFeaturesClient client)
+    {
+        var field = typeof(HonuaOgcFeaturesClient).GetField("_http", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var value = field!.GetValue(client);
+        return Assert.IsType<HttpClient>(value);
+    }
+}

--- a/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using Honua.Sdk.Wfs.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.Wfs.Tests;
+
+public sealed class ClientOptionsTests
+{
+    [Fact]
+    public void DefaultTimeout_IsOneHundredSeconds()
+    {
+        var options = new HonuaWfsClientOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(100), options.Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaWfs_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(43);
+        var services = new ServiceCollection();
+        services.AddHonuaWfs(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<HonuaWfsClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaWfs_InvalidTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            services.AddHonuaWfs(options => options.Timeout = TimeSpan.FromMilliseconds(10)));
+
+        Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static HttpClient GetHttpClient(HonuaWfsClient client)
+    {
+        var field = typeof(HonuaWfsClient).GetField("_httpClient", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var value = field!.GetValue(client);
+        return Assert.IsType<HttpClient>(value);
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit Timeout options across Admin, Geocoding, WFS, GeoServices, OGC API Features, and gRPC clients
- apply HTTP timeouts to HttpClient plus resilience total/attempt timeouts, and apply gRPC timeouts as per-call deadlines
- fix AddHonuaGeocoding typed-client registration so DI can resolve the client despite multiple constructors
- document timeout, retry, error, pagination, and endpoint coverage behavior

Closes #2

## Validation
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal
- git diff --check