### PR TITLE
[codex] expose unsupported edit capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
 
 ## Shared edit abstraction
 
-Edit-capable providers implement `IHonuaFeatureEditClient` from
-`Honua.Sdk.Abstractions`. Today gRPC and GeoServices FeatureServer are
-registered for shared edits; WFS and OGC API Features write endpoints are
-tracked separately.
+Feature providers expose shared write support through `IHonuaFeatureEditClient`
+from `Honua.Sdk.Abstractions`. Today gRPC and GeoServices FeatureServer
+advertise write capabilities; WFS and OGC API Features register unsupported
+capabilities with a clear reason until their protocol write paths are added.
 
 ```csharp
 using Honua.Sdk.Abstractions.Features;

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -87,6 +87,7 @@ Current typed endpoint coverage is:
 | `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, and next-link pagination. |
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
-WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edits are
-available through `IHonuaFeatureEditClient` for gRPC and GeoServices
-FeatureServer.
+WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edit
+capabilities are available through `IHonuaFeatureEditClient`; gRPC and
+GeoServices FeatureServer currently advertise write support, while WFS and OGC
+API Features report unsupported edit capabilities with a reason.

--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -43,13 +43,15 @@ provider object IDs, per-feature errors, top-level batch errors, and a
 |----------|---------------------|---------------------|
 | gRPC | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaGrpcClient.ApplyEditsAsync()` |
 | GeoServices FeatureServer | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaFeatureServerEditClient.ApplyEditsAsync()` plus add/update/delete convenience methods |
-| WFS | Not yet | WFS-T decision tracked by #35 |
-| OGC API Features | Not yet | Transaction/create-update-delete decision tracked by #35 |
+| WFS | Registered as unsupported via `IHonuaFeatureEditClient` | WFS-T implementation decision tracked by #35 |
+| OGC API Features | Registered as unsupported via `IHonuaFeatureEditClient` | Transaction/create-update-delete implementation decision tracked by #35 |
 | Admin | Not applicable | Admin has control-plane mutations, not data-plane feature edits |
 
-Unsupported read providers are not registered as `IHonuaFeatureEditClient`
-implementations. Select from `IEnumerable<IHonuaFeatureEditClient>` or inspect
-`EditCapabilities` before attempting a write.
+Select from `IEnumerable<IHonuaFeatureEditClient>` and inspect
+`EditCapabilities` before attempting a write. Unsupported feature providers
+return `SupportsAdds`, `SupportsUpdates`, and `SupportsDeletes` as `false`,
+populate `UnsupportedReason`, and throw `NotSupportedException` from
+`ApplyEditsAsync`.
 
 ## gRPC Notes
 

--- a/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
@@ -24,6 +24,9 @@ public sealed record FeatureEditCapabilities
 
     /// <summary>Native protocol surface used by the provider, when useful for diagnostics.</summary>
     public string? NativeSurface { get; init; }
+
+    /// <summary>Reason edits are unsupported when no edit operation is available.</summary>
+    public string? UnsupportedReason { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcFeaturesClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
+        services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -14,9 +14,18 @@ namespace Honua.Sdk.OgcFeatures;
 /// <summary>
 /// HTTP client implementation for the Honua OGC API Features read/query API.
 /// </summary>
-public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeatureQueryClient
+public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
 {
     private const string BasePath = "/ogc/features";
+    private const string UnsupportedEditReason =
+        "Honua.Sdk.OgcFeatures does not currently implement OGC API Features create, update, or delete endpoints.";
+
+    private static readonly FeatureEditCapabilities UnsupportedEditCapabilities = new()
+    {
+        NativeSurface = "OGC API Features transactions",
+        UnsupportedReason = UnsupportedEditReason
+    };
+
     private readonly HttpClient _http;
 
     /// <summary>
@@ -30,6 +39,9 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
 
     /// <inheritdoc />
     public string ProviderName => "ogc-features";
+
+    /// <inheritdoc />
+    public FeatureEditCapabilities EditCapabilities => UnsupportedEditCapabilities;
 
     /// <inheritdoc />
     public async Task<OgcLandingPage> GetLandingPageAsync(CancellationToken ct = default)
@@ -109,6 +121,14 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
         {
             yield return ToFeatureQueryResult(page);
         }
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        throw new NotSupportedException(UnsupportedEditReason);
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaWfsAuthHandler>();
         services.AddTransient<IHonuaWfsClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
+        services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         ConfigureResilience(services, httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -20,10 +20,17 @@ namespace Honua.Sdk.Wfs;
 /// <summary>
 /// WFS 2.0 read/query client for Honua Server.
 /// </summary>
-public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient
+public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
 {
     private static readonly ActivitySource ActivitySource = new("Honua.Sdk.Wfs");
     private static readonly GeoJsonFeatureCollectionHandler DefaultGeoJsonHandler = new();
+    private const string UnsupportedEditReason = "Honua.Sdk.Wfs does not currently implement WFS-T transactions.";
+    private static readonly FeatureEditCapabilities UnsupportedEditCapabilities = new()
+    {
+        NativeSurface = "WFS-T Transaction",
+        UnsupportedReason = UnsupportedEditReason
+    };
+
     private static readonly JsonSerializerOptions FeatureJsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -45,6 +52,9 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient
 
     /// <inheritdoc />
     public string ProviderName => "wfs";
+
+    /// <inheritdoc />
+    public FeatureEditCapabilities EditCapabilities => UnsupportedEditCapabilities;
 
     /// <inheritdoc />
     public async Task<WfsCapabilities> GetCapabilitiesAsync(CancellationToken ct = default)
@@ -145,6 +155,14 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient
         throw new InvalidOperationException(
             $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
             "Use protocol-specific manual paging for larger result sets.");
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        throw new NotSupportedException(UnsupportedEditReason);
     }
 
     /// <inheritdoc />

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Reflection;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.OgcFeatures.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -33,6 +34,26 @@ public sealed class ClientOptionsTests
         var client = provider.GetRequiredService<HonuaOgcFeaturesClient>();
 
         Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaOgcFeatures_RegistersUnsupportedSharedEditClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+
+        Assert.Equal("ogc-features", editClient.ProviderName);
+        Assert.False(editClient.EditCapabilities.SupportsAdds);
+        Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsDeletes);
+        Assert.Contains("create", editClient.EditCapabilities.UnsupportedReason);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -276,6 +276,28 @@ public class HonuaOgcFeaturesClientTests
         Assert.Equal("building-7", result.Features[0].Id);
     }
 
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_ThrowsUnsupportedWithCapabilities()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+        var editClient = (IHonuaFeatureEditClient)client;
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => editClient.ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = new FeatureSource { CollectionId = "buildings" }
+            }));
+
+        Assert.Equal("ogc-features", editClient.ProviderName);
+        Assert.False(editClient.EditCapabilities.SupportsAdds);
+        Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsDeletes);
+        Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
+        Assert.Equal("OGC API Features transactions", editClient.EditCapabilities.NativeSurface);
+        Assert.Equal(editClient.EditCapabilities.UnsupportedReason, ex.Message);
+        Assert.Contains("create", ex.Message);
+    }
+
     // ── GetItemAsync ────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Reflection;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Wfs.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -33,6 +34,26 @@ public sealed class ClientOptionsTests
         var client = provider.GetRequiredService<HonuaWfsClient>();
 
         Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void AddHonuaWfs_RegistersUnsupportedSharedEditClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaWfs(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+
+        Assert.Equal("wfs", editClient.ProviderName);
+        Assert.False(editClient.EditCapabilities.SupportsAdds);
+        Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsDeletes);
+        Assert.Contains("WFS-T", editClient.EditCapabilities.UnsupportedReason);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -164,6 +164,28 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_ThrowsUnsupportedWithCapabilities()
+    {
+        var client = TestHelpers.CreateClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+        var editClient = (IHonuaFeatureEditClient)client;
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => editClient.ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = new FeatureSource { TypeName = "parcels" }
+            }));
+
+        Assert.Equal("wfs", editClient.ProviderName);
+        Assert.False(editClient.EditCapabilities.SupportsAdds);
+        Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsDeletes);
+        Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
+        Assert.Equal("WFS-T Transaction", editClient.EditCapabilities.NativeSurface);
+        Assert.Equal(editClient.EditCapabilities.UnsupportedReason, ex.Message);
+        Assert.Contains("WFS-T", ex.Message);
+    }
+
+    [Fact]
     public async Task GetFeatures_WithBbox_BuildsCorrectUrl()
     {
         var client = TestHelpers.CreateClient(req =>


### PR DESCRIPTION
## Summary
- register WFS and OGC API Features as shared edit clients with unsupported edit capabilities
- add `UnsupportedReason` to `FeatureEditCapabilities` for discoverable no-write providers
- cover unsupported `ApplyEditsAsync` and DI registration behavior for WFS and OGC, plus docs

Refs #35
Refs #33

## Tests
- dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- git diff --check
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal