### PR TITLE
[codex] add shared feature edit abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ through GeoServices FeatureServer and OGC API Features endpoints.
 
 | Package | Description |
 |---------|-------------|
-| **Honua.Sdk.Abstractions** | Shared feature query abstractions implemented by provider-specific clients |
+| **Honua.Sdk.Abstractions** | Shared feature query/edit abstractions implemented by provider-specific clients |
 | **Honua.Sdk.Grpc** | gRPC client for `FeatureService` -- typed queries, streaming, edits, spatial filters |
 | **Honua.Sdk.Admin** | Admin REST client -- services, layers, connections, styles, metadata |
 | **Honua.Sdk.Wfs** | WFS 2.0 read/query client -- GetCapabilities, GetFeature (GeoJSON), DescribeFeatureType |
@@ -133,6 +133,29 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
     Limit = 10,
 });
 ```
+
+## Shared edit abstraction
+
+Edit-capable providers implement `IHonuaFeatureEditClient` from
+`Honua.Sdk.Abstractions`. Today gRPC is registered for shared edits; native
+GeoServices, WFS, and OGC API Features write endpoints are tracked separately.
+
+```csharp
+using Honua.Sdk.Abstractions.Features;
+
+IHonuaFeatureEditClient edits = featureEditClients
+    .Single(c => c.ProviderName == "grpc");
+
+var result = await edits.ApplyEditsAsync(new FeatureEditRequest
+{
+    Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+    DeleteObjectIds = [42],
+    RollbackOnFailure = true,
+});
+```
+
+See [docs/feature-edits.md](docs/feature-edits.md) for shared result models,
+provider support, and unsupported-provider behavior.
 
 ## Retry
 
@@ -265,6 +288,8 @@ third_party/
 - **[Quickstart](docs/quickstart.md)** -- build a console app that queries
   features through native clients and the shared abstraction, lists services,
   and geocodes an address in 5 minutes
+- **[Feature Edits](docs/feature-edits.md)** -- shared edit abstraction,
+  current gRPC support, and provider-specific write backlog boundaries
 - **[Staging Integration Guide](docs/staging-integration.md)** -- staging
   environment inputs, CI evidence artifacts, common failures, and bounded
   follow-on tickets for shared staging ownership

--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -1,0 +1,66 @@
+# Feature Edits
+
+Feature reads and feature writes are separate SDK surfaces. Read/query clients
+implement `IHonuaFeatureQueryClient`; edit-capable clients implement
+`IHonuaFeatureEditClient`.
+
+## Shared Edit Abstraction
+
+Use `IHonuaFeatureEditClient` from `Honua.Sdk.Abstractions` when application
+code should apply edits without depending directly on one protocol package.
+
+```csharp
+using Honua.Sdk.Abstractions.Features;
+
+IHonuaFeatureEditClient edits = featureEditClients
+    .Single(c => c.ProviderName == "grpc");
+
+var result = await edits.ApplyEditsAsync(new FeatureEditRequest
+{
+    Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+    Adds =
+    [
+        new FeatureEditFeature
+        {
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["name"] = JsonSerializer.SerializeToElement("New Park"),
+                ["status"] = JsonSerializer.SerializeToElement("open"),
+            },
+        }
+    ],
+    RollbackOnFailure = true,
+}, ct);
+```
+
+The shared response preserves per-operation add, update, and delete results,
+provider object IDs, per-feature errors, top-level batch errors, and a
+`Succeeded` helper for whole-batch checks.
+
+## Current Provider Support
+
+| Provider | Shared edit support | Native edit support |
+|----------|---------------------|---------------------|
+| gRPC | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaGrpcClient.ApplyEditsAsync()` |
+| GeoServices FeatureServer | Not yet | Tracked by #35 |
+| WFS | Not yet | WFS-T decision tracked by #35 |
+| OGC API Features | Not yet | Transaction/create-update-delete decision tracked by #35 |
+| Admin | Not applicable | Admin has control-plane mutations, not data-plane feature edits |
+
+Unsupported read providers are not registered as `IHonuaFeatureEditClient`
+implementations. Select from `IEnumerable<IHonuaFeatureEditClient>` or inspect
+`EditCapabilities` before attempting a write.
+
+## gRPC Notes
+
+The gRPC shared adapter maps:
+
+- `FeatureEditRequest.Source.ServiceId` and `LayerId` to the native
+  `ApplyEditsRequest`.
+- `Adds` and `Updates` to native feature payloads with JSON attributes and Esri
+  JSON geometry objects.
+- `DeleteObjectIds` and numeric `DeleteIds` to native delete object IDs.
+- Native per-feature edit errors to shared `FeatureEditResult.Error` values.
+
+gRPC updates and deletes require numeric feature IDs or object IDs. Non-numeric
+IDs fail locally with `ArgumentException` before a remote call.

--- a/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Provider edit capabilities exposed through the shared feature edit abstraction.
+/// </summary>
+public sealed record FeatureEditCapabilities
+{
+    /// <summary>Whether the provider supports adding features.</summary>
+    public bool SupportsAdds { get; init; }
+
+    /// <summary>Whether the provider supports updating features.</summary>
+    public bool SupportsUpdates { get; init; }
+
+    /// <summary>Whether the provider supports deleting features.</summary>
+    public bool SupportsDeletes { get; init; }
+
+    /// <summary>Whether the provider supports rollback-on-failure edit batches.</summary>
+    public bool SupportsRollbackOnFailure { get; init; }
+
+    /// <summary>Native protocol surface used by the provider, when useful for diagnostics.</summary>
+    public string? NativeSurface { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral edit request for add, update, and delete operations.
+/// </summary>
+public sealed record FeatureEditRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Features to add.</summary>
+    public IReadOnlyList<FeatureEditFeature> Adds { get; init; } = [];
+
+    /// <summary>Features to update. Providers that use object IDs require each update to include an ID.</summary>
+    public IReadOnlyList<FeatureEditFeature> Updates { get; init; } = [];
+
+    /// <summary>String feature identifiers to delete.</summary>
+    public IReadOnlyList<string> DeleteIds { get; init; } = [];
+
+    /// <summary>Numeric object identifiers to delete.</summary>
+    public IReadOnlyList<long> DeleteObjectIds { get; init; } = [];
+
+    /// <summary>Whether the provider should roll back all edits if any individual edit fails.</summary>
+    public bool RollbackOnFailure { get; init; } = true;
+
+    /// <summary>Whether the provider should force writes that would otherwise be rejected by conflict detection.</summary>
+    public bool ForceWrite { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral feature payload used by add and update edit operations.
+/// </summary>
+public sealed record FeatureEditFeature
+{
+    /// <summary>Provider feature identifier, when available.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Provider object identifier, when available.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Feature attributes/properties as JSON values.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Attributes { get; init; } =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>Feature geometry as a provider-native JSON object, when supplied.</summary>
+    public JsonElement? Geometry { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral response from applying a batch of feature edits.
+/// </summary>
+public sealed record FeatureEditResponse
+{
+    /// <summary>Provider name that handled the edit request.</summary>
+    public string ProviderName { get; init; } = string.Empty;
+
+    /// <summary>Results for add operations.</summary>
+    public IReadOnlyList<FeatureEditResult> AddResults { get; init; } = [];
+
+    /// <summary>Results for update operations.</summary>
+    public IReadOnlyList<FeatureEditResult> UpdateResults { get; init; } = [];
+
+    /// <summary>Results for delete operations.</summary>
+    public IReadOnlyList<FeatureEditResult> DeleteResults { get; init; } = [];
+
+    /// <summary>Top-level error when the provider rejects the whole edit batch.</summary>
+    public FeatureEditError? Error { get; init; }
+
+    /// <summary>Whether the whole edit batch and all reported item results succeeded.</summary>
+    public bool Succeeded =>
+        Error is null &&
+        AddResults.All(result => result.Succeeded) &&
+        UpdateResults.All(result => result.Succeeded) &&
+        DeleteResults.All(result => result.Succeeded);
+}
+
+/// <summary>
+/// Provider-neutral outcome of a single feature edit operation.
+/// </summary>
+public sealed record FeatureEditResult
+{
+    /// <summary>Provider feature identifier, when available.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Provider object identifier, when available.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Whether the individual edit operation succeeded.</summary>
+    public bool Succeeded { get; init; }
+
+    /// <summary>Error details when the individual edit operation failed.</summary>
+    public FeatureEditError? Error { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral edit error details.
+/// </summary>
+public sealed record FeatureEditError
+{
+    /// <summary>Provider-specific error code, when available.</summary>
+    public int? Code { get; init; }
+
+    /// <summary>Error message.</summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>Additional provider-specific error details, when available.</summary>
+    public string? Details { get; init; }
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureEditClient.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureEditClient.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Shared feature write contract implemented by edit-capable Honua clients.
+/// </summary>
+public interface IHonuaFeatureEditClient
+{
+    /// <summary>
+    /// Provider name for diagnostics and provider selection.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Provider edit capabilities exposed by this client.
+    /// </summary>
+    FeatureEditCapabilities EditCapabilities { get; }
+
+    /// <summary>
+    /// Applies add, update, and delete feature edits.
+    /// </summary>
+    /// <param name="request">Provider-neutral edit request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral edit response.</returns>
+    Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Grpc/Conversion/ProtoAdapter.cs
+++ b/src/Honua.Sdk.Grpc/Conversion/ProtoAdapter.cs
@@ -931,7 +931,7 @@ internal static class ProtoAdapter
         }
     }
 
-    private static object? UnwrapJsonValue(JsonElement element)
+    internal static object? UnwrapJsonValue(JsonElement element)
     {
         return element.ValueKind switch
         {

--- a/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<HonuaGrpcClient>();
         services.AddSingleton<IHonuaGrpcClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
         services.AddSingleton<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
+        services.AddSingleton<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
         return services;
     }
 }

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -16,11 +16,19 @@ namespace Honua.Sdk.Grpc;
 /// <summary>
 /// gRPC client for the Honua FeatureService.
 /// </summary>
-public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient, IDisposable
+public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient, IDisposable
 {
     private static readonly JsonSerializerOptions FeatureJsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+    private static readonly FeatureEditCapabilities GrpcEditCapabilities = new()
+    {
+        SupportsAdds = true,
+        SupportsUpdates = true,
+        SupportsDeletes = true,
+        SupportsRollbackOnFailure = true,
+        NativeSurface = "grpc FeatureService.ApplyEdits"
     };
 
     private readonly Honua.Server.Features.Grpc.Proto.FeatureService.FeatureServiceClient _client;
@@ -86,6 +94,9 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     public string ProviderName => "grpc";
 
     /// <inheritdoc />
+    public FeatureEditCapabilities EditCapabilities => GrpcEditCapabilities;
+
+    /// <inheritdoc />
     public async Task<Models.QueryFeaturesResponse> QueryFeaturesAsync(
         Models.QueryFeaturesRequest request, CancellationToken ct = default)
     {
@@ -136,6 +147,14 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         {
             throw new HonuaGrpcException(ex.StatusCode, ex.Status.Detail, ex);
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureEditResponse> ApplyEditsAsync(
+        FeatureEditRequest request, CancellationToken ct = default)
+    {
+        var response = await ApplyEditsAsync(BuildGrpcEditRequest(request), ct).ConfigureAwait(false);
+        return ToFeatureEditResponse(response);
     }
 
     /// <inheritdoc />
@@ -329,6 +348,98 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         };
     }
 
+    private static Models.ApplyEditsRequest BuildGrpcEditRequest(FeatureEditRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.Source.ServiceId))
+        {
+            throw new ArgumentException("A service ID is required for gRPC feature edits.", nameof(request));
+        }
+
+        if (!request.Source.LayerId.HasValue)
+        {
+            throw new ArgumentException("A layer ID is required for gRPC feature edits.", nameof(request));
+        }
+
+        return new Models.ApplyEditsRequest
+        {
+            ServiceId = request.Source.ServiceId,
+            LayerId = request.Source.LayerId.Value,
+            Adds = request.Adds.Select(feature => ToGrpcEditFeature(feature, requireObjectId: false)).ToList(),
+            Updates = request.Updates.Select(feature => ToGrpcEditFeature(feature, requireObjectId: true)).ToList(),
+            Deletes = ResolveDeleteObjectIds(request),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+    }
+
+    private static Models.Feature ToGrpcEditFeature(FeatureEditFeature feature, bool requireObjectId)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        return new Models.Feature
+        {
+            Id = ResolveObjectId(feature, requireObjectId),
+            Attributes = feature.Attributes.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ProtoAdapter.UnwrapJsonValue(kvp.Value)),
+            Geometry = ToGrpcGeometry(feature.Geometry),
+        };
+    }
+
+    private static long ResolveObjectId(FeatureEditFeature feature, bool required)
+    {
+        if (feature.ObjectId.HasValue)
+        {
+            return feature.ObjectId.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(feature.Id) &&
+            long.TryParse(feature.Id, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var objectId))
+        {
+            return objectId;
+        }
+
+        if (required)
+        {
+            throw new ArgumentException("gRPC feature updates require a numeric feature ID or object ID.");
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<long> ResolveDeleteObjectIds(FeatureEditRequest request)
+    {
+        var objectIds = new List<long>(request.DeleteObjectIds);
+        foreach (var id in request.DeleteIds)
+        {
+            if (!long.TryParse(id, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var objectId))
+            {
+                throw new ArgumentException("gRPC feature deletes require numeric feature IDs.", nameof(request));
+            }
+
+            objectIds.Add(objectId);
+        }
+
+        return objectIds;
+    }
+
+    private static IReadOnlyDictionary<string, object?>? ToGrpcGeometry(JsonElement? geometry)
+    {
+        if (!geometry.HasValue)
+        {
+            return null;
+        }
+
+        if (ProtoAdapter.UnwrapJsonValue(geometry.Value) is IReadOnlyDictionary<string, object?> dictionary)
+        {
+            return dictionary;
+        }
+
+        throw new ArgumentException("gRPC feature edit geometry must be a JSON object.");
+    }
+
     private static void EnsureSupportedFilterLanguage(FeatureFilterLanguage language)
     {
         if (language is not FeatureFilterLanguage.ProviderDefault and not FeatureFilterLanguage.SqlWhere)
@@ -421,6 +532,39 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             NumberReturned = page.Features.Count,
             HasMoreResults = !page.IsLastPage,
             ObjectIdFieldName = string.IsNullOrWhiteSpace(page.ObjectIdFieldName) ? null : page.ObjectIdFieldName,
+        };
+    }
+
+    private FeatureEditResponse ToFeatureEditResponse(Models.ApplyEditsResponse response)
+    {
+        return new FeatureEditResponse
+        {
+            ProviderName = ProviderName,
+            AddResults = response.AddResults.Select(ToFeatureEditResult).ToList(),
+            UpdateResults = response.UpdateResults.Select(ToFeatureEditResult).ToList(),
+            DeleteResults = response.DeleteResults.Select(ToFeatureEditResult).ToList(),
+            Error = response.Error is not null ? ToFeatureEditError(response.Error) : null,
+        };
+    }
+
+    private static FeatureEditResult ToFeatureEditResult(Models.EditResult result)
+    {
+        var id = result.ObjectId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return new FeatureEditResult
+        {
+            Id = id,
+            ObjectId = result.ObjectId,
+            Succeeded = result.Success,
+            Error = result.Error is not null ? ToFeatureEditError(result.Error) : null,
+        };
+    }
+
+    private static FeatureEditError ToFeatureEditError(Models.EditError error)
+    {
+        return new FeatureEditError
+        {
+            Code = error.Code,
+            Message = error.Message,
         };
     }
 

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Grpc.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
 using Proto = Honua.Server.Features.Grpc.Proto;
@@ -99,6 +102,128 @@ public class HonuaGrpcClientTests
         Assert.Single(result.Features);
         Assert.Equal("42", result.Features[0].Id);
         Assert.Equal("Park", result.Features[0].Attributes["name"].GetString());
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_DelegatesToGrpcApplyEdits()
+    {
+        Proto.ApplyEditsRequest? capturedRequest = null;
+        var protoResponse = new Proto.ApplyEditsResponse
+        {
+            Error = null,
+        };
+        protoResponse.AddResults.Add(new Proto.EditResult { ObjectId = 101, Success = true });
+        protoResponse.UpdateResults.Add(new Proto.EditResult
+        {
+            ObjectId = 102,
+            Success = false,
+            Error = new Proto.EditError { Code = 400, Message = "Update rejected" }
+        });
+        protoResponse.DeleteResults.Add(new Proto.EditResult { ObjectId = 103, Success = true });
+
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.ApplyEditsAsync(
+                It.IsAny<Proto.ApplyEditsRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.ApplyEditsRequest, Metadata, DateTime?, CancellationToken>(
+                (req, _, _, _) => capturedRequest = req)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        var response = await ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { ServiceId = "parks", LayerId = 2 },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonValue("New Park"),
+                        ["active"] = JsonValue(true),
+                        ["visitors"] = JsonValue(12),
+                    },
+                    Geometry = JsonObject("""{"x":1.25,"y":2.5,"spatialReference":{"wkid":4326}}"""),
+                }
+            ],
+            Updates =
+            [
+                new FeatureEditFeature
+                {
+                    Id = "77",
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonValue("Renamed Park"),
+                    },
+                }
+            ],
+            DeleteObjectIds = [88],
+            DeleteIds = ["89"],
+            RollbackOnFailure = true,
+            ForceWrite = true,
+        });
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("parks", capturedRequest.ServiceId);
+        Assert.Equal(2, capturedRequest.LayerId);
+        Assert.True(capturedRequest.RollbackOnFailure);
+        Assert.True(capturedRequest.ForceWrite);
+        Assert.Single(capturedRequest.Adds);
+        Assert.Equal("New Park", capturedRequest.Adds[0].Attributes["name"].StringValue);
+        Assert.True(capturedRequest.Adds[0].Attributes["active"].BoolValue);
+        Assert.Equal(12, capturedRequest.Adds[0].Attributes["visitors"].Int64Value);
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.Point, capturedRequest.Adds[0].Geometry.ShapeCase);
+        Assert.Single(capturedRequest.Updates);
+        Assert.Equal(77, capturedRequest.Updates[0].Id);
+        Assert.Equal([88L, 89L], capturedRequest.Deletes);
+
+        Assert.Equal("grpc", response.ProviderName);
+        Assert.False(response.Succeeded);
+        Assert.Equal(101, response.AddResults[0].ObjectId);
+        Assert.True(response.AddResults[0].Succeeded);
+        Assert.Equal(102, response.UpdateResults[0].ObjectId);
+        Assert.False(response.UpdateResults[0].Succeeded);
+        Assert.Equal(400, response.UpdateResults[0].Error?.Code);
+        Assert.Equal("Update rejected", response.UpdateResults[0].Error?.Message);
+        Assert.Equal(103, response.DeleteResults[0].ObjectId);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_NonNumericUpdateId_Throws()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = new FeatureSource { ServiceId = "parks", LayerId = 2 },
+                Updates =
+                [
+                    new FeatureEditFeature { Id = "abc" }
+                ],
+            }));
+
+        Assert.Contains("numeric", ex.Message);
+    }
+
+    [Fact]
+    public void AddHonuaGrpc_RegistersSharedEditClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaGrpc(options => options.Address = "http://localhost:5000");
+
+        using var provider = services.BuildServiceProvider();
+        var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+
+        Assert.Equal("grpc", editClient.ProviderName);
+        Assert.True(editClient.EditCapabilities.SupportsAdds);
+        Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.True(editClient.EditCapabilities.SupportsDeletes);
     }
 
     [Fact]
@@ -456,6 +581,15 @@ public class HonuaGrpcClientTests
 
     private static string? GetMetadataValue(Metadata metadata, string key)
         => metadata.FirstOrDefault(entry => entry.Key == key)?.Value;
+
+    private static JsonElement JsonValue<T>(T value)
+        => JsonSerializer.SerializeToElement(value);
+
+    private static JsonElement JsonObject(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
 
     private static AsyncServerStreamingCall<T> CreateAsyncServerStreamingCall<T>(IEnumerable<T> responses)
     {


### PR DESCRIPTION
## Summary
- add `IHonuaFeatureEditClient` and provider-neutral feature edit request/result models to `Honua.Sdk.Abstractions`
- adapt the existing gRPC `ApplyEditsAsync()` surface into the shared edit abstraction while keeping the native gRPC API intact
- register gRPC as both a query client and an edit client in DI
- document current edit support boundaries and leave GeoServices/WFS/OGC native writes to #35

Refs #33
Refs #35

## Validation
- dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal
- git diff --check