### PR TITLE
Add OGC API Features edit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
 ## Shared edit abstraction
 
 Feature providers expose shared write support through `IHonuaFeatureEditClient`
-from `Honua.Sdk.Abstractions`. Today gRPC and GeoServices FeatureServer
-advertise write capabilities; WFS and OGC API Features register unsupported
-capabilities with a clear reason until their protocol write paths are added.
+from `Honua.Sdk.Abstractions`. Today gRPC, GeoServices FeatureServer, and OGC
+API Features advertise write capabilities; WFS registers unsupported
+capabilities with a clear reason until WFS-T support is added.
 
 ```csharp
 using Honua.Sdk.Abstractions.Features;

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -88,6 +88,6 @@ Current typed endpoint coverage is:
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
 WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edit
-capabilities are available through `IHonuaFeatureEditClient`; gRPC and
-GeoServices FeatureServer currently advertise write support, while WFS and OGC
-API Features report unsupported edit capabilities with a reason.
+capabilities are available through `IHonuaFeatureEditClient`; gRPC,
+GeoServices FeatureServer, and OGC API Features currently advertise write
+support, while WFS reports unsupported edit capabilities with a reason.

--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -44,7 +44,7 @@ provider object IDs, per-feature errors, top-level batch errors, and a
 | gRPC | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaGrpcClient.ApplyEditsAsync()` |
 | GeoServices FeatureServer | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaFeatureServerEditClient.ApplyEditsAsync()` plus add/update/delete convenience methods |
 | WFS | Registered as unsupported via `IHonuaFeatureEditClient` | WFS-T implementation decision tracked by #35 |
-| OGC API Features | Registered as unsupported via `IHonuaFeatureEditClient` | Transaction/create-update-delete implementation decision tracked by #35 |
+| OGC API Features | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaOgcFeaturesEditClient.CreateItemAsync()`/`UpdateItemAsync()`/`DeleteItemAsync()` |
 | Admin | Not applicable | Admin has control-plane mutations, not data-plane feature edits |
 
 Select from `IEnumerable<IHonuaFeatureEditClient>` and inspect
@@ -89,3 +89,20 @@ FeatureServer updates require the layer object ID field in each update
 payload. When using the shared abstraction, the SDK injects the object ID field
 from layer metadata when `FeatureEditFeature.ObjectId` or a numeric `Id` is
 provided.
+
+## OGC API Features Notes
+
+The OGC API Features shared adapter maps:
+
+- `FeatureEditRequest.Source.CollectionId` to
+  `/ogc/features/collections/{collectionId}/items`.
+- `Adds` to `POST` GeoJSON feature payloads.
+- `Updates` to `PUT` GeoJSON feature payloads at
+  `/items/{featureId}` using `FeatureEditFeature.Id` or `ObjectId`.
+- `DeleteIds` and numeric `DeleteObjectIds` to `DELETE /items/{featureId}`.
+- OGC problem details and HTTP errors to shared `FeatureEditResult.Error`
+  values.
+
+OGC API Features writes are item-level operations, not server-side edit
+batches. Multi-operation shared edit requests must set
+`RollbackOnFailure = false`; rollback-on-failure batches are rejected locally.

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcFeaturesClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
+        services.AddTransient<IHonuaOgcFeaturesEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         ConfigureResilience(httpBuilder, configure);

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.OgcFeatures.Exceptions;
@@ -14,16 +15,18 @@ namespace Honua.Sdk.OgcFeatures;
 /// <summary>
 /// HTTP client implementation for the Honua OGC API Features read/query API.
 /// </summary>
-public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcFeaturesEditClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
 {
     private const string BasePath = "/ogc/features";
-    private const string UnsupportedEditReason =
-        "Honua.Sdk.OgcFeatures does not currently implement OGC API Features create, update, or delete endpoints.";
+    private const string RollbackUnsupportedReason =
+        "OGC API Features create, update, and delete endpoints do not support rollback-on-failure edit batches.";
 
-    private static readonly FeatureEditCapabilities UnsupportedEditCapabilities = new()
+    private static readonly FeatureEditCapabilities OgcEditCapabilities = new()
     {
-        NativeSurface = "OGC API Features transactions",
-        UnsupportedReason = UnsupportedEditReason
+        SupportsAdds = true,
+        SupportsUpdates = true,
+        SupportsDeletes = true,
+        NativeSurface = "OGC API Features create/update/delete"
     };
 
     private readonly HttpClient _http;
@@ -41,7 +44,7 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
     public string ProviderName => "ogc-features";
 
     /// <inheritdoc />
-    public FeatureEditCapabilities EditCapabilities => UnsupportedEditCapabilities;
+    public FeatureEditCapabilities EditCapabilities => OgcEditCapabilities;
 
     /// <inheritdoc />
     public async Task<OgcLandingPage> GetLandingPageAsync(CancellationToken ct = default)
@@ -124,11 +127,37 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
     }
 
     /// <inheritdoc />
-    public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    public async Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-        ct.ThrowIfCancellationRequested();
-        throw new NotSupportedException(UnsupportedEditReason);
+        var collectionId = GetEditCollectionId(request);
+        EnsureSupportedEditRequest(request);
+
+        var addResults = new List<FeatureEditResult>();
+        foreach (var feature in request.Adds)
+        {
+            addResults.Add(await ApplyAddAsync(collectionId, feature, ct).ConfigureAwait(false));
+        }
+
+        var updateResults = new List<FeatureEditResult>();
+        foreach (var feature in request.Updates)
+        {
+            updateResults.Add(await ApplyUpdateAsync(collectionId, feature, ct).ConfigureAwait(false));
+        }
+
+        var deleteResults = new List<FeatureEditResult>();
+        foreach (var featureId in ResolveDeleteIds(request))
+        {
+            deleteResults.Add(await ApplyDeleteAsync(collectionId, featureId, ct).ConfigureAwait(false));
+        }
+
+        return new FeatureEditResponse
+        {
+            ProviderName = ProviderName,
+            AddResults = addResults,
+            UpdateResults = updateResults,
+            DeleteResults = deleteResults
+        };
     }
 
     /// <inheritdoc />
@@ -141,6 +170,37 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
         var body = await GetStringAsync(url, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeature)
             ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize feature.", body);
+    }
+
+    /// <inheritdoc />
+    public Task<OgcFeature> CreateItemAsync(string collectionId, OgcFeature feature, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionId);
+        ArgumentNullException.ThrowIfNull(feature);
+        var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items?f=json";
+        return SendFeatureAsync(HttpMethod.Post, url, feature, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<OgcFeature> UpdateItemAsync(string collectionId, string featureId, OgcFeature feature, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionId);
+        ArgumentNullException.ThrowIfNull(featureId);
+        ArgumentNullException.ThrowIfNull(feature);
+        var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items/{Uri.EscapeDataString(featureId)}?f=json";
+        return SendFeatureAsync(HttpMethod.Put, url, feature, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteItemAsync(string collectionId, string featureId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionId);
+        ArgumentNullException.ThrowIfNull(featureId);
+        var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items/{Uri.EscapeDataString(featureId)}?f=json";
+
+        using var response = await _http.DeleteAsync(url, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
     }
 
     /// <inheritdoc />
@@ -195,6 +255,31 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         EnsureSuccess(response, body);
         return body;
+    }
+
+    private async Task<OgcFeature> SendFeatureAsync(HttpMethod method, string url, OgcFeature feature, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(method, url)
+        {
+            Content = CreateGeoJsonContent(feature)
+        };
+        using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return feature;
+        }
+
+        return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeature)
+            ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize edited feature.", body);
+    }
+
+    private static StringContent CreateGeoJsonContent(OgcFeature feature)
+    {
+        var json = JsonSerializer.Serialize(feature, OgcFeaturesJsonContext.Default.OgcFeature);
+        return new StringContent(json, Encoding.UTF8, "application/geo+json");
     }
 
     private static void EnsureSuccess(HttpResponseMessage response, string body)
@@ -375,6 +460,160 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaFeat
             ? request.ObjectIds.Select(id => id.ToString(CultureInfo.InvariantCulture)).ToList()
             : null;
     }
+
+    private static string GetEditCollectionId(FeatureEditRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Source.CollectionId))
+        {
+            throw new ArgumentException("A collection ID is required for OGC API Features edits.", nameof(request));
+        }
+
+        return request.Source.CollectionId;
+    }
+
+    private static void EnsureSupportedEditRequest(FeatureEditRequest request)
+    {
+        if (request.ForceWrite)
+        {
+            throw new NotSupportedException("OGC API Features edits do not support ForceWrite.");
+        }
+
+        var operationCount = request.Adds.Count + request.Updates.Count + request.DeleteIds.Count + request.DeleteObjectIds.Count;
+        if (operationCount == 0)
+        {
+            throw new ArgumentException("At least one OGC API Features edit operation is required.", nameof(request));
+        }
+
+        foreach (var update in request.Updates)
+        {
+            _ = ResolveFeatureId(update);
+        }
+
+        foreach (var deleteId in request.DeleteIds)
+        {
+            if (string.IsNullOrWhiteSpace(deleteId))
+            {
+                throw new ArgumentException("OGC API Features deletes require non-empty feature IDs.", nameof(request));
+            }
+        }
+
+        if (request.RollbackOnFailure && operationCount > 1)
+        {
+            throw new NotSupportedException(RollbackUnsupportedReason);
+        }
+    }
+
+    private async Task<FeatureEditResult> ApplyAddAsync(string collectionId, FeatureEditFeature feature, CancellationToken ct)
+    {
+        try
+        {
+            var response = await CreateItemAsync(collectionId, ToOgcFeature(feature), ct).ConfigureAwait(false);
+            return ToFeatureEditResult(response, feature);
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            return ToFeatureEditResult(feature, ex);
+        }
+    }
+
+    private async Task<FeatureEditResult> ApplyUpdateAsync(string collectionId, FeatureEditFeature feature, CancellationToken ct)
+    {
+        var featureId = ResolveFeatureId(feature);
+
+        try
+        {
+            var response = await UpdateItemAsync(collectionId, featureId, ToOgcFeature(feature, featureId), ct).ConfigureAwait(false);
+            return ToFeatureEditResult(response, feature);
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            return ToFeatureEditResult(feature, ex);
+        }
+    }
+
+    private async Task<FeatureEditResult> ApplyDeleteAsync(string collectionId, string featureId, CancellationToken ct)
+    {
+        try
+        {
+            await DeleteItemAsync(collectionId, featureId, ct).ConfigureAwait(false);
+            return new FeatureEditResult
+            {
+                Id = featureId,
+                Succeeded = true
+            };
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            return new FeatureEditResult
+            {
+                Id = featureId,
+                Succeeded = false,
+                Error = ToFeatureEditError(ex)
+            };
+        }
+    }
+
+    private static OgcFeature ToOgcFeature(FeatureEditFeature feature, string? featureId = null)
+    {
+        var id = featureId ?? ResolveOptionalFeatureId(feature);
+
+        return new OgcFeature
+        {
+            Id = id is null ? null : JsonSerializer.SerializeToElement(id),
+            Geometry = feature.Geometry.HasValue ? feature.Geometry.Value.Clone() : null,
+            Properties = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone())
+        };
+    }
+
+    private static string ResolveFeatureId(FeatureEditFeature feature)
+        => ResolveOptionalFeatureId(feature) ??
+           throw new ArgumentException("OGC API Features updates require FeatureEditFeature.Id or ObjectId.");
+
+    private static string? ResolveOptionalFeatureId(FeatureEditFeature feature)
+    {
+        if (!string.IsNullOrWhiteSpace(feature.Id))
+        {
+            return feature.Id;
+        }
+
+        return feature.ObjectId?.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static IReadOnlyList<string> ResolveDeleteIds(FeatureEditRequest request)
+    {
+        var ids = new List<string>(request.DeleteIds);
+        ids.AddRange(request.DeleteObjectIds.Select(id => id.ToString(CultureInfo.InvariantCulture)));
+        return ids;
+    }
+
+    private static FeatureEditResult ToFeatureEditResult(OgcFeature response, FeatureEditFeature fallback)
+    {
+        var id = response.Id.HasValue ? JsonElementToString(response.Id.Value) : ResolveOptionalFeatureId(fallback);
+
+        return new FeatureEditResult
+        {
+            Id = id,
+            ObjectId = long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId) ? objectId : null,
+            Succeeded = true
+        };
+    }
+
+    private static FeatureEditResult ToFeatureEditResult(FeatureEditFeature feature, HonuaOgcFeaturesException exception)
+        => new()
+        {
+            Id = ResolveOptionalFeatureId(feature),
+            ObjectId = feature.ObjectId,
+            Succeeded = false,
+            Error = ToFeatureEditError(exception)
+        };
+
+    private static FeatureEditError ToFeatureEditError(HonuaOgcFeaturesException exception)
+        => new()
+        {
+            Code = (int)exception.StatusCode,
+            Message = exception.Message,
+            Details = exception.ResponseBody
+        };
 
     private FeatureQueryResult ToFeatureQueryResult(OgcFeatureCollection response)
     {

--- a/src/Honua.Sdk.OgcFeatures/IHonuaOgcFeaturesEditClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/IHonuaOgcFeaturesEditClient.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures;
+
+/// <summary>
+/// Client interface for OGC API Features create, update, and delete operations.
+/// </summary>
+public interface IHonuaOgcFeaturesEditClient
+{
+    /// <summary>
+    /// Creates a feature in a collection with the OGC API Features items endpoint.
+    /// </summary>
+    /// <param name="collectionId">The collection identifier.</param>
+    /// <param name="feature">GeoJSON feature to create.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The created feature representation returned by the server.</returns>
+    Task<OgcFeature> CreateItemAsync(string collectionId, OgcFeature feature, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates or replaces a feature in a collection with the OGC API Features item endpoint.
+    /// </summary>
+    /// <param name="collectionId">The collection identifier.</param>
+    /// <param name="featureId">The feature identifier.</param>
+    /// <param name="feature">GeoJSON feature payload.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The updated feature representation returned by the server.</returns>
+    Task<OgcFeature> UpdateItemAsync(string collectionId, string featureId, OgcFeature feature, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a feature from a collection with the OGC API Features item endpoint.
+    /// </summary>
+    /// <param name="collectionId">The collection identifier.</param>
+    /// <param name="featureId">The feature identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task DeleteItemAsync(string collectionId, string featureId, CancellationToken ct = default);
+}

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -37,7 +37,7 @@ public sealed class ClientOptionsTests
     }
 
     [Fact]
-    public void AddHonuaOgcFeatures_RegistersUnsupportedSharedEditClient()
+    public void AddHonuaOgcFeatures_RegistersEditClients()
     {
         var services = new ServiceCollection();
         services.AddHonuaOgcFeatures(options =>
@@ -48,12 +48,14 @@ public sealed class ClientOptionsTests
 
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+        var nativeEditClient = Assert.Single(provider.GetServices<IHonuaOgcFeaturesEditClient>());
 
         Assert.Equal("ogc-features", editClient.ProviderName);
-        Assert.False(editClient.EditCapabilities.SupportsAdds);
-        Assert.False(editClient.EditCapabilities.SupportsUpdates);
-        Assert.False(editClient.EditCapabilities.SupportsDeletes);
-        Assert.Contains("create", editClient.EditCapabilities.UnsupportedReason);
+        Assert.True(editClient.EditCapabilities.SupportsAdds);
+        Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.True(editClient.EditCapabilities.SupportsDeletes);
+        Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
+        Assert.IsType<HonuaOgcFeaturesClient>(nativeEditClient);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.OgcFeatures;
 using Honua.Sdk.OgcFeatures.Exceptions;
@@ -277,25 +278,226 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
-    public async Task ApplyEditsAsync_SharedAbstraction_ThrowsUnsupportedWithCapabilities()
+    public async Task CreateItemAsync_PostsGeoJsonFeature()
+    {
+        string? capturedBody = null;
+        var client = TestHelpers.CreateOgcFeaturesClient(async req =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Contains("/ogc/features/collections/buildings/items", req.RequestUri?.ToString());
+            Assert.Equal("application/geo+json", req.Content?.Headers.ContentType?.MediaType);
+            capturedBody = await req.Content!.ReadAsStringAsync();
+
+            return TestHelpers.CreateRawJsonResponse("""
+            {
+                "type": "Feature",
+                "id": "created-1",
+                "properties": { "name": "Created" }
+            }
+            """, HttpStatusCode.Created);
+        });
+
+        var result = await client.CreateItemAsync(
+            "buildings",
+            new OgcFeature
+            {
+                Properties = new Dictionary<string, JsonElement>
+                {
+                    ["name"] = JsonSerializer.SerializeToElement("Created")
+                }
+            });
+
+        Assert.Contains("\"properties\"", capturedBody);
+        Assert.Equal("created-1", result.Id?.GetString());
+    }
+
+    [Fact]
+    public async Task UpdateItemAsync_PutsGeoJsonFeature()
+    {
+        string? capturedBody = null;
+        var client = TestHelpers.CreateOgcFeaturesClient(async req =>
+        {
+            Assert.Equal(HttpMethod.Put, req.Method);
+            Assert.Contains("/ogc/features/collections/buildings/items/building-7", req.RequestUri?.ToString());
+            capturedBody = await req.Content!.ReadAsStringAsync();
+
+            return TestHelpers.CreateRawJsonResponse("""
+            {
+                "type": "Feature",
+                "id": "building-7",
+                "properties": { "name": "Updated" }
+            }
+            """);
+        });
+
+        var result = await client.UpdateItemAsync(
+            "buildings",
+            "building-7",
+            new OgcFeature
+            {
+                Properties = new Dictionary<string, JsonElement>
+                {
+                    ["name"] = JsonSerializer.SerializeToElement("Updated")
+                }
+            });
+
+        Assert.Contains("\"Updated\"", capturedBody);
+        Assert.Equal("building-7", result.Id?.GetString());
+    }
+
+    [Fact]
+    public async Task DeleteItemAsync_SendsDelete()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            Assert.Equal(HttpMethod.Delete, req.Method);
+            Assert.Contains("/ogc/features/collections/buildings/items/building-7", req.RequestUri?.ToString());
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        });
+
+        await client.DeleteItemAsync("buildings", "building-7");
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_AppliesSequentialEdits()
+    {
+        var call = 0;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            call++;
+            return call switch
+            {
+                1 => Task.FromResult(TestHelpers.CreateRawJsonResponse(
+                    """{ "type": "Feature", "id": "created-1", "properties": {} }""",
+                    HttpStatusCode.Created)),
+                2 => Task.FromResult(TestHelpers.CreateRawJsonResponse(
+                    """{ "type": "Feature", "id": "updated-1", "properties": {} }""")),
+                3 => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent)),
+                _ => throw new InvalidOperationException("Unexpected edit request.")
+            };
+        });
+
+        var response = await ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { CollectionId = "buildings" },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Created")
+                    }
+                }
+            ],
+            Updates =
+            [
+                new FeatureEditFeature
+                {
+                    Id = "updated-1",
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Updated")
+                    }
+                }
+            ],
+            DeleteIds = ["deleted-1"],
+            RollbackOnFailure = false
+        });
+
+        Assert.Equal("ogc-features", response.ProviderName);
+        Assert.True(response.Succeeded);
+        Assert.Equal("created-1", Assert.Single(response.AddResults).Id);
+        Assert.Equal("updated-1", Assert.Single(response.UpdateResults).Id);
+        Assert.Equal("deleted-1", Assert.Single(response.DeleteResults).Id);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_MapsHttpErrorsToEditResults()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse("""
+            {
+                "type": "https://example.test/problems/edit-rejected",
+                "title": "Edit rejected",
+                "detail": "Geometry is outside the collection extent."
+            }
+            """, HttpStatusCode.BadRequest)));
+
+        var response = await ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { CollectionId = "buildings" },
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Id = "candidate-1",
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["name"] = JsonSerializer.SerializeToElement("Rejected")
+                    }
+                }
+            ]
+        });
+
+        var result = Assert.Single(response.AddResults);
+        Assert.False(response.Succeeded);
+        Assert.False(result.Succeeded);
+        Assert.Equal("candidate-1", result.Id);
+        Assert.Equal((int)HttpStatusCode.BadRequest, result.Error?.Code);
+        Assert.Contains("outside", result.Error?.Message);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_ValidatesUpdateIdsBeforeWrites()
     {
         var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
-        var editClient = (IHonuaFeatureEditClient)client;
 
-        var ex = await Assert.ThrowsAsync<NotSupportedException>(
-            () => editClient.ApplyEditsAsync(new FeatureEditRequest
+        var ex = await Assert.ThrowsAsync<ArgumentException>(
+            () => ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
             {
-                Source = new FeatureSource { CollectionId = "buildings" }
+                Source = new FeatureSource { CollectionId = "buildings" },
+                Adds =
+                [
+                    new FeatureEditFeature
+                    {
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["name"] = JsonSerializer.SerializeToElement("Created")
+                        }
+                    }
+                ],
+                Updates =
+                [
+                    new FeatureEditFeature
+                    {
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["name"] = JsonSerializer.SerializeToElement("Missing ID")
+                        }
+                    }
+                ],
+                RollbackOnFailure = false
             }));
 
-        Assert.Equal("ogc-features", editClient.ProviderName);
-        Assert.False(editClient.EditCapabilities.SupportsAdds);
-        Assert.False(editClient.EditCapabilities.SupportsUpdates);
-        Assert.False(editClient.EditCapabilities.SupportsDeletes);
-        Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
-        Assert.Equal("OGC API Features transactions", editClient.EditCapabilities.NativeSurface);
-        Assert.Equal(editClient.EditCapabilities.UnsupportedReason, ex.Message);
-        Assert.Contains("create", ex.Message);
+        Assert.Contains("updates require", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_RollbackBatch_Throws()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+            {
+                Source = new FeatureSource { CollectionId = "buildings" },
+                Adds = [new FeatureEditFeature()],
+                DeleteIds = ["building-7"],
+                RollbackOnFailure = true
+            }));
+
+        Assert.Contains("rollback", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     // ── GetItemAsync ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `IHonuaOgcFeaturesEditClient` for native OGC API Features create/update/delete item endpoints
- implement the shared `IHonuaFeatureEditClient` adapter for OGC item-level edits with rollback restrictions and HTTP/problem-details error mapping
- register the native edit client in DI and update the edit capability/docs matrix

## Validation
- `dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true`
- `git diff --check`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal`
- `dotnet pack Honua.Sdk.sln --configuration Release --no-build /p:TreatWarningsAsErrors=true`

Closes #33
Closes #35