### PR TITLE
Add source-oriented feature facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Build
         run: dotnet build src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release /p:TreatWarningsAsErrors=true
 
+      - name: Test
+        run: dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release
+
   dotnet-admin-sdk:
     name: .NET Admin SDK
     runs-on: ubuntu-latest

--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -37,6 +37,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.OgcFeatures.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Abstractions", "src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj", "{360ACBB7-1206-42F6-8040-7CEB13916D3C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Abstractions.Tests", "tests\Honua.Sdk.Abstractions.Tests\Honua.Sdk.Abstractions.Tests.csproj", "{975A5C94-0A96-4ED8-A244-69F33ED5A69A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -215,6 +217,18 @@ Global
 		{360ACBB7-1206-42F6-8040-7CEB13916D3C}.Release|x64.Build.0 = Release|Any CPU
 		{360ACBB7-1206-42F6-8040-7CEB13916D3C}.Release|x86.ActiveCfg = Release|Any CPU
 		{360ACBB7-1206-42F6-8040-7CEB13916D3C}.Release|x86.Build.0 = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|x64.Build.0 = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Debug|x86.Build.0 = Debug|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x64.ActiveCfg = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x64.Build.0 = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x86.ActiveCfg = Release|Any CPU
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -234,5 +248,6 @@ Global
 		{EA624844-68D9-4511-9A58-D0726834AFA4} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{BE25E03B-2BC4-4188-B9F1-D085686FF0FA} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{360ACBB7-1206-42F6-8040-7CEB13916D3C} = {2F8F8F8F-8F8F-8F8F-8F8F-8F8F8F8F8F8F}
+		{975A5C94-0A96-4ED8-A244-69F33ED5A69A} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -134,6 +134,36 @@ var page = await queryClient.QueryAsync(new FeatureQueryRequest
 });
 ```
 
+For source-oriented application code, wrap a provider client in
+`HonuaSource`. The source descriptor owns the provider locator, so query code
+does not switch on gRPC, WFS, GeoServices, or OGC-specific source fields:
+
+```csharp
+var source = new HonuaSource(
+    new SourceDescriptor
+    {
+        Id = "parks",
+        Protocol = FeatureProtocolIds.OgcFeatures,
+        Locator = new SourceLocator { CollectionId = "parks" }
+    },
+    queryClient,
+    editClient: queryClient as IHonuaFeatureEditClient,
+    nativeClient: queryClient);
+
+var result = await source.QueryAsync(new SourceQuery
+{
+    Where = "status = 'open'",
+    FilterLanguage = FeatureFilterLanguage.Cql2Text,
+    OutFields = ["name", "status"],
+    Limit = 10,
+});
+
+var native = source.Protocol<IHonuaOgcFeaturesClient>(FeatureProtocolIds.OgcFeatures);
+```
+
+See [docs/source-facade.md](docs/source-facade.md) for the descriptor,
+capability, and protocol alias model.
+
 ## Shared edit abstraction
 
 Feature providers expose shared write support through `IHonuaFeatureEditClient`

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -91,3 +91,10 @@ WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edit
 capabilities are available through `IHonuaFeatureEditClient`; gRPC and
 GeoServices FeatureServer currently advertise write support, while WFS and OGC
 API Features report unsupported edit capabilities with a reason.
+
+`Honua.Sdk.Abstractions` also exposes the source-oriented facade used for
+cross-provider application code: `SourceDescriptor`, `SourceLocator`,
+`SourceQuery`, `IHonuaSource`, and `HonuaSource`. It wraps the existing
+query/edit interfaces, normalizes protocol aliases such as
+`geoservices-featureserver` to `geoservices-feature-service`, and keeps native
+clients available through `IHonuaSource.Protocol<TClient>()`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -319,6 +319,29 @@ Then add:
             Console.WriteLine($"  {feature.Id}");
 ```
 
+To keep provider-specific source identifiers out of call sites, wrap the
+selected client in a source descriptor:
+
+```csharp
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+                Locator = new SourceLocator { CollectionId = "parks" }
+            },
+            ogc,
+            editClient: ogc as IHonuaFeatureEditClient,
+            nativeClient: ogc);
+
+        var ids = await source.QueryObjectIdsAsync(new SourceQuery
+        {
+            Where = "status = 'open'",
+            FilterLanguage = FeatureFilterLanguage.Cql2Text,
+            Limit = 3,
+        }, ct);
+```
+
 ## What's Next
 
 - **[Admin Bootstrap Console](../examples/AdminBootstrapConsole/)** -- the
@@ -330,6 +353,8 @@ Then add:
 - **[Staging Integration Guide](staging-integration.md)** -- required staging
   environment variables, CI evidence artifacts, and troubleshooting for the
   read-only staging suite
+- **[Source facade](source-facade.md)** -- source descriptors, protocol
+  aliases, capabilities, and native protocol escape hatches
 - **[INSTALL.md](../INSTALL.md)** -- package sources, GitHub Packages setup,
   and version policy
 - **[Field Data Collection example](../examples/FieldDataCollection/)** -- a

--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -1,0 +1,80 @@
+# Source Facade
+
+`Honua.Sdk.Abstractions` includes an additive source-oriented facade over the
+existing protocol clients. Native clients remain the implementation surface;
+`IHonuaSource` gives application code one place to query, drain pages, ask for
+feature IDs, apply supported edits, and reach the native client when a
+protocol-specific method is needed.
+
+## Core Types
+
+- `SourceDescriptor` is the serializable source identity: `Id`, `Protocol`,
+  `Locator`, declared `Capabilities`, optional `Schema`, and `Attribution`.
+- `SourceLocator` carries protocol-specific addressing fields such as
+  `ServiceId`, `LayerId`, `CollectionId`, and `TypeName`.
+- `SourceQuery` is the source-oriented query request. `HonuaSource` maps it to
+  the existing `FeatureQueryRequest` and fills `FeatureQueryRequest.Source`
+  from the descriptor.
+- `IHonuaSource` is the runtime handle with `QueryAsync()`,
+  `QueryPagesAsync()`, `QueryAllAsync()`, `QueryObjectIdsAsync()`,
+  `ApplyEditsAsync()`, and `Protocol<TClient>()`.
+
+```csharp
+var source = new HonuaSource(
+    new SourceDescriptor
+    {
+        Id = "parks",
+        Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+        Locator = new SourceLocator { ServiceId = "parks", LayerId = 0 }
+    },
+    queryClient,
+    editClient,
+    nativeClient);
+
+var page = await source.QueryAsync(new SourceQuery
+{
+    Where = "status = 'open'",
+    FilterLanguage = FeatureFilterLanguage.SqlWhere,
+    Limit = 25,
+});
+```
+
+## Protocol IDs
+
+Use `FeatureProtocolIds` for stable protocol identifiers. The facade accepts
+existing provider-name aliases and normalizes them to canonical IDs:
+
+| Canonical ID | Common aliases |
+| --- | --- |
+| `grpc` | `grpc` |
+| `geoservices-feature-service` | `geoservices-featureserver`, `featureserver`, `FeatureServer` |
+| `ogc-features` | `ogc-api-features`, `ogcapi-features`, `OgcFeatures` |
+| `wfs` | `wfs` |
+
+Call `FeatureProtocolIds.Normalize()` or `FeatureProtocolIds.Matches()` when
+persisted descriptors may contain older provider names.
+
+## Capabilities
+
+Use `FeatureCapabilities` for shared capability identifiers. The .NET facade
+currently advertises query, query-object-IDs, stream/page iteration, and edit
+capabilities where the wrapped client supports them. `FeatureProtocolCapabilities`
+contains protocol defaults and helpers for union/intersection when a caller is
+building a multi-source view.
+
+`HonuaSource` intersects declared descriptor capabilities with runtime client
+capabilities. For example, WFS can still be described as queryable while
+`ApplyEditsAsync()` throws a clear `NotSupportedException` until WFS-T is
+implemented.
+
+## Native Escape Hatch
+
+The facade does not replace protocol-native clients. Use `Protocol<TClient>()`
+for operations outside the shared source surface:
+
+```csharp
+var featureServer = source.Protocol<IHonuaFeatureServerClient>(
+    FeatureProtocolIds.GeoServicesFeatureServer);
+
+var layerInfo = await featureServer!.GetLayerInfoAsync("parks", 0);
+```

--- a/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Canonical feature source capability identifiers shared across Honua SDKs.
+/// </summary>
+public static class FeatureCapabilities
+{
+    /// <summary>Feature query support.</summary>
+    public const string Query = "query";
+
+    /// <summary>Aggregate query support.</summary>
+    public const string QueryAggregate = "queryAggregate";
+
+    /// <summary>Extent-only query support.</summary>
+    public const string QueryExtent = "queryExtent";
+
+    /// <summary>Object or feature ID query support.</summary>
+    public const string QueryObjectIds = "queryObjectIds";
+
+    /// <summary>Related-record query support.</summary>
+    public const string QueryRelated = "queryRelated";
+
+    /// <summary>Add, update, or delete feature edit support.</summary>
+    public const string ApplyEdits = "applyEdits";
+
+    /// <summary>Attachment query or edit support.</summary>
+    public const string Attachments = "attachments";
+
+    /// <summary>Map rendering support.</summary>
+    public const string Render = "render";
+
+    /// <summary>Tile access support.</summary>
+    public const string Tiles = "tiles";
+
+    /// <summary>SQL expression support.</summary>
+    public const string Sql = "sql";
+
+    /// <summary>Streaming or page iteration support.</summary>
+    public const string Stream = "stream";
+
+    /// <summary>Protocol buffer response support.</summary>
+    public const string Pbf = "pbf";
+
+    /// <summary>Connectivity or health probe support.</summary>
+    public const string Connect = "connect";
+
+    /// <summary>Image service support.</summary>
+    public const string Image = "image";
+
+    /// <summary>Geometry service support.</summary>
+    public const string Geometry = "geometry";
+
+    /// <summary>Geoprocessing service support.</summary>
+    public const string Geoprocess = "geoprocess";
+
+    /// <summary>OGC API Processes support.</summary>
+    public const string Processes = "processes";
+
+    /// <summary>All canonical capability identifiers supported by the shared vocabulary.</summary>
+    public static IReadOnlyList<string> All { get; } =
+    [
+        Query,
+        QueryAggregate,
+        QueryExtent,
+        QueryObjectIds,
+        QueryRelated,
+        ApplyEdits,
+        Attachments,
+        Render,
+        Tiles,
+        Sql,
+        Stream,
+        Pbf,
+        Connect,
+        Image,
+        Geometry,
+        Geoprocess,
+        Processes
+    ];
+
+    /// <summary>
+    /// Returns whether a capability collection contains the requested canonical capability.
+    /// </summary>
+    /// <param name="capabilities">Capability identifiers to inspect.</param>
+    /// <param name="capability">Capability identifier to find.</param>
+    /// <returns><see langword="true"/> when the collection includes the capability.</returns>
+    public static bool Contains(
+        IEnumerable<string> capabilities,
+        string capability)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+        ArgumentException.ThrowIfNullOrWhiteSpace(capability);
+
+        return capabilities.Any(value => string.Equals(value, capability, StringComparison.Ordinal));
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Default feature source capability sets for protocol clients implemented by this SDK.
+/// </summary>
+public static class FeatureProtocolCapabilities
+{
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> Defaults =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            [FeatureProtocolIds.Grpc] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.ApplyEdits,
+                FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.GeoServicesFeatureService] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.ApplyEdits,
+                FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.OgcFeatures] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.Wfs] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.Stream
+            ]
+        };
+
+    /// <summary>
+    /// Gets the default capabilities for a protocol identifier or alias.
+    /// </summary>
+    /// <param name="protocolId">Protocol identifier or alias.</param>
+    /// <returns>Default capability identifiers. Unknown protocols return an empty list.</returns>
+    public static IReadOnlyList<string> DefaultsFor(string protocolId)
+    {
+        var canonical = FeatureProtocolIds.Normalize(protocolId);
+        return Defaults.TryGetValue(canonical, out var capabilities)
+            ? capabilities
+            : [];
+    }
+
+    /// <summary>
+    /// Intersects capability collections with canonical string comparison.
+    /// </summary>
+    /// <param name="participants">Capability collections to intersect.</param>
+    /// <returns>Capabilities supported by every participant.</returns>
+    public static IReadOnlyList<string> Intersect(params IEnumerable<string>[] participants)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+        if (participants.Length == 0)
+        {
+            return [];
+        }
+
+        var result = new HashSet<string>(participants[0], StringComparer.Ordinal);
+        foreach (var participant in participants.Skip(1))
+        {
+            result.IntersectWith(participant);
+        }
+
+        return FeatureCapabilities.All.Where(result.Contains).ToList();
+    }
+
+    /// <summary>
+    /// Unions capability collections with canonical declaration order.
+    /// </summary>
+    /// <param name="participants">Capability collections to union.</param>
+    /// <returns>Capabilities supported by any participant.</returns>
+    public static IReadOnlyList<string> Union(params IEnumerable<string>[] participants)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var participant in participants)
+        {
+            result.UnionWith(participant);
+        }
+
+        return FeatureCapabilities.All.Where(result.Contains).ToList();
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Canonical feature source protocol identifiers and aliases shared across Honua SDKs.
+/// </summary>
+public static class FeatureProtocolIds
+{
+    /// <summary>.NET gRPC FeatureService client protocol identifier.</summary>
+    public const string Grpc = "grpc";
+
+    /// <summary>Canonical GeoServices Feature Service protocol identifier.</summary>
+    public const string GeoServicesFeatureService = "geoservices-feature-service";
+
+    /// <summary>Existing .NET GeoServices FeatureServer provider name alias.</summary>
+    public const string GeoServicesFeatureServer = "geoservices-featureserver";
+
+    /// <summary>OGC API Features protocol identifier.</summary>
+    public const string OgcFeatures = "ogc-features";
+
+    /// <summary>WFS protocol identifier.</summary>
+    public const string Wfs = "wfs";
+
+    private static readonly IReadOnlyDictionary<string, string> CanonicalIds =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Grpc] = Grpc,
+            [GeoServicesFeatureService] = GeoServicesFeatureService,
+            [GeoServicesFeatureServer] = GeoServicesFeatureService,
+            ["featureserver"] = GeoServicesFeatureService,
+            ["feature-server"] = GeoServicesFeatureService,
+            ["feature-service"] = GeoServicesFeatureService,
+            ["geoservices-feature-server"] = GeoServicesFeatureService,
+            [OgcFeatures] = OgcFeatures,
+            ["ogcapi-features"] = OgcFeatures,
+            ["ogc-api-features"] = OgcFeatures,
+            ["OgcFeatures"] = OgcFeatures,
+            [Wfs] = Wfs
+        };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> AliasMap =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            [Grpc] = [Grpc],
+            [GeoServicesFeatureService] =
+            [
+                GeoServicesFeatureService,
+                GeoServicesFeatureServer,
+                "featureserver",
+                "feature-server",
+                "feature-service",
+                "FeatureServer",
+                "geoservices-feature-server"
+            ],
+            [OgcFeatures] =
+            [
+                OgcFeatures,
+                "ogcapi-features",
+                "ogc-api-features",
+                "OgcFeatures"
+            ],
+            [Wfs] = [Wfs]
+        };
+
+    /// <summary>Canonical protocol identifiers currently backed by .NET feature clients.</summary>
+    public static IReadOnlyList<string> All { get; } =
+    [
+        Grpc,
+        GeoServicesFeatureService,
+        OgcFeatures,
+        Wfs
+    ];
+
+    /// <summary>
+    /// Normalizes a protocol identifier or provider name alias to its canonical protocol identifier.
+    /// </summary>
+    /// <param name="protocolId">Protocol identifier or alias.</param>
+    /// <returns>The canonical protocol identifier.</returns>
+    public static string Normalize(string protocolId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(protocolId);
+
+        return CanonicalIds.TryGetValue(protocolId, out var canonical)
+            ? canonical
+            : protocolId;
+    }
+
+    /// <summary>
+    /// Returns whether two protocol identifiers refer to the same canonical protocol.
+    /// </summary>
+    /// <param name="left">First protocol identifier or alias.</param>
+    /// <param name="right">Second protocol identifier or alias.</param>
+    /// <returns><see langword="true"/> when both identifiers normalize to the same protocol.</returns>
+    public static bool Matches(string left, string right)
+        => string.Equals(Normalize(left), Normalize(right), StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns the known aliases for a canonical protocol identifier.
+    /// </summary>
+    /// <param name="protocolId">Canonical protocol identifier or alias.</param>
+    /// <returns>Known aliases, including the canonical identifier.</returns>
+    public static IReadOnlyList<string> AliasesFor(string protocolId)
+    {
+        var canonical = Normalize(protocolId);
+        return AliasMap.TryGetValue(canonical, out var aliases)
+            ? aliases
+            : [canonical];
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -112,15 +112,24 @@ public sealed class HonuaSource : IHonuaSource
         var objectIdQuery = query is null
             ? new SourceQuery { ReturnGeometry = false }
             : query with { ReturnGeometry = false };
-        var result = await QueryAllAsync(objectIdQuery, ct).ConfigureAwait(false);
-        var idFieldName = result.ObjectIdFieldName ?? Descriptor.Schema?.PrimaryKey;
+        var request = BuildQueryRequest(objectIdQuery);
+        var idFieldName = Descriptor.Schema?.PrimaryKey;
+        var ids = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
-        return result.Features
-            .Select(feature => ResolveFeatureId(feature, idFieldName))
-            .Where(id => id is not null)
-            .Select(id => id!)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
+        await foreach (var page in _queryClient.QueryPagesAsync(request, ct).ConfigureAwait(false))
+        {
+            idFieldName ??= page.ObjectIdFieldName;
+            foreach (var feature in page.Features)
+            {
+                if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))
+                {
+                    ids.Add(id);
+                }
+            }
+        }
+
+        return ids;
     }
 
     /// <inheritdoc />
@@ -129,7 +138,7 @@ public sealed class HonuaSource : IHonuaSource
         ArgumentNullException.ThrowIfNull(request);
         EnsureCapability(FeatureCapabilities.ApplyEdits);
 
-        if (_editClient is null)
+        if (_editClient is null || !SupportsEditProtocol(Descriptor, _editClient))
         {
             throw new NotSupportedException(BuildUnsupportedMessage(FeatureCapabilities.ApplyEdits));
         }
@@ -170,6 +179,7 @@ public sealed class HonuaSource : IHonuaSource
         }
 
         if (editClient?.EditCapabilities is { } editCapabilities &&
+            SupportsEditProtocol(descriptor, editClient) &&
             (editCapabilities.SupportsAdds || editCapabilities.SupportsUpdates || editCapabilities.SupportsDeletes))
         {
             if (declared.Contains(FeatureCapabilities.ApplyEdits, StringComparer.Ordinal) || descriptor.Capabilities.Count == 0)
@@ -188,6 +198,10 @@ public sealed class HonuaSource : IHonuaSource
     private static bool SupportsQueryProtocol(SourceDescriptor descriptor, IHonuaFeatureQueryClient queryClient)
         => FeatureProtocolIds.Matches(descriptor.Protocol, queryClient.ProviderName) ||
            FeatureProtocolIds.Matches(descriptor.CanonicalProtocol, queryClient.ProviderName);
+
+    private static bool SupportsEditProtocol(SourceDescriptor descriptor, IHonuaFeatureEditClient editClient)
+        => FeatureProtocolIds.Matches(descriptor.Protocol, editClient.ProviderName) ||
+           FeatureProtocolIds.Matches(descriptor.CanonicalProtocol, editClient.ProviderName);
 
     private FeatureQueryRequest BuildQueryRequest(SourceQuery? query)
         => (query ?? new SourceQuery()).ToFeatureQueryRequest(Descriptor.ToFeatureSource());

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Default <see cref="IHonuaSource"/> implementation over existing query and edit clients.
+/// </summary>
+public sealed class HonuaSource : IHonuaSource
+{
+    private readonly IHonuaFeatureQueryClient _queryClient;
+    private readonly IHonuaFeatureEditClient? _editClient;
+    private readonly object? _nativeClient;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaSource"/> class.
+    /// </summary>
+    /// <param name="descriptor">Serializable source descriptor.</param>
+    /// <param name="queryClient">Provider-neutral query client.</param>
+    /// <param name="editClient">Optional provider-neutral edit client.</param>
+    /// <param name="nativeClient">Optional native protocol client for <see cref="Protocol(string)"/>.</param>
+    public HonuaSource(
+        SourceDescriptor descriptor,
+        IHonuaFeatureQueryClient queryClient,
+        IHonuaFeatureEditClient? editClient = null,
+        object? nativeClient = null)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(queryClient);
+
+        Descriptor = descriptor;
+        _queryClient = queryClient;
+        _editClient = editClient;
+        _nativeClient = nativeClient ?? queryClient;
+        Capabilities = BuildCapabilities(descriptor, queryClient, editClient);
+    }
+
+    /// <inheritdoc />
+    public SourceDescriptor Descriptor { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Capabilities { get; }
+
+    /// <inheritdoc />
+    public Task<FeatureQueryResult> QueryAsync(SourceQuery? query = null, CancellationToken ct = default)
+    {
+        EnsureCapability(FeatureCapabilities.Query);
+        return _queryClient.QueryAsync(BuildQueryRequest(query), ct);
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
+        SourceQuery? query = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        EnsureCapability(FeatureCapabilities.Stream);
+
+        await foreach (var page in _queryClient.QueryPagesAsync(BuildQueryRequest(query), ct).ConfigureAwait(false))
+        {
+            yield return page;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureQueryResult> QueryAllAsync(SourceQuery? query = null, CancellationToken ct = default)
+    {
+        EnsureCapability(FeatureCapabilities.Query);
+
+        var providerName = _queryClient.ProviderName;
+        var features = new List<FeatureRecord>();
+        long? numberMatched = null;
+        string? objectIdFieldName = null;
+        var sawPage = false;
+
+        await foreach (var page in _queryClient.QueryPagesAsync(BuildQueryRequest(query), ct).ConfigureAwait(false))
+        {
+            sawPage = true;
+            providerName = page.ProviderName;
+            features.AddRange(page.Features);
+            numberMatched ??= page.NumberMatched;
+            objectIdFieldName ??= page.ObjectIdFieldName;
+        }
+
+        if (!sawPage)
+        {
+            return new FeatureQueryResult
+            {
+                ProviderName = providerName,
+                Features = [],
+                NumberReturned = 0
+            };
+        }
+
+        return new FeatureQueryResult
+        {
+            ProviderName = providerName,
+            Features = features,
+            NumberMatched = numberMatched,
+            NumberReturned = features.Count,
+            ObjectIdFieldName = objectIdFieldName
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> QueryObjectIdsAsync(SourceQuery? query = null, CancellationToken ct = default)
+    {
+        EnsureCapability(FeatureCapabilities.QueryObjectIds);
+
+        var objectIdQuery = query is null
+            ? new SourceQuery { ReturnGeometry = false }
+            : query with { ReturnGeometry = false };
+        var result = await QueryAllAsync(objectIdQuery, ct).ConfigureAwait(false);
+        var idFieldName = result.ObjectIdFieldName ?? Descriptor.Schema?.PrimaryKey;
+
+        return result.Features
+            .Select(feature => ResolveFeatureId(feature, idFieldName))
+            .Where(id => id is not null)
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        EnsureCapability(FeatureCapabilities.ApplyEdits);
+
+        if (_editClient is null)
+        {
+            throw new NotSupportedException(BuildUnsupportedMessage(FeatureCapabilities.ApplyEdits));
+        }
+
+        return _editClient.ApplyEditsAsync(request with { Source = Descriptor.ToFeatureSource() }, ct);
+    }
+
+    /// <inheritdoc />
+    public object? Protocol(string protocolId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(protocolId);
+        return MatchesProtocol(protocolId) ? _nativeClient : null;
+    }
+
+    /// <inheritdoc />
+    public TClient? Protocol<TClient>(string? protocolId = null)
+        where TClient : class
+    {
+        var native = Protocol(protocolId ?? Descriptor.Protocol);
+        return native as TClient;
+    }
+
+    private static IReadOnlyList<string> BuildCapabilities(
+        SourceDescriptor descriptor,
+        IHonuaFeatureQueryClient queryClient,
+        IHonuaFeatureEditClient? editClient)
+    {
+        var declared = descriptor.Capabilities.Count > 0
+            ? descriptor.Capabilities
+            : FeatureProtocolCapabilities.DefaultsFor(descriptor.Protocol);
+        var capabilities = new HashSet<string>(declared, StringComparer.Ordinal);
+
+        if (!SupportsQueryProtocol(descriptor, queryClient))
+        {
+            capabilities.Remove(FeatureCapabilities.Query);
+            capabilities.Remove(FeatureCapabilities.QueryObjectIds);
+            capabilities.Remove(FeatureCapabilities.Stream);
+        }
+
+        if (editClient?.EditCapabilities is { } editCapabilities &&
+            (editCapabilities.SupportsAdds || editCapabilities.SupportsUpdates || editCapabilities.SupportsDeletes))
+        {
+            if (declared.Contains(FeatureCapabilities.ApplyEdits, StringComparer.Ordinal) || descriptor.Capabilities.Count == 0)
+            {
+                capabilities.Add(FeatureCapabilities.ApplyEdits);
+            }
+        }
+        else
+        {
+            capabilities.Remove(FeatureCapabilities.ApplyEdits);
+        }
+
+        return FeatureCapabilities.All.Where(capabilities.Contains).ToList();
+    }
+
+    private static bool SupportsQueryProtocol(SourceDescriptor descriptor, IHonuaFeatureQueryClient queryClient)
+        => FeatureProtocolIds.Matches(descriptor.Protocol, queryClient.ProviderName) ||
+           FeatureProtocolIds.Matches(descriptor.CanonicalProtocol, queryClient.ProviderName);
+
+    private FeatureQueryRequest BuildQueryRequest(SourceQuery? query)
+        => (query ?? new SourceQuery()).ToFeatureQueryRequest(Descriptor.ToFeatureSource());
+
+    private void EnsureCapability(string capability)
+    {
+        if (FeatureCapabilities.Contains(Capabilities, capability))
+        {
+            return;
+        }
+
+        throw new NotSupportedException(BuildUnsupportedMessage(capability));
+    }
+
+    private string BuildUnsupportedMessage(string capability)
+        => $"Source '{Descriptor.Id}' using protocol '{Descriptor.CanonicalProtocol}' does not support '{capability}'.";
+
+    private bool MatchesProtocol(string protocolId)
+        => FeatureProtocolIds.Matches(Descriptor.Protocol, protocolId) ||
+           FeatureProtocolIds.Matches(_queryClient.ProviderName, protocolId);
+
+    private static string? ResolveFeatureId(FeatureRecord feature, string? idFieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(feature.Id))
+        {
+            return feature.Id;
+        }
+
+        if (!string.IsNullOrWhiteSpace(idFieldName) &&
+            feature.Attributes.TryGetValue(idFieldName, out var value))
+        {
+            return JsonElementToString(value);
+        }
+
+        return null;
+    }
+
+    private static string? JsonElementToString(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            _ => null,
+        };
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaSource.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Source-oriented runtime handle over one protocol-backed feature provider.
+/// </summary>
+public interface IHonuaSource
+{
+    /// <summary>Serializable source descriptor.</summary>
+    SourceDescriptor Descriptor { get; }
+
+    /// <summary>Canonical capabilities supported by this source handle.</summary>
+    IReadOnlyList<string> Capabilities { get; }
+
+    /// <summary>Executes a feature query and returns one page.</summary>
+    /// <param name="query">Source-oriented query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A provider-neutral result page.</returns>
+    Task<FeatureQueryResult> QueryAsync(SourceQuery? query = null, CancellationToken ct = default);
+
+    /// <summary>Executes a feature query and returns provider-neutral result pages.</summary>
+    /// <param name="query">Source-oriented query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral result pages.</returns>
+    IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(SourceQuery? query = null, CancellationToken ct = default);
+
+    /// <summary>Drains feature query pages into one result envelope.</summary>
+    /// <param name="query">Source-oriented query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A provider-neutral result with all returned records.</returns>
+    Task<FeatureQueryResult> QueryAllAsync(SourceQuery? query = null, CancellationToken ct = default);
+
+    /// <summary>Queries feature/object identifiers for records matching a request.</summary>
+    /// <param name="query">Source-oriented query request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Feature or object identifiers represented as strings.</returns>
+    Task<IReadOnlyList<string>> QueryObjectIdsAsync(SourceQuery? query = null, CancellationToken ct = default);
+
+    /// <summary>Applies add, update, and delete feature edits against this source.</summary>
+    /// <param name="request">Edit request. The source descriptor supplies provider-specific source identifiers.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral edit response.</returns>
+    Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the native protocol client when the requested protocol matches this source.
+    /// </summary>
+    /// <param name="protocolId">Canonical protocol identifier or alias.</param>
+    /// <returns>The native client object, or <see langword="null"/> when unavailable.</returns>
+    object? Protocol(string protocolId);
+
+    /// <summary>
+    /// Returns the typed native protocol client when the requested protocol and client type match.
+    /// </summary>
+    /// <typeparam name="TClient">Expected native client type.</typeparam>
+    /// <param name="protocolId">Canonical protocol identifier or alias. Defaults to this source's protocol.</param>
+    /// <returns>The typed native client, or <see langword="null"/> when unavailable.</returns>
+    TClient? Protocol<TClient>(string? protocolId = null)
+        where TClient : class;
+}

--- a/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Protocol-specific endpoint information for a source-oriented feature client.
+/// </summary>
+public sealed record SourceLocator
+{
+    /// <summary>Fully qualified URL to the protocol endpoint, when known.</summary>
+    public string? Url { get; init; }
+
+    /// <summary>Honua service identifier for gRPC and GeoServices FeatureServer providers.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Layer identifier within a service.</summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>OGC API Features collection identifier.</summary>
+    public string? CollectionId { get; init; }
+
+    /// <summary>WFS qualified feature type name.</summary>
+    public string? TypeName { get; init; }
+
+    /// <summary>WFS feature namespace URI used by transaction-capable providers.</summary>
+    public string? FeatureNamespace { get; init; }
+
+    /// <summary>OGC tile-matrix-set identifier for tile-backed sources.</summary>
+    public string? TileMatrixSetId { get; init; }
+
+    /// <summary>OGC style identifier for styled-output endpoints.</summary>
+    public string? StyleId { get; init; }
+
+    /// <summary>OData entity set identifier.</summary>
+    public string? EntitySet { get; init; }
+
+    /// <summary>GeoServices GP task identifier.</summary>
+    public string? TaskName { get; init; }
+}
+
+/// <summary>
+/// Optional schema description for a source.
+/// </summary>
+public sealed record SourceSchema
+{
+    /// <summary>Field descriptors advertised for the source.</summary>
+    public IReadOnlyList<SourceField> Fields { get; init; } = [];
+
+    /// <summary>Primary key or object ID field name.</summary>
+    public string? PrimaryKey { get; init; }
+
+    /// <summary>Temporal validity field name, when applicable.</summary>
+    public string? TimeField { get; init; }
+}
+
+/// <summary>
+/// Field descriptor used by <see cref="SourceSchema"/>.
+/// </summary>
+public sealed record SourceField
+{
+    /// <summary>Field name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Provider or canonical field type.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Whether the field accepts null values.</summary>
+    public bool? Nullable { get; init; }
+
+    /// <summary>Maximum length for string fields.</summary>
+    public int? Length { get; init; }
+}
+
+/// <summary>
+/// Serializable descriptor for one protocol-backed feature source.
+/// </summary>
+public sealed record SourceDescriptor
+{
+    /// <summary>Application-level source identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Canonical protocol identifier or supported alias.</summary>
+    public required string Protocol { get; init; }
+
+    /// <summary>Protocol-specific source locator.</summary>
+    public SourceLocator Locator { get; init; } = new();
+
+    /// <summary>
+    /// Declared source capabilities. When empty, the source facade uses this SDK's protocol defaults.
+    /// </summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Optional field schema.</summary>
+    public SourceSchema? Schema { get; init; }
+
+    /// <summary>Optional attribution text.</summary>
+    public string? Attribution { get; init; }
+
+    /// <summary>Gets the canonical protocol identifier for <see cref="Protocol"/>.</summary>
+    public string CanonicalProtocol => FeatureProtocolIds.Normalize(Protocol);
+
+    /// <summary>
+    /// Converts this descriptor's locator into the existing provider-neutral feature source shape.
+    /// </summary>
+    /// <returns>A <see cref="FeatureSource"/> for query and edit requests.</returns>
+    public FeatureSource ToFeatureSource()
+        => new()
+        {
+            ServiceId = Locator.ServiceId,
+            LayerId = Locator.LayerId,
+            CollectionId = Locator.CollectionId,
+            TypeName = Locator.TypeName
+        };
+}

--- a/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Source-oriented feature query shape that maps to <see cref="FeatureQueryRequest"/>.
+/// </summary>
+public sealed record SourceQuery
+{
+    /// <summary>Logical filter expression in the language specified by <see cref="FilterLanguage"/>.</summary>
+    public string? Where { get; init; }
+
+    /// <summary>Filter language. Provider default uses the wrapped client's native default.</summary>
+    public FeatureFilterLanguage FilterLanguage { get; init; } = FeatureFilterLanguage.ProviderDefault;
+
+    /// <summary>Feature identifiers for providers with string IDs.</summary>
+    public IReadOnlyList<string>? FeatureIds { get; init; }
+
+    /// <summary>Object identifiers for providers with numeric object IDs.</summary>
+    public IReadOnlyList<long>? ObjectIds { get; init; }
+
+    /// <summary>Fields/properties to include in the response.</summary>
+    public IReadOnlyList<string>? OutFields { get; init; }
+
+    /// <summary>Whether to return geometry.</summary>
+    public bool? ReturnGeometry { get; init; }
+
+    /// <summary>Zero-based offset of the first returned record.</summary>
+    public int? Offset { get; init; }
+
+    /// <summary>Maximum number of records to return.</summary>
+    public int? Limit { get; init; }
+
+    /// <summary>Provider-native order-by expression.</summary>
+    public string? OrderBy { get; init; }
+
+    /// <summary>Optional bounding box spatial filter.</summary>
+    public FeatureBoundingBox? Bbox { get; init; }
+
+    /// <summary>Optional output coordinate reference system identifier.</summary>
+    public string? OutputCrs { get; init; }
+
+    internal FeatureQueryRequest ToFeatureQueryRequest(FeatureSource source)
+        => new()
+        {
+            Source = source,
+            Filter = Where,
+            FilterLanguage = FilterLanguage,
+            FeatureIds = FeatureIds,
+            ObjectIds = ObjectIds,
+            OutFields = OutFields,
+            ReturnGeometry = ReturnGeometry,
+            Offset = Offset,
+            Limit = Limit,
+            OrderBy = OrderBy,
+            Bbox = Bbox,
+            OutputCrs = OutputCrs
+        };
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/GlobalUsings.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+global using Xunit;

--- a/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
+++ b/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class SourceFacadeTests
+{
+    [Theory]
+    [InlineData("grpc", FeatureProtocolIds.Grpc)]
+    [InlineData("geoservices-featureserver", FeatureProtocolIds.GeoServicesFeatureService)]
+    [InlineData("FeatureServer", FeatureProtocolIds.GeoServicesFeatureService)]
+    [InlineData("ogc-api-features", FeatureProtocolIds.OgcFeatures)]
+    [InlineData("wfs", FeatureProtocolIds.Wfs)]
+    public void Normalize_MapsProviderAliasesToCanonicalProtocolIds(string alias, string expected)
+    {
+        Assert.Equal(expected, FeatureProtocolIds.Normalize(alias));
+        Assert.True(FeatureProtocolIds.Matches(alias, expected));
+    }
+
+    [Fact]
+    public void DefaultsFor_ReturnsCanonicalCapabilitySet()
+    {
+        var geoservices = FeatureProtocolCapabilities.DefaultsFor("geoservices-featureserver");
+        var wfs = FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Wfs);
+
+        Assert.Contains(FeatureCapabilities.Query, geoservices);
+        Assert.Contains(FeatureCapabilities.ApplyEdits, geoservices);
+        Assert.Contains(FeatureCapabilities.QueryObjectIds, wfs);
+        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, wfs);
+    }
+
+    [Fact]
+    public async Task HonuaSource_QueryAllAsync_DrainsPagesAndSuppliesDescriptorSource()
+    {
+        FeatureQueryRequest? capturedRequest = null;
+        var queryClient = new FakeQueryClient(
+            "grpc",
+            request =>
+            {
+                capturedRequest = request;
+                return
+                [
+                    new FeatureQueryResult
+                    {
+                        ProviderName = "grpc",
+                        Features =
+                        [
+                            new FeatureRecord
+                            {
+                                Id = "1",
+                                Attributes = new Dictionary<string, JsonElement>
+                                {
+                                    ["name"] = JsonSerializer.SerializeToElement("One")
+                                }
+                            }
+                        ],
+                        NumberMatched = 2,
+                        NumberReturned = 1,
+                        HasMoreResults = true
+                    },
+                    new FeatureQueryResult
+                    {
+                        ProviderName = "grpc",
+                        Features =
+                        [
+                            new FeatureRecord
+                            {
+                                Id = "2",
+                                Attributes = new Dictionary<string, JsonElement>
+                                {
+                                    ["name"] = JsonSerializer.SerializeToElement("Two")
+                                }
+                            }
+                        ],
+                        NumberMatched = 2,
+                        NumberReturned = 1
+                    }
+                ];
+            });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.Grpc,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 }
+            },
+            queryClient,
+            nativeClient: queryClient);
+
+        var result = await source.QueryAllAsync(new SourceQuery { Where = "1=1", Limit = 100 });
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("svc", capturedRequest.Source.ServiceId);
+        Assert.Equal(0, capturedRequest.Source.LayerId);
+        Assert.Equal("1=1", capturedRequest.Filter);
+        Assert.Equal(100, capturedRequest.Limit);
+        Assert.Equal(2, result.Features.Count);
+        Assert.Equal(2, result.NumberMatched);
+        Assert.Equal(2, result.NumberReturned);
+    }
+
+    [Fact]
+    public async Task HonuaSource_QueryObjectIdsAsync_UsesFeatureIdsAndPrimaryKeyFallback()
+    {
+        var queryClient = new FakeQueryClient(
+            "wfs",
+            _ =>
+            [
+                new FeatureQueryResult
+                {
+                    ProviderName = "wfs",
+                    Features =
+                    [
+                        new FeatureRecord { Id = "parcels.1" },
+                        new FeatureRecord
+                        {
+                            Attributes = new Dictionary<string, JsonElement>
+                            {
+                                ["parcel_id"] = JsonSerializer.SerializeToElement("APN-002")
+                            }
+                        }
+                    ],
+                    NumberReturned = 2
+                }
+            ]);
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.Wfs,
+                Locator = new SourceLocator { TypeName = "parcels" },
+                Schema = new SourceSchema { PrimaryKey = "parcel_id" }
+            },
+            queryClient);
+
+        var ids = await source.QueryObjectIdsAsync();
+
+        Assert.Equal(["parcels.1", "APN-002"], ids);
+    }
+
+    [Fact]
+    public async Task HonuaSource_ApplyEditsAsync_RejectsUnsupportedEditCapability()
+    {
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.Wfs,
+                Locator = new SourceLocator { TypeName = "parcels" }
+            },
+            new FakeQueryClient("wfs", _ => []),
+            new FakeEditClient("wfs", new FeatureEditCapabilities
+            {
+                NativeSurface = "WFS-T Transaction",
+                UnsupportedReason = "WFS-T is not implemented."
+            }));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => source.ApplyEditsAsync(new FeatureEditRequest
+            {
+                Adds = [new FeatureEditFeature()]
+            }));
+
+        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        Assert.Contains("applyEdits", ex.Message);
+    }
+
+    private sealed class FakeQueryClient(
+        string providerName,
+        Func<FeatureQueryRequest, IReadOnlyList<FeatureQueryResult>> queryPages) : IHonuaFeatureQueryClient
+    {
+        public string ProviderName { get; } = providerName;
+
+        public Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
+            => Task.FromResult(queryPages(request).FirstOrDefault() ?? new FeatureQueryResult { ProviderName = ProviderName });
+
+        public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
+            FeatureQueryRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            foreach (var page in queryPages(request))
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return page;
+                await Task.Yield();
+            }
+        }
+    }
+
+    private sealed class FakeEditClient(
+        string providerName,
+        FeatureEditCapabilities capabilities) : IHonuaFeatureEditClient
+    {
+        public string ProviderName { get; } = providerName;
+
+        public FeatureEditCapabilities EditCapabilities { get; } = capabilities;
+
+        public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
+            => Task.FromResult(new FeatureEditResponse { ProviderName = ProviderName });
+    }
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -143,6 +143,50 @@ public sealed class SourceFacadeTests
     }
 
     [Fact]
+    public async Task HonuaSource_QueryObjectIdsAsync_DoesNotRequireQueryCapability()
+    {
+        FeatureQueryRequest? capturedRequest = null;
+        var queryClient = new FakeQueryClient(
+            "wfs",
+            request =>
+            {
+                capturedRequest = request;
+                return
+                [
+                    new FeatureQueryResult
+                    {
+                        ProviderName = "wfs",
+                        Features =
+                        [
+                            new FeatureRecord { Id = "parcels.1" },
+                            new FeatureRecord { Id = "parcels.1" },
+                            new FeatureRecord { Id = "parcels.2" }
+                        ],
+                        NumberReturned = 3
+                    }
+                ];
+            });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "ids-only",
+                Protocol = FeatureProtocolIds.Wfs,
+                Locator = new SourceLocator { TypeName = "parcels" },
+                Capabilities = [FeatureCapabilities.QueryObjectIds]
+            },
+            queryClient);
+
+        var ids = await source.QueryObjectIdsAsync(new SourceQuery { Limit = 10 });
+
+        Assert.DoesNotContain(FeatureCapabilities.Query, source.Capabilities);
+        Assert.Contains(FeatureCapabilities.QueryObjectIds, source.Capabilities);
+        Assert.NotNull(capturedRequest);
+        Assert.False(capturedRequest.ReturnGeometry);
+        Assert.Equal(10, capturedRequest.Limit);
+        Assert.Equal(["parcels.1", "parcels.2"], ids);
+    }
+
+    [Fact]
     public async Task HonuaSource_ApplyEditsAsync_RejectsUnsupportedEditCapability()
     {
         var source = new HonuaSource(
@@ -167,6 +211,38 @@ public sealed class SourceFacadeTests
 
         Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, source.Capabilities);
         Assert.Contains("applyEdits", ex.Message);
+    }
+
+    [Fact]
+    public async Task HonuaSource_ApplyEditsAsync_RejectsMismatchedEditClient()
+    {
+        var editClient = new FakeEditClient(
+            "geoservices-featureserver",
+            new FeatureEditCapabilities
+            {
+                SupportsAdds = true,
+                SupportsUpdates = true,
+                SupportsDeletes = true
+            });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.Grpc,
+                Locator = new SourceLocator { ServiceId = "parks", LayerId = 0 }
+            },
+            new FakeQueryClient("grpc", _ => []),
+            editClient);
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => source.ApplyEditsAsync(new FeatureEditRequest
+            {
+                DeleteObjectIds = [1]
+            }));
+
+        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        Assert.Contains("applyEdits", ex.Message);
+        Assert.Equal(0, editClient.ApplyCalls);
     }
 
     private sealed class FakeQueryClient(
@@ -199,7 +275,12 @@ public sealed class SourceFacadeTests
 
         public FeatureEditCapabilities EditCapabilities { get; } = capabilities;
 
+        public int ApplyCalls { get; private set; }
+
         public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken ct = default)
-            => Task.FromResult(new FeatureEditResponse { ProviderName = ProviderName });
+        {
+            ApplyCalls++;
+            return Task.FromResult(new FeatureEditResponse { ProviderName = ProviderName });
+        }
     }
 }

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -210,6 +210,46 @@ public class HonuaFeatureServerClientTests
         Assert.Equal("7", result.Features[0].Id);
     }
 
+    [Fact]
+    public async Task HonuaSourceFacade_QueriesFeatureServerClientAndMatchesProviderAlias()
+    {
+        string? capturedUrl = null;
+        var json = """
+        {
+            "objectIdFieldName": "OBJECTID",
+            "features": [
+                { "attributes": { "OBJECTID": 7, "NAME": "Point A" } }
+            ],
+            "exceededTransferLimit": false
+        }
+        """;
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            capturedUrl = req.RequestUri?.ToString();
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 }
+            },
+            client,
+            client,
+            client);
+
+        var result = await source.QueryAsync(new SourceQuery { Where = "POP > 100", Limit = 10 });
+        var ids = await source.QueryObjectIdsAsync();
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("/rest/services/svc/FeatureServer/0/query", capturedUrl);
+        Assert.Equal("geoservices-featureserver", result.ProviderName);
+        Assert.Equal(["7"], ids);
+        Assert.Contains(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        Assert.Same(client, source.Protocol<HonuaFeatureServerClient>("geoservices-featureserver"));
+    }
+
     // ── Feature edits ───────────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -150,6 +150,49 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task HonuaSourceFacade_QueriesGrpcClientAndExposesNativeProtocol()
+    {
+        Proto.QueryFeaturesRequest? capturedRequest = null;
+        var protoResponse = new Proto.QueryFeaturesResponse();
+        protoResponse.Features.Add(new Proto.Feature { Id = 42 });
+
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>((req, _, _, _) => capturedRequest = req)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object);
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.Grpc,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 3 }
+            },
+            client,
+            client,
+            client);
+
+        var query = new SourceQuery { Where = "1=1", Limit = 10 };
+        var result = await source.QueryAsync(query);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal("svc", capturedRequest.ServiceId);
+        Assert.Equal(3, capturedRequest.LayerId);
+        Assert.Equal("1=1", capturedRequest.Where);
+        Assert.Equal(10, capturedRequest.ResultRecordCount);
+        Assert.Equal("grpc", result.ProviderName);
+        Assert.Equal("42", Assert.Single(result.Features).Id);
+        Assert.Contains(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        Assert.Same(client, source.Protocol<HonuaGrpcClient>());
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_SharedAbstraction_DelegatesToGrpcApplyEdits()
     {
         Proto.ApplyEditsRequest? capturedRequest = null;

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -277,6 +277,59 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task HonuaSourceFacade_QueriesOgcFeaturesClientAndSuppressesUnsupportedEdits()
+    {
+        string? capturedUrl = null;
+        var json = """
+        {
+            "type": "FeatureCollection",
+            "numberMatched": 1,
+            "numberReturned": 1,
+            "features": [
+                {
+                    "type": "Feature",
+                    "id": "building-7",
+                    "properties": { "name": "Building A" }
+                }
+            ]
+        }
+        """;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            capturedUrl = req.RequestUri?.ToString();
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "buildings",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+                Locator = new SourceLocator { CollectionId = "buildings" }
+            },
+            client,
+            client,
+            client);
+
+        var result = await source.QueryAsync(new SourceQuery { Where = "height > 10", Limit = 5 });
+        var ids = await source.QueryObjectIdsAsync();
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("/ogc/features/collections/buildings/items", capturedUrl);
+        Assert.Equal("ogc-features", result.ProviderName);
+        Assert.Equal(["building-7"], ids);
+        if (((IHonuaFeatureEditClient)client).EditCapabilities.SupportsAdds)
+        {
+            Assert.Contains(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        }
+        else
+        {
+            Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        }
+
+        Assert.Same(client, source.Protocol<HonuaOgcFeaturesClient>());
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_SharedAbstraction_ThrowsUnsupportedWithCapabilities()
     {
         var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -164,6 +164,37 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task HonuaSourceFacade_QueriesWfsClientAndSuppressesUnsupportedEdits()
+    {
+        string? capturedQuery = null;
+        var client = TestHelpers.CreateClient(req =>
+        {
+            capturedQuery = req.RequestUri!.Query;
+            return Task.FromResult(TestHelpers.CreateGeoJsonResponse(TwoFeatureResponse));
+        });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.Wfs,
+                Locator = new SourceLocator { TypeName = "parcels" }
+            },
+            client,
+            client,
+            client);
+
+        var result = await source.QueryAsync(new SourceQuery { Where = "<fes:Filter />", FilterLanguage = FeatureFilterLanguage.FesXml });
+        var ids = await source.QueryObjectIdsAsync();
+
+        Assert.NotNull(capturedQuery);
+        Assert.Contains("TYPENAMES=parcels", capturedQuery);
+        Assert.Equal("wfs", result.ProviderName);
+        Assert.Equal(["parcels.1", "parcels.2"], ids);
+        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, source.Capabilities);
+        Assert.Same(client, source.Protocol<HonuaWfsClient>());
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_SharedAbstraction_ThrowsUnsupportedWithCapabilities()
     {
         var client = TestHelpers.CreateClient(_ => throw new InvalidOperationException("HTTP should not be called."));


### PR DESCRIPTION
## Summary
- add source-oriented facade types in `Honua.Sdk.Abstractions`: `SourceDescriptor`, `SourceLocator`, `SourceQuery`, `IHonuaSource`, and `HonuaSource`
- add canonical protocol/capability identifiers with alias normalization for existing provider names
- cover the facade across gRPC, GeoServices FeatureServer, OGC API Features, and WFS clients, plus abstraction-level alias/capability tests
- document the source descriptor/capability model and add Abstractions test coverage to CI

## Validation
- `dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true`
- `git diff --check`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal`
- `dotnet pack Honua.Sdk.sln --configuration Release --no-build /p:TreatWarningsAsErrors=true`
- `HONUA_API_COMPAT_BASE_REF=origin/trunk scripts/validate-api-compat.sh`

Closes #46