### PR TITLE
[codex] add gated FeatureServer edit integration

### DIFF
--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -34,6 +34,10 @@ jobs:
       HONUA_STAGING_SERVER_COMMIT: ${{ vars.HONUA_STAGING_SERVER_COMMIT }}
       HONUA_STAGING_SERVER_IMAGE: ${{ vars.HONUA_STAGING_SERVER_IMAGE }}
       HONUA_STAGING_SEED_PROFILE: ${{ vars.HONUA_STAGING_SEED_PROFILE }}
+      HONUA_STAGING_ENABLE_FEATURESERVER_EDITS: ${{ vars.HONUA_STAGING_ENABLE_FEATURESERVER_EDITS }}
+      HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON: ${{ vars.HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON }}
+      HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON: ${{ vars.HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON }}
+      HONUA_STAGING_FEATURESERVER_EDIT_GEOMETRY_JSON: ${{ vars.HONUA_STAGING_FEATURESERVER_EDIT_GEOMETRY_JSON }}
       HONUA_STAGING_EVIDENCE_PATH: ${{ github.workspace }}/artifacts/evidence/ci-report.json
       HONUA_STAGING_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       TEST_RESULTS_DIR: ${{ github.workspace }}/artifacts/test-results
@@ -123,6 +127,7 @@ summary = report.get("Summary", {})
 checks = report.get("Checks", [])
 sdk_packages = report.get("SdkPackages", [])
 protocol_surfaces = report.get("ProtocolSurfaces", [])
+feature_server_edit_check_ran = report.get("FeatureServerEditCheckRan", False)
 
 with open(summary_path, "a", encoding="utf-8") as summary_file:
     summary_file.write("## Staging Integration\n\n")
@@ -136,6 +141,7 @@ with open(summary_path, "a", encoding="utf-8") as summary_file:
     summary_file.write(f"- Server commit: `{report.get('ServerCommit') or 'unknown'}`\n")
     summary_file.write(f"- Server image: `{report.get('ServerImage') or 'unknown'}`\n")
     summary_file.write(f"- Seed profile: `{report.get('SeedProfile') or 'unknown'}`\n")
+    summary_file.write(f"- FeatureServer edit check: `{'ran' if feature_server_edit_check_ran else 'not run'}`\n")
     summary_file.write(f"- Protocol surfaces: `{', '.join(protocol_surfaces) or 'unknown'}`\n")
     summary_file.write(
         "- SDK packages: `" +

--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -2,8 +2,10 @@
 
 The staging suite for this repository lives in
 `tests/Honua.Sdk.IntegrationTests` and runs through
-`.github/workflows/staging-integration.yml`. It is intentionally read-only and
-does not execute the mutating bootstrap sample against shared staging.
+`.github/workflows/staging-integration.yml`. The default lane is intentionally
+read-only and does not execute the mutating bootstrap sample against shared
+staging. A FeatureServer edit round-trip can be enabled only against a
+dedicated disposable edit fixture.
 
 ## What The Suite Covers
 
@@ -11,6 +13,8 @@ does not execute the mutating bootstrap sample against shared staging.
 - A bounded gRPC `QueryFeaturesAsync()` call with `ReturnGeometry = false`
 - WFS `GetCapabilitiesAsync()` and bounded `GetFeaturesAsync()`
 - FeatureServer metadata plus a bounded `QueryAsync()`
+- Optional FeatureServer add/update/delete round-trip against a dedicated edit
+  fixture
 - OGC API Features collections, bounded items, and a single item lookup
 
 Each request uses a small row limit and deterministic fixture identifiers so the
@@ -52,6 +56,13 @@ Optional evidence metadata:
 - `HONUA_STAGING_SERVER_IMAGE`
 - `HONUA_STAGING_SEED_PROFILE`
 
+Optional FeatureServer edit fixture values:
+
+- `HONUA_STAGING_ENABLE_FEATURESERVER_EDITS=true`
+- `HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON`
+- `HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON`
+- `HONUA_STAGING_FEATURESERVER_EDIT_GEOMETRY_JSON`
+
 Local execution uses the same environment variables. Example:
 
 ```bash
@@ -61,6 +72,11 @@ export HONUA_STAGING_SERVICE_NAME=sdk_demo
 export HONUA_STAGING_LAYER_ID=0
 export HONUA_STAGING_WFS_TYPENAME=public:sdk_demo_points
 export HONUA_STAGING_OGC_COLLECTION_ID=sdk_demo_points
+
+# Optional: enable only against a disposable edit fixture.
+export HONUA_STAGING_ENABLE_FEATURESERVER_EDITS=true
+export HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON='{"name":"sdk-add","status":"new"}'
+export HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON='{"name":"sdk-update","status":"updated"}'
 
 dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release
 ```
@@ -81,6 +97,7 @@ The JSON evidence includes:
 - SDK package versions
 - server commit and image when configured
 - seed profile when configured
+- whether the FeatureServer edit check ran
 - service/layer/type/collection identifiers
 - protocol surfaces under test
 - per-check status, duration, and detail string

--- a/tests/Honua.Sdk.IntegrationTests/StagingConfiguredFactAttribute.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingConfiguredFactAttribute.cs
@@ -11,3 +11,15 @@ public sealed class StagingConfiguredFactAttribute : FactAttribute
         }
     }
 }
+
+public sealed class StagingFeatureServerEditsFactAttribute : FactAttribute
+{
+    public StagingFeatureServerEditsFactAttribute()
+    {
+        var missing = StagingIntegrationOptions.GetMissingFeatureServerEditEnvironmentVariables();
+        if (missing.Count > 0)
+        {
+            Skip = $"Set FeatureServer edit staging variables to run. Missing: {string.Join(", ", missing)}.";
+        }
+    }
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
@@ -39,6 +39,7 @@ public sealed class StagingEvidenceTests
         Assert.Equal("server-sha", root.GetProperty("ServerCommit").GetString());
         Assert.Equal("ghcr.io/honua/server:test", root.GetProperty("ServerImage").GetString());
         Assert.Equal("sdk-readonly", root.GetProperty("SeedProfile").GetString());
+        Assert.False(root.GetProperty("FeatureServerEditCheckRan").GetBoolean());
 
         var packages = root.GetProperty("SdkPackages").EnumerateArray().ToArray();
         Assert.Contains(packages, package => HasPackage(package, "Honua.Sdk.Admin"));
@@ -50,6 +51,12 @@ public sealed class StagingEvidenceTests
             .ToArray();
         Assert.Contains("grpc", surfaces);
         Assert.Contains("geoservices-featureserver", surfaces);
+        Assert.DoesNotContain("geoservices-featureserver-edits", surfaces);
+
+        var checks = root.GetProperty("Checks").EnumerateArray()
+            .Select(check => check.GetProperty("Name").GetString())
+            .ToArray();
+        Assert.Contains("features-edit-roundtrip", checks);
 
         File.Delete(evidencePath);
     }

--- a/tests/Honua.Sdk.IntegrationTests/StagingFeatureServerEditIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingFeatureServerEditIntegrationTests.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
+namespace Honua.Sdk.IntegrationTests;
+
+[Collection("StagingIntegration")]
+[Trait("Category", "Integration")]
+[Trait("Scope", "Staging")]
+[Trait("Mutation", "FeatureServer")]
+public sealed class StagingFeatureServerEditIntegrationTests(StagingIntegrationFixture fixture)
+{
+    private readonly StagingIntegrationFixture _fixture = fixture;
+
+    [StagingFeatureServerEditsFact]
+    public async Task FeatureServerApplyEdits_AddUpdateDelete_RoundTrips()
+    {
+        using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
+
+        await _fixture.RecordCheckAsync(
+            "features-edit-roundtrip",
+            async ct =>
+            {
+                var addAttributes = ParseAttributes(
+                    _fixture.Options.FeatureServerEditAddAttributesJson,
+                    "HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON");
+                var updateAttributes = ParseAttributes(
+                    _fixture.Options.FeatureServerEditUpdateAttributesJson,
+                    "HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON");
+                var geometry = ParseOptionalElement(_fixture.Options.FeatureServerEditGeometryJson);
+                long? objectIdForCleanup = null;
+
+                try
+                {
+                    var addResponse = await _fixture.FeatureServerEditClient.AddFeaturesAsync(
+                        _fixture.Options.ServiceName,
+                        _fixture.Options.LayerId,
+                        [
+                            new FeatureServerFeature
+                            {
+                                Attributes = addAttributes,
+                                Geometry = geometry
+                            }
+                        ],
+                        rollbackOnFailure: true,
+                        ct).ConfigureAwait(false);
+
+                    var addResult = Assert.Single(addResponse.AddResults);
+                    Assert.True(addResult.Success, FormatError(addResult.Error));
+                    Assert.True(addResult.ObjectId.HasValue, "FeatureServer add did not return an object ID.");
+                    objectIdForCleanup = addResult.ObjectId.Value;
+
+                    var sharedEditClient = _fixture.Services
+                        .GetServices<IHonuaFeatureEditClient>()
+                        .Single(client => client.ProviderName == "geoservices-featureserver");
+
+                    var updateResponse = await sharedEditClient.ApplyEditsAsync(
+                        new FeatureEditRequest
+                        {
+                            Source = new FeatureSource
+                            {
+                                ServiceId = _fixture.Options.ServiceName,
+                                LayerId = _fixture.Options.LayerId
+                            },
+                            Updates =
+                            [
+                                new FeatureEditFeature
+                                {
+                                    ObjectId = objectIdForCleanup.Value,
+                                    Attributes = updateAttributes
+                                }
+                            ],
+                            RollbackOnFailure = true
+                        },
+                        ct).ConfigureAwait(false);
+
+                    var updateResult = Assert.Single(updateResponse.UpdateResults);
+                    Assert.True(updateResult.Succeeded, FormatError(updateResult.Error));
+
+                    var deleteResponse = await _fixture.FeatureServerEditClient.DeleteFeaturesAsync(
+                        _fixture.Options.ServiceName,
+                        _fixture.Options.LayerId,
+                        [objectIdForCleanup.Value],
+                        rollbackOnFailure: true,
+                        ct).ConfigureAwait(false);
+
+                    var deleteResult = Assert.Single(deleteResponse.DeleteResults);
+                    Assert.True(deleteResult.Success, FormatError(deleteResult.Error));
+                    var objectId = objectIdForCleanup.Value;
+                    objectIdForCleanup = null;
+
+                    return
+                        $"objectId={objectId.ToString(CultureInfo.InvariantCulture)}; " +
+                        "add=pass; update=pass; delete=pass";
+                }
+                finally
+                {
+                    if (objectIdForCleanup.HasValue)
+                    {
+                        using var cleanupTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                        await TryDeleteAsync(objectIdForCleanup.Value, cleanupTimeout.Token).ConfigureAwait(false);
+                    }
+                }
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    private async Task TryDeleteAsync(long objectId, CancellationToken ct)
+    {
+        try
+        {
+            await _fixture.FeatureServerEditClient.DeleteFeaturesAsync(
+                _fixture.Options.ServiceName,
+                _fixture.Options.LayerId,
+                [objectId],
+                rollbackOnFailure: true,
+                ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Preserve the original edit failure; staging evidence will contain the failed operation.
+        }
+    }
+
+    private static Dictionary<string, JsonElement> ParseAttributes(string? json, string name)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new Xunit.Sdk.XunitException($"{name} must be a JSON object.");
+        }
+
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new Xunit.Sdk.XunitException($"{name} must be a JSON object.");
+        }
+
+        return document.RootElement.EnumerateObject()
+            .ToDictionary(property => property.Name, property => property.Value.Clone());
+    }
+
+    private static JsonElement? ParseOptionalElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static string FormatError(FeatureServerEditError? error)
+        => error is null
+            ? "FeatureServer edit result did not succeed."
+            : $"FeatureServer edit failed: code={error.Code?.ToString(CultureInfo.InvariantCulture) ?? "unknown"}; message={error.Description ?? error.Message ?? "unknown"}";
+
+    private static string FormatError(FeatureEditError? error)
+        => error is null
+            ? "Shared FeatureServer edit result did not succeed."
+            : $"Shared FeatureServer edit failed: code={error.Code?.ToString(CultureInfo.InvariantCulture) ?? "unknown"}; message={error.Message}";
+}

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
@@ -25,6 +25,7 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         "wfs-get-features",
         "features-service-info",
         "features-query",
+        "features-edit-roundtrip",
         "ogc-collections",
         "ogc-items",
         "ogc-item"
@@ -93,6 +94,8 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
 
     public IHonuaFeatureServerClient FeatureServerClient => Services.GetRequiredService<IHonuaFeatureServerClient>();
 
+    public IHonuaFeatureServerEditClient FeatureServerEditClient => Services.GetRequiredService<IHonuaFeatureServerEditClient>();
+
     public IHonuaOgcFeaturesClient OgcFeaturesClient => Services.GetRequiredService<IHonuaOgcFeaturesClient>();
 
     public Task InitializeAsync() => Task.CompletedTask;
@@ -154,6 +157,7 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         }
 
         var checks = KnownChecks.Select(name => _results[name]).ToArray();
+        var featureServerEditsRan = WasCheckRun("features-edit-roundtrip");
         var report = new StagingEvidenceReport
         {
             SchemaVersion = "1.0",
@@ -168,7 +172,8 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
             ServerCommit = Options.ServerCommit,
             ServerImage = Options.ServerImage,
             SeedProfile = Options.SeedProfile,
-            ProtocolSurfaces = ProtocolSurfaces,
+            FeatureServerEditCheckRan = featureServerEditsRan,
+            ProtocolSurfaces = GetProtocolSurfaces(featureServerEditsRan),
             SdkPackages = GetSdkPackageVersions(),
             Checks = checks,
             Summary = new StagingEvidenceSummary
@@ -187,6 +192,20 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
 
         await File.WriteAllTextAsync(Options.EvidencePath, json).ConfigureAwait(false);
     }
+
+    private IReadOnlyList<string> GetProtocolSurfaces(bool featureServerEditsRan)
+    {
+        if (!featureServerEditsRan)
+        {
+            return ProtocolSurfaces;
+        }
+
+        return [.. ProtocolSurfaces, "geoservices-featureserver-edits"];
+    }
+
+    private bool WasCheckRun(string name)
+        => _results.TryGetValue(name, out var result) &&
+           !string.Equals(result.Status, "not-run", StringComparison.Ordinal);
 
     private static IReadOnlyList<SdkPackageVersion> GetSdkPackageVersions()
         =>
@@ -247,6 +266,8 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         public string? ServerImage { get; init; }
 
         public string? SeedProfile { get; init; }
+
+        public bool FeatureServerEditCheckRan { get; init; }
 
         public IReadOnlyList<string> ProtocolSurfaces { get; init; } = [];
 

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationOptions.cs
@@ -14,6 +14,10 @@ public sealed class StagingIntegrationOptions
     private const string ServerCommitKey = "HONUA_STAGING_SERVER_COMMIT";
     private const string ServerImageKey = "HONUA_STAGING_SERVER_IMAGE";
     private const string SeedProfileKey = "HONUA_STAGING_SEED_PROFILE";
+    private const string EnableFeatureServerEditsKey = "HONUA_STAGING_ENABLE_FEATURESERVER_EDITS";
+    private const string FeatureServerEditAddAttributesJsonKey = "HONUA_STAGING_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON";
+    private const string FeatureServerEditUpdateAttributesJsonKey = "HONUA_STAGING_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON";
+    private const string FeatureServerEditGeometryJsonKey = "HONUA_STAGING_FEATURESERVER_EDIT_GEOMETRY_JSON";
 
     public Uri BaseUri { get; init; } = new("https://localhost");
 
@@ -39,6 +43,14 @@ public sealed class StagingIntegrationOptions
 
     public string? SeedProfile { get; init; }
 
+    public bool EnableFeatureServerEdits { get; init; }
+
+    public string? FeatureServerEditAddAttributesJson { get; init; }
+
+    public string? FeatureServerEditUpdateAttributesJson { get; init; }
+
+    public string? FeatureServerEditGeometryJson { get; init; }
+
     public static IReadOnlyList<string> GetMissingEnvironmentVariables()
     {
         var missing = new List<string>();
@@ -55,6 +67,20 @@ public sealed class StagingIntegrationOptions
             missing.Add($"{ApiKeyKey} or {BearerTokenKey}");
         }
 
+        return missing;
+    }
+
+    public static IReadOnlyList<string> GetMissingFeatureServerEditEnvironmentVariables()
+    {
+        var missing = GetMissingEnvironmentVariables().ToList();
+        if (!IsEnabled(Read(EnableFeatureServerEditsKey)))
+        {
+            missing.Add($"{EnableFeatureServerEditsKey}=true");
+            return missing;
+        }
+
+        RequireValue(FeatureServerEditAddAttributesJsonKey, missing);
+        RequireValue(FeatureServerEditUpdateAttributesJsonKey, missing);
         return missing;
     }
 
@@ -101,7 +127,11 @@ public sealed class StagingIntegrationOptions
             RunId = Read(RunIdKey) ?? DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmssZ", System.Globalization.CultureInfo.InvariantCulture),
             ServerCommit = Read(ServerCommitKey),
             ServerImage = Read(ServerImageKey),
-            SeedProfile = Read(SeedProfileKey)
+            SeedProfile = Read(SeedProfileKey),
+            EnableFeatureServerEdits = IsEnabled(Read(EnableFeatureServerEditsKey)),
+            FeatureServerEditAddAttributesJson = Read(FeatureServerEditAddAttributesJsonKey),
+            FeatureServerEditUpdateAttributesJson = Read(FeatureServerEditUpdateAttributesJsonKey),
+            FeatureServerEditGeometryJson = Read(FeatureServerEditGeometryJsonKey)
         };
     }
 
@@ -121,4 +151,11 @@ public sealed class StagingIntegrationOptions
             missing.Add(key);
         }
     }
+
+    private static bool IsEnabled(string? value)
+        => value is not null &&
+           (string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, "on", StringComparison.OrdinalIgnoreCase));
 }


### PR DESCRIPTION
## Summary
- add an opt-in staging FeatureServer add/update/delete round-trip using public SDK APIs
- gate mutating staging coverage behind explicit edit fixture environment variables
- record edit enablement and edit check status in staging evidence and workflow summaries

Refs #31

## Tests
- dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- git diff --check
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal