### PR TITLE
[codex] add geoservices feature edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
 ## Shared edit abstraction
 
 Edit-capable providers implement `IHonuaFeatureEditClient` from
-`Honua.Sdk.Abstractions`. Today gRPC is registered for shared edits; native
-GeoServices, WFS, and OGC API Features write endpoints are tracked separately.
+`Honua.Sdk.Abstractions`. Today gRPC and GeoServices FeatureServer are
+registered for shared edits; WFS and OGC API Features write endpoints are
+tracked separately.
 
 ```csharp
 using Honua.Sdk.Abstractions.Features;

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -83,8 +83,10 @@ Current typed endpoint coverage is:
 | `Honua.Sdk.Admin` | Service listing/settings/protocols, MapServer/access/time/layer metadata settings, metadata resources and manifests, version/capabilities/compatibility/config, secure connections/encryption, layer publishing/table discovery/styles, observability, migrations, deploy preflight/plans/operations, and geocoding. |
 | `Honua.Sdk.Grpc` | Feature query, streaming feature query, and feature edits. |
 | `Honua.Sdk.Wfs` | `GetCapabilities`, `DescribeFeatureType`, `GetFeature`, feature count via hits, custom output handlers, and auto-pagination. |
-| `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, and auto-pagination. |
+| `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, auto-pagination, layer edit capabilities, and applyEdits/add/update/delete feature edits. |
 | `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, and next-link pagination. |
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
-WFS, GeoServices FeatureServer, and OGC API Features.
+WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edits are
+available through `IHonuaFeatureEditClient` for gRPC and GeoServices
+FeatureServer.

--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -13,7 +13,7 @@ code should apply edits without depending directly on one protocol package.
 using Honua.Sdk.Abstractions.Features;
 
 IHonuaFeatureEditClient edits = featureEditClients
-    .Single(c => c.ProviderName == "grpc");
+    .Single(c => c.ProviderName == "geoservices-featureserver");
 
 var result = await edits.ApplyEditsAsync(new FeatureEditRequest
 {
@@ -42,7 +42,7 @@ provider object IDs, per-feature errors, top-level batch errors, and a
 | Provider | Shared edit support | Native edit support |
 |----------|---------------------|---------------------|
 | gRPC | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaGrpcClient.ApplyEditsAsync()` |
-| GeoServices FeatureServer | Not yet | Tracked by #35 |
+| GeoServices FeatureServer | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaFeatureServerEditClient.ApplyEditsAsync()` plus add/update/delete convenience methods |
 | WFS | Not yet | WFS-T decision tracked by #35 |
 | OGC API Features | Not yet | Transaction/create-update-delete decision tracked by #35 |
 | Admin | Not applicable | Admin has control-plane mutations, not data-plane feature edits |
@@ -64,3 +64,26 @@ The gRPC shared adapter maps:
 
 gRPC updates and deletes require numeric feature IDs or object IDs. Non-numeric
 IDs fail locally with `ArgumentException` before a remote call.
+
+## GeoServices FeatureServer Notes
+
+The FeatureServer shared adapter maps:
+
+- `FeatureEditRequest.Source.ServiceId` and `LayerId` to
+  `/rest/services/{serviceId}/FeatureServer/{layerId}/applyEdits`.
+- `Adds` and `Updates` to GeoServices feature JSON payloads with `attributes`
+  and optional Esri JSON `geometry`.
+- `DeleteObjectIds` and numeric `DeleteIds` to GeoServices `deletes`.
+- GeoServices per-feature edit errors to shared `FeatureEditResult.Error`
+  values.
+
+Native callers can use `ApplyEditsAsync`, `AddFeaturesAsync`,
+`UpdateFeaturesAsync`, and `DeleteFeaturesAsync` on
+`IHonuaFeatureServerEditClient`. Use `GetEditCapabilitiesAsync(serviceId, layerId)`
+to inspect layer capabilities parsed from FeatureServer layer metadata before
+attempting writes.
+
+FeatureServer updates require the layer object ID field in each update
+payload. When using the shared abstraction, the SDK injects the object ID field
+from layer metadata when `FeatureEditFeature.ObjectId` or a numeric `Id` is
+provided.

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -37,7 +37,9 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaFeatureServerClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
+        services.AddTransient<IHonuaFeatureServerEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
+        services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
@@ -16,6 +16,8 @@ namespace Honua.Sdk.GeoServices.FeatureServer;
 [JsonSerializable(typeof(FeatureServerServiceInfo))]
 [JsonSerializable(typeof(FeatureServerLayerInfo))]
 [JsonSerializable(typeof(FeatureServerQueryResponse))]
+[JsonSerializable(typeof(FeatureServerEditResponse))]
+[JsonSerializable(typeof(FeatureServerFeature[]))]
 [JsonSerializable(typeof(FeatureServerValidateSqlResponse))]
 [JsonSerializable(typeof(GeoServicesErrorResponse))]
 [JsonSerializable(typeof(JsonElement))]

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -14,9 +14,18 @@ namespace Honua.Sdk.GeoServices.FeatureServer;
 /// <summary>
 /// HTTP client implementation for the Honua FeatureServer (GeoServices) read/query API.
 /// </summary>
-public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonuaFeatureQueryClient
+public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonuaFeatureServerEditClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
 {
     private const int PostFallbackThreshold = 2000;
+    private static readonly FeatureEditCapabilities ProviderEditCapabilities = new()
+    {
+        SupportsAdds = true,
+        SupportsUpdates = true,
+        SupportsDeletes = true,
+        SupportsRollbackOnFailure = true,
+        NativeSurface = "GeoServices FeatureServer applyEdits"
+    };
+
     private readonly HttpClient _http;
 
     /// <summary>
@@ -30,6 +39,9 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
 
     /// <inheritdoc />
     public string ProviderName => "geoservices-featureserver";
+
+    /// <inheritdoc />
+    public FeatureEditCapabilities EditCapabilities => ProviderEditCapabilities;
 
     private static string ServicePath(string serviceId) =>
         $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer";
@@ -54,6 +66,14 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         var body = await GetStringAsync(url, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerLayerInfo)
             ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize layer info.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureEditCapabilities> GetEditCapabilitiesAsync(
+        string serviceId, int layerId, CancellationToken ct = default)
+    {
+        var layer = await GetLayerInfoAsync(serviceId, layerId, ct).ConfigureAwait(false);
+        return BuildEditCapabilities(layer.Capabilities);
     }
 
     /// <inheritdoc />
@@ -107,6 +127,99 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         {
             yield return ToFeatureQueryResult(page);
         }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureServerEditResponse> ApplyEditsAsync(
+        string serviceId,
+        int layerId,
+        FeatureServerEditRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(serviceId);
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureHasEdits(request);
+
+        var parameters = BuildEditParams(request);
+        var basePath = $"{ServicePath(serviceId)}/{layerId}/applyEdits";
+        var body = await PostFormAsync(basePath, parameters, ct).ConfigureAwait(false);
+        return DeserializeEditResponse(body);
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureServerEditResponse> AddFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<FeatureServerFeature> features,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        return ApplyEditsAsync(
+            serviceId,
+            layerId,
+            new FeatureServerEditRequest
+            {
+                Adds = features,
+                RollbackOnFailure = rollbackOnFailure
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureServerEditResponse> UpdateFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<FeatureServerFeature> features,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(features);
+        return ApplyEditsAsync(
+            serviceId,
+            layerId,
+            new FeatureServerEditRequest
+            {
+                Updates = features,
+                RollbackOnFailure = rollbackOnFailure
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureServerEditResponse> DeleteFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<long> objectIds,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(objectIds);
+        return ApplyEditsAsync(
+            serviceId,
+            layerId,
+            new FeatureServerEditRequest
+            {
+                Deletes = objectIds,
+                RollbackOnFailure = rollbackOnFailure
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureEditResponse> ApplyEditsAsync(
+        FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetEditSource(request);
+        var objectIdField = await ResolveObjectIdFieldAsync(serviceId, layerId, request, ct).ConfigureAwait(false);
+        var response = await ApplyEditsAsync(
+            serviceId,
+            layerId,
+            BuildFeatureServerEditRequest(request, objectIdField),
+            ct).ConfigureAwait(false);
+
+        return ToFeatureEditResponse(response);
     }
 
     /// <inheritdoc />
@@ -370,6 +483,12 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize query response.", body);
     }
 
+    private static FeatureServerEditResponse DeserializeEditResponse(string body)
+    {
+        return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerEditResponse)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize edit response.", body);
+    }
+
     private static List<(string Key, string? Value)> BuildQueryParams(FeatureServerQueryParams query)
     {
         var parameters = new List<(string Key, string? Value)>
@@ -423,6 +542,51 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             parameters.Add(("returnDistinctValues", "true"));
 
         return parameters;
+    }
+
+    private static List<(string Key, string? Value)> BuildEditParams(FeatureServerEditRequest request)
+    {
+        var parameters = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("rollbackOnFailure", request.RollbackOnFailure ? "true" : "false"),
+        };
+
+        if (request.Adds is { Count: > 0 })
+        {
+            parameters.Add(("adds", SerializeFeatures(request.Adds)));
+        }
+
+        if (request.Updates is { Count: > 0 })
+        {
+            parameters.Add(("updates", SerializeFeatures(request.Updates)));
+        }
+
+        if (request.Deletes is { Count: > 0 })
+        {
+            parameters.Add(("deletes", string.Join(",", request.Deletes)));
+        }
+
+        return parameters;
+    }
+
+    private static string SerializeFeatures(IReadOnlyList<FeatureServerFeature> features)
+    {
+        return JsonSerializer.Serialize(
+            features.ToArray(),
+            FeatureServerJsonContext.Default.FeatureServerFeatureArray);
+    }
+
+    private static void EnsureHasEdits(FeatureServerEditRequest request)
+    {
+        if (request.Adds is { Count: > 0 } ||
+            request.Updates is { Count: > 0 } ||
+            request.Deletes is { Count: > 0 })
+        {
+            return;
+        }
+
+        throw new ArgumentException("At least one add, update, or delete edit is required.", nameof(request));
     }
 
     private static List<(string Key, string? Value)> BuildStatisticsParams(FeatureServerStatisticsParams query)
@@ -494,6 +658,149 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         };
 
         return (request.Source.ServiceId, request.Source.LayerId.Value, query);
+    }
+
+    private static (string ServiceId, int LayerId) GetEditSource(FeatureEditRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Source.ServiceId))
+        {
+            throw new ArgumentException("A service ID is required for FeatureServer edits.", nameof(request));
+        }
+
+        if (!request.Source.LayerId.HasValue)
+        {
+            throw new ArgumentException("A layer ID is required for FeatureServer edits.", nameof(request));
+        }
+
+        return (request.Source.ServiceId, request.Source.LayerId.Value);
+    }
+
+    private async Task<string?> ResolveObjectIdFieldAsync(
+        string serviceId,
+        int layerId,
+        FeatureEditRequest request,
+        CancellationToken ct)
+    {
+        if (!request.Updates.Any(HasFeatureObjectId))
+        {
+            return null;
+        }
+
+        var layer = await GetLayerInfoAsync(serviceId, layerId, ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(layer.ObjectIdField))
+        {
+            throw new InvalidOperationException(
+                "FeatureServer layer metadata does not expose an object ID field required for shared updates.");
+        }
+
+        return layer.ObjectIdField;
+    }
+
+    private static FeatureServerEditRequest BuildFeatureServerEditRequest(
+        FeatureEditRequest request,
+        string? objectIdField)
+    {
+        if (request.ForceWrite)
+        {
+            throw new NotSupportedException("FeatureServer edits do not support force-write conflict overrides.");
+        }
+
+        return new FeatureServerEditRequest
+        {
+            Adds = request.Adds.Select(feature => ToFeatureServerFeature(feature, objectIdField: null)).ToList(),
+            Updates = request.Updates.Select(feature => ToFeatureServerFeature(feature, objectIdField)).ToList(),
+            Deletes = ResolveDeleteObjectIds(request),
+            RollbackOnFailure = request.RollbackOnFailure,
+        };
+    }
+
+    private static FeatureServerFeature ToFeatureServerFeature(FeatureEditFeature feature, string? objectIdField)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var attributes = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+        if (!string.IsNullOrWhiteSpace(objectIdField) && !ContainsAttribute(attributes, objectIdField))
+        {
+            var objectId = ResolveFeatureObjectId(feature);
+            if (objectId.HasValue)
+            {
+                attributes[objectIdField] = JsonSerializer.SerializeToElement(objectId.Value);
+            }
+        }
+
+        return new FeatureServerFeature
+        {
+            Attributes = attributes,
+            Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
+        };
+    }
+
+    private static IReadOnlyList<long> ResolveDeleteObjectIds(FeatureEditRequest request)
+    {
+        var objectIds = new List<long>(request.DeleteObjectIds);
+        foreach (var id in request.DeleteIds)
+        {
+            if (!long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                throw new ArgumentException("FeatureServer feature deletes require numeric feature IDs.", nameof(request));
+            }
+
+            objectIds.Add(objectId);
+        }
+
+        return objectIds;
+    }
+
+    private static bool HasFeatureObjectId(FeatureEditFeature feature)
+        => feature.ObjectId.HasValue || !string.IsNullOrWhiteSpace(feature.Id);
+
+    private static long? ResolveFeatureObjectId(FeatureEditFeature feature)
+    {
+        if (feature.ObjectId.HasValue)
+        {
+            return feature.ObjectId.Value;
+        }
+
+        if (string.IsNullOrWhiteSpace(feature.Id))
+        {
+            return null;
+        }
+
+        if (long.TryParse(feature.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+        {
+            return objectId;
+        }
+
+        throw new ArgumentException("FeatureServer feature updates require numeric feature IDs.");
+    }
+
+    private static bool ContainsAttribute(Dictionary<string, JsonElement> attributes, string name)
+        => attributes.Keys.Any(key => string.Equals(key, name, StringComparison.OrdinalIgnoreCase));
+
+    private static FeatureEditCapabilities BuildEditCapabilities(string? capabilities)
+    {
+        var tokens = ParseCapabilities(capabilities);
+        var supportsAdds = tokens.Contains("create") || tokens.Contains("editing");
+        var supportsUpdates = tokens.Contains("update") || tokens.Contains("editing");
+        var supportsDeletes = tokens.Contains("delete") || tokens.Contains("editing");
+
+        return new FeatureEditCapabilities
+        {
+            SupportsAdds = supportsAdds,
+            SupportsUpdates = supportsUpdates,
+            SupportsDeletes = supportsDeletes,
+            SupportsRollbackOnFailure = supportsAdds || supportsUpdates || supportsDeletes,
+            NativeSurface = "GeoServices FeatureServer applyEdits"
+        };
+    }
+
+    private static HashSet<string> ParseCapabilities(string? capabilities)
+    {
+        return string.IsNullOrWhiteSpace(capabilities)
+            ? []
+            : capabilities.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(capability => capability.ToLowerInvariant())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static void EnsureSupportedFilterLanguage(FeatureFilterLanguage language)
@@ -578,6 +885,38 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             NumberReturned = features.Count,
             HasMoreResults = response.ExceededTransferLimit,
             ObjectIdFieldName = response.ObjectIdFieldName,
+        };
+    }
+
+    private FeatureEditResponse ToFeatureEditResponse(FeatureServerEditResponse response)
+    {
+        return new FeatureEditResponse
+        {
+            ProviderName = ProviderName,
+            AddResults = response.AddResults.Select(ToFeatureEditResult).ToList(),
+            UpdateResults = response.UpdateResults.Select(ToFeatureEditResult).ToList(),
+            DeleteResults = response.DeleteResults.Select(ToFeatureEditResult).ToList(),
+        };
+    }
+
+    private static FeatureEditResult ToFeatureEditResult(FeatureServerEditResult result)
+    {
+        var id = result.ObjectId?.ToString(CultureInfo.InvariantCulture) ?? result.GlobalId;
+        return new FeatureEditResult
+        {
+            Id = id,
+            ObjectId = result.ObjectId,
+            Succeeded = result.Success,
+            Error = result.Error is not null ? ToFeatureEditError(result.Error) : null,
+        };
+    }
+
+    private static FeatureEditError ToFeatureEditError(FeatureServerEditError error)
+    {
+        return new FeatureEditError
+        {
+            Code = error.Code,
+            Message = error.Description ?? error.Message ?? "FeatureServer edit failed.",
         };
     }
 

--- a/src/Honua.Sdk.GeoServices/FeatureServer/IHonuaFeatureServerEditClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/IHonuaFeatureServerEditClient.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
+namespace Honua.Sdk.GeoServices.FeatureServer;
+
+/// <summary>
+/// Client interface for the Honua FeatureServer (GeoServices) feature edit API.
+/// </summary>
+public interface IHonuaFeatureServerEditClient
+{
+    /// <summary>
+    /// Gets FeatureServer edit capabilities for a layer.
+    /// </summary>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral edit capabilities inferred from layer metadata.</returns>
+    Task<FeatureEditCapabilities> GetEditCapabilitiesAsync(string serviceId, int layerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies add, update, and delete feature edits using the FeatureServer <c>applyEdits</c> endpoint.
+    /// </summary>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="request">Edit request containing adds, updates, deletes, and rollback behavior.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Edit response with per-operation results.</returns>
+    Task<FeatureServerEditResponse> ApplyEditsAsync(
+        string serviceId,
+        int layerId,
+        FeatureServerEditRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Adds features using the FeatureServer <c>applyEdits</c> endpoint.
+    /// </summary>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="features">Features to add.</param>
+    /// <param name="rollbackOnFailure">Whether the server should roll back all edits if any add fails.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Edit response with add results.</returns>
+    Task<FeatureServerEditResponse> AddFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<FeatureServerFeature> features,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates features using the FeatureServer <c>applyEdits</c> endpoint.
+    /// </summary>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="features">Features to update. Each feature must include the layer object ID field.</param>
+    /// <param name="rollbackOnFailure">Whether the server should roll back all edits if any update fails.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Edit response with update results.</returns>
+    Task<FeatureServerEditResponse> UpdateFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<FeatureServerFeature> features,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes features using the FeatureServer <c>applyEdits</c> endpoint.
+    /// </summary>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="objectIds">Object IDs to delete.</param>
+    /// <param name="rollbackOnFailure">Whether the server should roll back all edits if any delete fails.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Edit response with delete results.</returns>
+    Task<FeatureServerEditResponse> DeleteFeaturesAsync(
+        string serviceId,
+        int layerId,
+        IReadOnlyList<long> objectIds,
+        bool rollbackOnFailure = true,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerEditModels.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerEditModels.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.GeoServices.FeatureServer.Models;
+
+/// <summary>
+/// Request payload for FeatureServer add, update, and delete edit operations.
+/// </summary>
+public sealed class FeatureServerEditRequest
+{
+    /// <summary>Features to add.</summary>
+    public IReadOnlyList<FeatureServerFeature>? Adds { get; init; }
+
+    /// <summary>Features to update. Each feature must include the layer object ID field.</summary>
+    public IReadOnlyList<FeatureServerFeature>? Updates { get; init; }
+
+    /// <summary>Object IDs of features to delete.</summary>
+    public IReadOnlyList<long>? Deletes { get; init; }
+
+    /// <summary>Whether the server should roll back all edits if any individual edit fails.</summary>
+    public bool RollbackOnFailure { get; init; } = true;
+}
+
+/// <summary>
+/// Response from FeatureServer add, update, and delete edit operations.
+/// </summary>
+public sealed class FeatureServerEditResponse
+{
+    /// <summary>Results for add operations.</summary>
+    [JsonPropertyName("addResults")]
+    public IReadOnlyList<FeatureServerEditResult> AddResults { get; init; } = [];
+
+    /// <summary>Results for update operations.</summary>
+    [JsonPropertyName("updateResults")]
+    public IReadOnlyList<FeatureServerEditResult> UpdateResults { get; init; } = [];
+
+    /// <summary>Results for delete operations.</summary>
+    [JsonPropertyName("deleteResults")]
+    public IReadOnlyList<FeatureServerEditResult> DeleteResults { get; init; } = [];
+
+    /// <summary>Edit moment reported by the server, when available.</summary>
+    [JsonPropertyName("editMoment")]
+    public long? EditMoment { get; init; }
+}
+
+/// <summary>
+/// The outcome of a single FeatureServer edit operation.
+/// </summary>
+public sealed class FeatureServerEditResult
+{
+    /// <summary>Object ID of the affected feature.</summary>
+    [JsonPropertyName("objectId")]
+    public long? ObjectId { get; init; }
+
+    /// <summary>Global ID of the affected feature, when available.</summary>
+    [JsonPropertyName("globalId")]
+    public string? GlobalId { get; init; }
+
+    /// <summary>Whether the edit operation succeeded.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    /// <summary>Error details when the edit operation failed.</summary>
+    [JsonPropertyName("error")]
+    public FeatureServerEditError? Error { get; init; }
+}
+
+/// <summary>
+/// Error details for a failed FeatureServer edit operation.
+/// </summary>
+public sealed class FeatureServerEditError
+{
+    /// <summary>Provider-specific error code.</summary>
+    [JsonPropertyName("code")]
+    public int? Code { get; init; }
+
+    /// <summary>Error description returned by GeoServices.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Alternate error message returned by some GeoServices implementations.</summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.Extensions;
 using Honua.Sdk.GeoServices.FeatureServer;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Sdk.GeoServices.Tests.FeatureServer;
 
@@ -205,6 +208,221 @@ public class HonuaFeatureServerClientTests
         Assert.Equal("geoservices-featureserver", result.ProviderName);
         Assert.Single(result.Features);
         Assert.Equal("7", result.Features[0].Id);
+    }
+
+    // ── Feature edits ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task ApplyEditsAsync_PostsApplyEditsFormAndReturnsResults()
+    {
+        HttpMethod? capturedMethod = null;
+        string? capturedPath = null;
+        Dictionary<string, string?>? capturedForm = null;
+        var json = """
+        {
+            "addResults": [{ "objectId": 101, "success": true }],
+            "updateResults": [
+                {
+                    "objectId": 102,
+                    "success": false,
+                    "error": { "code": 400, "description": "Update rejected" }
+                }
+            ],
+            "deleteResults": [{ "objectId": 103, "success": true }],
+            "editMoment": 123456789
+        }
+        """;
+        var client = TestHelpers.CreateFeatureServerClient(async req =>
+        {
+            capturedMethod = req.Method;
+            capturedPath = req.RequestUri?.AbsolutePath;
+            capturedForm = await ParseFormAsync(req).ConfigureAwait(false);
+            return TestHelpers.CreateRawJsonResponse(json);
+        });
+
+        var response = await client.ApplyEditsAsync("svc", 0, new FeatureServerEditRequest
+        {
+            Adds =
+            [
+                new FeatureServerFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["NAME"] = JsonValue("New Park"),
+                        ["ACTIVE"] = JsonValue(true),
+                    },
+                    Geometry = JsonObject("""{"x":1.25,"y":2.5}"""),
+                }
+            ],
+            Updates =
+            [
+                new FeatureServerFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["OBJECTID"] = JsonValue(102),
+                        ["NAME"] = JsonValue("Renamed Park"),
+                    },
+                }
+            ],
+            Deletes = [103],
+            RollbackOnFailure = false,
+        });
+
+        Assert.Equal(HttpMethod.Post, capturedMethod);
+        Assert.Equal("/rest/services/svc/FeatureServer/0/applyEdits", capturedPath);
+        Assert.NotNull(capturedForm);
+        Assert.Equal("json", capturedForm!["f"]);
+        Assert.Equal("false", capturedForm["rollbackOnFailure"]);
+        Assert.Equal("103", capturedForm["deletes"]);
+
+        using var adds = JsonDocument.Parse(capturedForm["adds"]!);
+        Assert.Equal("New Park", adds.RootElement[0].GetProperty("attributes").GetProperty("NAME").GetString());
+        Assert.True(adds.RootElement[0].GetProperty("attributes").GetProperty("ACTIVE").GetBoolean());
+        Assert.Equal(1.25, adds.RootElement[0].GetProperty("geometry").GetProperty("x").GetDouble());
+
+        using var updates = JsonDocument.Parse(capturedForm["updates"]!);
+        Assert.Equal(102, updates.RootElement[0].GetProperty("attributes").GetProperty("OBJECTID").GetInt64());
+
+        Assert.Equal(123456789, response.EditMoment);
+        Assert.Single(response.AddResults);
+        Assert.True(response.AddResults[0].Success);
+        Assert.False(response.UpdateResults[0].Success);
+        Assert.Equal(400, response.UpdateResults[0].Error?.Code);
+        Assert.Equal("Update rejected", response.UpdateResults[0].Error?.Description);
+        Assert.Equal(103, response.DeleteResults[0].ObjectId);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_InjectsObjectIdFieldAndMapsResults()
+    {
+        var callCount = 0;
+        Dictionary<string, string?>? capturedForm = null;
+        var client = TestHelpers.CreateFeatureServerClient(async req =>
+        {
+            callCount++;
+            if (req.Method == HttpMethod.Get)
+            {
+                return TestHelpers.CreateRawJsonResponse("""{ "id": 0, "objectIdField": "OBJECTID", "capabilities": "Query,Create,Update,Delete" }""");
+            }
+
+            capturedForm = await ParseFormAsync(req).ConfigureAwait(false);
+            return TestHelpers.CreateRawJsonResponse("""
+            {
+                "addResults": [{ "objectId": 201, "success": true }],
+                "updateResults": [{ "objectId": 202, "success": true }],
+                "deleteResults": [{ "objectId": 203, "success": true }]
+            }
+            """);
+        });
+
+        var response = await ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { ServiceId = "svc", LayerId = 0 },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["NAME"] = JsonValue("New Park"),
+                    },
+                }
+            ],
+            Updates =
+            [
+                new FeatureEditFeature
+                {
+                    ObjectId = 202,
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["NAME"] = JsonValue("Updated Park"),
+                    },
+                }
+            ],
+            DeleteIds = ["203"],
+        });
+
+        Assert.Equal(2, callCount);
+        Assert.NotNull(capturedForm);
+        Assert.Equal("203", capturedForm!["deletes"]);
+
+        using var updates = JsonDocument.Parse(capturedForm["updates"]!);
+        var attributes = updates.RootElement[0].GetProperty("attributes");
+        Assert.Equal("Updated Park", attributes.GetProperty("NAME").GetString());
+        Assert.Equal(202, attributes.GetProperty("OBJECTID").GetInt64());
+
+        Assert.Equal("geoservices-featureserver", response.ProviderName);
+        Assert.True(response.Succeeded);
+        Assert.Equal(201, response.AddResults[0].ObjectId);
+        Assert.Equal(202, response.UpdateResults[0].ObjectId);
+        Assert.Equal(203, response.DeleteResults[0].ObjectId);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_NonNumericDeleteId_Throws()
+    {
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse("""{}""")));
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = new FeatureSource { ServiceId = "svc", LayerId = 0 },
+                DeleteIds = ["abc"],
+            }));
+
+        Assert.Contains("numeric", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_EmptyRequest_Throws()
+    {
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse("""{}""")));
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+            client.ApplyEditsAsync("svc", 0, new FeatureServerEditRequest()));
+
+        Assert.Contains("At least one", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetEditCapabilitiesAsync_ParsesLayerCapabilities()
+    {
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse("""
+            { "id": 0, "objectIdField": "OBJECTID", "capabilities": "Query,Create,Update,Delete" }
+            """)));
+
+        var capabilities = await client.GetEditCapabilitiesAsync("svc", 0);
+
+        Assert.True(capabilities.SupportsAdds);
+        Assert.True(capabilities.SupportsUpdates);
+        Assert.True(capabilities.SupportsDeletes);
+        Assert.True(capabilities.SupportsRollbackOnFailure);
+        Assert.Equal("GeoServices FeatureServer applyEdits", capabilities.NativeSurface);
+    }
+
+    [Fact]
+    public void AddHonuaFeatureServer_RegistersEditClients()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = new Uri("http://localhost:5000");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+        var featureServerEditClient = Assert.Single(provider.GetServices<IHonuaFeatureServerEditClient>());
+
+        Assert.Equal("geoservices-featureserver", editClient.ProviderName);
+        Assert.True(editClient.EditCapabilities.SupportsAdds);
+        Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.True(editClient.EditCapabilities.SupportsDeletes);
+        Assert.IsType<HonuaFeatureServerClient>(featureServerEditClient);
     }
 
     // ── GetFeatureAsync ────────────────────────────────────────────
@@ -510,5 +728,25 @@ public class HonuaFeatureServerClientTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.NotNull(capturedUrl);
         Assert.Contains("f=flatgeobuf", capturedUrl);
+    }
+
+    private static JsonElement JsonValue<T>(T value)
+        => JsonSerializer.SerializeToElement(value);
+
+    private static JsonElement JsonObject(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static async Task<Dictionary<string, string?>> ParseFormAsync(HttpRequestMessage request)
+    {
+        var body = request.Content is null ? string.Empty : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return body
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => WebUtility.UrlDecode(pair[0])!,
+                pair => pair.Length > 1 ? WebUtility.UrlDecode(pair[1]) : null);
     }
 }


### PR DESCRIPTION
## Summary
- add native FeatureServer edit models and `applyEdits`/add/update/delete client methods
- expose layer edit capability parsing from FeatureServer metadata
- register GeoServices FeatureServer as `IHonuaFeatureEditClient` and map shared edit requests/results
- document GeoServices edit support and remaining WFS/OGC write boundaries

Refs #35
Refs #33

## Validation
- dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal
- git diff --check