### PR TITLE
[codex] improve staging failure diagnostics

### DIFF
--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -100,7 +100,9 @@ The JSON evidence includes:
 - whether the FeatureServer edit check ran
 - service/layer/type/collection identifiers
 - protocol surfaces under test
-- per-check status, duration, and detail string
+- per-check status, duration, and detail string; failed checks include the SDK
+  method, request path or gRPC method, status when available, and a short
+  response body summary
 - a total passed / failed / not-run summary
 
 ## Troubleshooting

--- a/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Text.Json;
+using Honua.Sdk.Wfs.Exceptions;
 
 namespace Honua.Sdk.IntegrationTests;
 
@@ -57,6 +59,63 @@ public sealed class StagingEvidenceTests
             .Select(check => check.GetProperty("Name").GetString())
             .ToArray();
         Assert.Contains("features-edit-roundtrip", checks);
+
+        File.Delete(evidencePath);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WritesFailureDiagnostics()
+    {
+        var evidencePath = Path.Combine(Path.GetTempPath(), $"honua-sdk-evidence-{Guid.NewGuid():N}.json");
+
+        using var environment = new EnvironmentScope();
+        environment.Set("HONUA_STAGING_BASE_URL", "https://localhost:5001");
+        environment.Set("HONUA_STAGING_API_KEY", "test-key");
+        environment.Set("HONUA_STAGING_SERVICE_NAME", "sdk-demo");
+        environment.Set("HONUA_STAGING_LAYER_ID", "0");
+        environment.Set("HONUA_STAGING_WFS_TYPENAME", "public:sdk_demo");
+        environment.Set("HONUA_STAGING_OGC_COLLECTION_ID", "sdk-demo");
+        environment.Set("HONUA_STAGING_EVIDENCE_PATH", evidencePath);
+        environment.Set("HONUA_STAGING_RUN_ID", "run-2");
+
+        var fixture = new StagingIntegrationFixture();
+        try
+        {
+            var ex = await Assert.ThrowsAsync<HonuaWfsException>(() =>
+                fixture.RecordCheckAsync(
+                    "wfs-get-features",
+                    "IHonuaWfsClient.GetFeaturesAsync",
+                    "/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature",
+                    _ => Task.FromException<string>(new HonuaWfsException(
+                        HttpStatusCode.BadGateway,
+                        "Gateway failed",
+                        """{"error":"upstream unavailable","detail":"read timeout"}""",
+                        "NoApplicableCode")),
+                    CancellationToken.None));
+
+            Assert.Equal(HttpStatusCode.BadGateway, ex.StatusCode);
+            await fixture.DisposeAsync();
+        }
+        finally
+        {
+            fixture.Dispose();
+        }
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(evidencePath));
+        var root = doc.RootElement;
+        var check = root.GetProperty("Checks").EnumerateArray()
+            .Single(item => string.Equals(item.GetProperty("Name").GetString(), "wfs-get-features", StringComparison.Ordinal));
+        var details = check.GetProperty("Details").GetString();
+
+        Assert.Equal("fail", check.GetProperty("Status").GetString());
+        Assert.NotNull(details);
+        Assert.Contains("sdkMethod=IHonuaWfsClient.GetFeaturesAsync", details!);
+        Assert.Contains("requestPath=/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature", details);
+        Assert.Contains("exception=HonuaWfsException", details);
+        Assert.Contains("status=502 BadGateway", details);
+        Assert.Contains("""responseBody={"error":"upstream unavailable","detail":"read timeout"}""", details);
+        Assert.Contains("exceptionCode=NoApplicableCode", details);
+        Assert.Equal(1, root.GetProperty("Summary").GetProperty("Failed").GetInt32());
 
         File.Delete(evidencePath);
     }

--- a/tests/Honua.Sdk.IntegrationTests/StagingFeatureServerEditIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingFeatureServerEditIntegrationTests.cs
@@ -17,9 +17,14 @@ public sealed class StagingFeatureServerEditIntegrationTests(StagingIntegrationF
     public async Task FeatureServerApplyEdits_AddUpdateDelete_RoundTrips()
     {
         using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
+        var layerPath = $"/rest/services/{Uri.EscapeDataString(_fixture.Options.ServiceName)}/FeatureServer/{_fixture.Options.LayerId}";
+        var sdkMethod = "IHonuaFeatureServerEditClient.AddFeaturesAsync";
+        var requestPath = $"{layerPath}/addFeatures";
 
         await _fixture.RecordCheckAsync(
             "features-edit-roundtrip",
+            () => sdkMethod,
+            () => requestPath,
             async ct =>
             {
                 var addAttributes = ParseAttributes(
@@ -33,6 +38,8 @@ public sealed class StagingFeatureServerEditIntegrationTests(StagingIntegrationF
 
                 try
                 {
+                    sdkMethod = "IHonuaFeatureServerEditClient.AddFeaturesAsync";
+                    requestPath = $"{layerPath}/addFeatures";
                     var addResponse = await _fixture.FeatureServerEditClient.AddFeaturesAsync(
                         _fixture.Options.ServiceName,
                         _fixture.Options.LayerId,
@@ -55,6 +62,8 @@ public sealed class StagingFeatureServerEditIntegrationTests(StagingIntegrationF
                         .GetServices<IHonuaFeatureEditClient>()
                         .Single(client => client.ProviderName == "geoservices-featureserver");
 
+                    sdkMethod = "IHonuaFeatureEditClient.ApplyEditsAsync";
+                    requestPath = $"{layerPath}/applyEdits";
                     var updateResponse = await sharedEditClient.ApplyEditsAsync(
                         new FeatureEditRequest
                         {
@@ -78,6 +87,8 @@ public sealed class StagingFeatureServerEditIntegrationTests(StagingIntegrationF
                     var updateResult = Assert.Single(updateResponse.UpdateResults);
                     Assert.True(updateResult.Succeeded, FormatError(updateResult.Error));
 
+                    sdkMethod = "IHonuaFeatureServerEditClient.DeleteFeaturesAsync";
+                    requestPath = $"{layerPath}/deleteFeatures";
                     var deleteResponse = await _fixture.FeatureServerEditClient.DeleteFeaturesAsync(
                         _fixture.Options.ServiceName,
                         _fixture.Options.LayerId,

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
@@ -1,10 +1,16 @@
 using System.Diagnostics;
+using System.Globalization;
+using System.Net;
 using System.Reflection;
 using System.Text.Json;
+using Honua.Sdk.Admin.Exceptions;
 using Honua.Sdk.Admin.Extensions;
 using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.Grpc.Extensions;
+using Honua.Sdk.OgcFeatures.Exceptions;
 using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.Wfs.Exceptions;
 using Honua.Sdk.Wfs.Extensions;
 
 namespace Honua.Sdk.IntegrationTests;
@@ -110,9 +116,22 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
 
     public async Task RecordCheckAsync(
         string name,
+        string sdkMethod,
+        string requestPath,
+        Func<CancellationToken, Task<string>> action,
+        CancellationToken ct)
+        => await RecordCheckAsync(name, () => sdkMethod, () => requestPath, action, ct).ConfigureAwait(false);
+
+    public async Task RecordCheckAsync(
+        string name,
+        Func<string> sdkMethod,
+        Func<string> requestPath,
         Func<CancellationToken, Task<string>> action,
         CancellationToken ct)
     {
+        ArgumentNullException.ThrowIfNull(sdkMethod);
+        ArgumentNullException.ThrowIfNull(requestPath);
+
         var startedAt = DateTimeOffset.UtcNow;
         var stopwatch = Stopwatch.StartNew();
 
@@ -133,7 +152,7 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
                 "fail",
                 startedAt,
                 stopwatch.ElapsedMilliseconds,
-                $"{ex.GetType().Name}: {ex.Message}");
+                BuildFailureDetails(sdkMethod(), requestPath(), ex));
             throw;
         }
     }
@@ -224,6 +243,117 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
             assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
             assembly.GetName().Version?.ToString() ??
             "unknown");
+
+    private static string BuildFailureDetails(string sdkMethod, string requestPath, Exception exception)
+    {
+        var parts = new List<string>
+        {
+            $"sdkMethod={sdkMethod}",
+            $"requestPath={requestPath}",
+            $"exception={exception.GetType().Name}",
+            $"message={Summarize(exception.Message)}",
+            $"status={FormatStatus(exception)}",
+            $"responseBody={SummarizeResponseBody(GetResponseBody(exception))}"
+        };
+
+        AddProtocolDetails(parts, exception);
+        return string.Join("; ", parts);
+    }
+
+    private static string FormatStatus(Exception exception)
+    {
+        if (GetHttpStatusCode(exception) is { } httpStatus)
+        {
+            return $"{(int)httpStatus} {httpStatus}";
+        }
+
+        if (exception is HonuaGrpcException grpcException)
+        {
+            return $"grpc {grpcException.StatusCode}";
+        }
+
+        return "unknown";
+    }
+
+    private static HttpStatusCode? GetHttpStatusCode(Exception exception)
+        => exception switch
+        {
+            HonuaAdminApiException adminException => adminException.StatusCode,
+            HonuaFeatureServerException featureServerException => featureServerException.StatusCode,
+            HonuaOgcFeaturesException ogcException => ogcException.StatusCode,
+            HonuaWfsException wfsException => wfsException.StatusCode,
+            System.Net.Http.HttpRequestException { StatusCode: { } statusCode } => statusCode,
+            _ => null
+        };
+
+    private static string? GetResponseBody(Exception exception)
+        => exception switch
+        {
+            HonuaAdminApiException adminException => adminException.ResponseBody,
+            HonuaFeatureServerException featureServerException => featureServerException.ResponseBody,
+            HonuaOgcFeaturesException ogcException => ogcException.ResponseBody,
+            HonuaWfsException wfsException => wfsException.ResponseBody,
+            _ => null
+        };
+
+    private static void AddProtocolDetails(List<string> parts, Exception exception)
+    {
+        switch (exception)
+        {
+            case HonuaAdminOperationException adminOperationException
+                when !string.IsNullOrWhiteSpace(adminOperationException.Operation):
+                parts.Add($"operation={adminOperationException.Operation}");
+                break;
+            case HonuaFeatureServerException featureServerException:
+                if (featureServerException.GeoServicesErrorCode.HasValue)
+                {
+                    parts.Add($"geoServicesErrorCode={featureServerException.GeoServicesErrorCode.Value.ToString(CultureInfo.InvariantCulture)}");
+                }
+
+                if (featureServerException.Details is { Count: > 0 })
+                {
+                    parts.Add($"details={Summarize(string.Join(" | ", featureServerException.Details))}");
+                }
+
+                break;
+            case HonuaOgcFeaturesException ogcException:
+                if (!string.IsNullOrWhiteSpace(ogcException.ProblemType))
+                {
+                    parts.Add($"problemType={Summarize(ogcException.ProblemType)}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(ogcException.ProblemTitle))
+                {
+                    parts.Add($"problemTitle={Summarize(ogcException.ProblemTitle)}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(ogcException.ProblemDetail))
+                {
+                    parts.Add($"problemDetail={Summarize(ogcException.ProblemDetail)}");
+                }
+
+                break;
+            case HonuaWfsException wfsException when !string.IsNullOrWhiteSpace(wfsException.ExceptionCode):
+                parts.Add($"exceptionCode={wfsException.ExceptionCode}");
+                break;
+        }
+    }
+
+    private static string SummarizeResponseBody(string? responseBody)
+        => string.IsNullOrWhiteSpace(responseBody)
+            ? "none"
+            : Summarize(responseBody);
+
+    private static string Summarize(string value, int maxLength = 300)
+    {
+        var normalized = string.Join(
+            " ",
+            value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        return normalized.Length <= maxLength
+            ? normalized
+            : normalized[..maxLength] + "...";
+    }
 
     public sealed record StagingCheckResult(
         string Name,

--- a/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
@@ -20,6 +20,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "admin-compatibility",
+            "IHonuaAdminClient.CheckCompatibilityAsync",
+            "/api/v1/admin/capabilities",
             async ct =>
             {
                 var compatibility = await _fixture.AdminClient.CheckCompatibilityAsync(ct).ConfigureAwait(false);
@@ -37,6 +39,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "admin-service-settings",
+            "IHonuaAdminClient.GetServiceSettingsAsync",
+            $"/api/v1/admin/services/{Uri.EscapeDataString(_fixture.Options.ServiceName)}/settings",
             async ct =>
             {
                 var settings = await _fixture.AdminClient.GetServiceSettingsAsync(
@@ -61,6 +65,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "grpc-query",
+            "IHonuaGrpcClient.QueryFeaturesAsync",
+            "grpc://FeatureService/QueryFeatures",
             async ct =>
             {
                 var response = await _fixture.GrpcClient.QueryFeaturesAsync(
@@ -89,6 +95,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "wfs-capabilities",
+            "IHonuaWfsClient.GetCapabilitiesAsync",
+            "/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetCapabilities",
             async ct =>
             {
                 var capabilities = await _fixture.WfsClient.GetCapabilitiesAsync(ct).ConfigureAwait(false);
@@ -104,6 +112,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "wfs-get-features",
+            "IHonuaWfsClient.GetFeaturesAsync",
+            "/wfs?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature",
             async ct =>
             {
                 var features = await _fixture.WfsClient.GetFeaturesAsync(
@@ -130,6 +140,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "features-service-info",
+            "IHonuaFeatureServerClient.GetServiceInfoAsync",
+            $"/rest/services/{Uri.EscapeDataString(_fixture.Options.ServiceName)}/FeatureServer",
             async ct =>
             {
                 var serviceInfo = await _fixture.FeatureServerClient.GetServiceInfoAsync(
@@ -148,6 +160,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "features-query",
+            "IHonuaFeatureServerClient.QueryAsync",
+            $"/rest/services/{Uri.EscapeDataString(_fixture.Options.ServiceName)}/FeatureServer/{_fixture.Options.LayerId}/query",
             async ct =>
             {
                 var response = await _fixture.FeatureServerClient.QueryAsync(
@@ -181,6 +195,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "ogc-collections",
+            "IHonuaOgcFeaturesClient.ListCollectionsAsync",
+            "/ogc/features/collections",
             async ct =>
             {
                 var collections = await _fixture.OgcFeaturesClient.ListCollectionsAsync(ct).ConfigureAwait(false);
@@ -197,6 +213,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "ogc-items",
+            "IHonuaOgcFeaturesClient.GetItemsAsync",
+            $"/ogc/features/collections/{Uri.EscapeDataString(_fixture.Options.OgcCollectionId)}/items",
             async ct =>
             {
                 var items = await _fixture.OgcFeaturesClient.GetItemsAsync(
@@ -221,6 +239,8 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
 
         await _fixture.RecordCheckAsync(
             "ogc-item",
+            "IHonuaOgcFeaturesClient.GetItemAsync",
+            $"/ogc/features/collections/{Uri.EscapeDataString(_fixture.Options.OgcCollectionId)}/items/{{featureId}}",
             async ct =>
             {
                 Assert.False(string.IsNullOrWhiteSpace(firstItemId));


### PR DESCRIPTION
## Summary
- record SDK method and request path metadata for staging integration checks
- include status and response body summaries for protocol-specific staging failures
- add evidence coverage for WFS failure diagnostics and document the evidence detail fields

Refs #31

## Tests
- dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- git diff --check
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal