### PR TITLE
test: cover source facade in staging integration

### DIFF
--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -13,6 +13,8 @@ dedicated disposable edit fixture.
 - A bounded gRPC `QueryFeaturesAsync()` call with `ReturnGeometry = false`
 - WFS `GetCapabilitiesAsync()` and bounded `GetFeaturesAsync()`
 - FeatureServer metadata plus a bounded `QueryAsync()`
+- Source-facade queries across gRPC, FeatureServer, WFS, and OGC API Features
+  using `IHonuaSource.QueryAsync()`
 - Optional FeatureServer add/update/delete round-trip against a dedicated edit
   fixture
 - OGC API Features collections, bounded items, and a single item lookup

--- a/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingEvidenceTests.cs
@@ -53,11 +53,13 @@ public sealed class StagingEvidenceTests
             .ToArray();
         Assert.Contains("grpc", surfaces);
         Assert.Contains("geoservices-featureserver", surfaces);
+        Assert.Contains("source-facade", surfaces);
         Assert.DoesNotContain("geoservices-featureserver-edits", surfaces);
 
         var checks = root.GetProperty("Checks").EnumerateArray()
             .Select(check => check.GetProperty("Name").GetString())
             .ToArray();
+        Assert.Contains("source-facade-query", checks);
         Assert.Contains("features-edit-roundtrip", checks);
 
         File.Delete(evidencePath);

--- a/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingIntegrationFixture.cs
@@ -31,6 +31,7 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         "wfs-get-features",
         "features-service-info",
         "features-query",
+        "source-facade-query",
         "features-edit-roundtrip",
         "ogc-collections",
         "ogc-items",
@@ -43,7 +44,8 @@ public sealed class StagingIntegrationFixture : IAsyncLifetime, IDisposable
         "grpc",
         "wfs",
         "geoservices-featureserver",
-        "ogc-api-features"
+        "ogc-api-features",
+        "source-facade"
     ];
 
     private readonly Dictionary<string, StagingCheckResult> _results =

--- a/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Honua.Sdk.Grpc.Models;
 using Honua.Sdk.OgcFeatures.Models;
@@ -189,6 +190,61 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
     }
 
     [StagingConfiguredFact]
+    public async Task SourceFacade_QueriesAllConfiguredFeatureProviders()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        await _fixture.RecordCheckAsync(
+            "source-facade-query",
+            "IHonuaSource.QueryAsync",
+            "source://grpc,geoservices-feature-service,wfs,ogc-features",
+            async ct =>
+            {
+                var sources = new[]
+                {
+                    CreateSource(
+                        "grpc",
+                        FeatureProtocolIds.Grpc,
+                        new SourceLocator { ServiceId = _fixture.Options.ServiceName, LayerId = _fixture.Options.LayerId }),
+                    CreateSource(
+                        "geoservices",
+                        FeatureProtocolIds.GeoServicesFeatureService,
+                        new SourceLocator { ServiceId = _fixture.Options.ServiceName, LayerId = _fixture.Options.LayerId }),
+                    CreateSource(
+                        "wfs",
+                        FeatureProtocolIds.Wfs,
+                        new SourceLocator { TypeName = _fixture.Options.WfsTypeName }),
+                    CreateSource(
+                        "ogc",
+                        FeatureProtocolIds.OgcFeatures,
+                        new SourceLocator { CollectionId = _fixture.Options.OgcCollectionId })
+                };
+
+                var summaries = new List<string>();
+                foreach (var source in sources)
+                {
+                    Assert.Contains(FeatureCapabilities.Query, source.Capabilities);
+
+                    var result = await source.QueryAsync(
+                        new SourceQuery
+                        {
+                            Where = BuildWhere(source.Descriptor.CanonicalProtocol),
+                            FilterLanguage = BuildFilterLanguage(source.Descriptor.CanonicalProtocol),
+                            ReturnGeometry = false,
+                            Limit = 1
+                        },
+                        ct).ConfigureAwait(false);
+
+                    Assert.InRange(result.Features.Count, 1, 1);
+                    summaries.Add($"{source.Descriptor.Id}:{result.ProviderName}:rows={result.Features.Count}");
+                }
+
+                return string.Join("; ", summaries);
+            },
+            timeout.Token).ConfigureAwait(false);
+    }
+
+    [StagingConfiguredFact]
     public async Task OgcCollections_Items_AndSingleItem_AreReadable()
     {
         using var timeout = _fixture.CreateTimeoutScope();
@@ -269,4 +325,35 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
             _ => throw new Xunit.Sdk.XunitException($"Unsupported OGC feature ID kind: {id.ValueKind}.")
         };
     }
+
+    private HonuaSource CreateSource(string id, string protocol, SourceLocator locator)
+    {
+        var queryClient = _fixture.Services
+            .GetServices<IHonuaFeatureQueryClient>()
+            .Single(client => FeatureProtocolIds.Matches(protocol, client.ProviderName));
+        var editClient = _fixture.Services
+            .GetServices<IHonuaFeatureEditClient>()
+            .SingleOrDefault(client => FeatureProtocolIds.Matches(protocol, client.ProviderName));
+
+        return new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = id,
+                Protocol = protocol,
+                Locator = locator
+            },
+            queryClient,
+            editClient,
+            queryClient);
+    }
+
+    private static string? BuildWhere(string protocol)
+        => protocol is FeatureProtocolIds.Grpc or FeatureProtocolIds.GeoServicesFeatureService
+            ? "1=1"
+            : null;
+
+    private static FeatureFilterLanguage BuildFilterLanguage(string protocol)
+        => protocol is FeatureProtocolIds.Grpc or FeatureProtocolIds.GeoServicesFeatureService
+            ? FeatureFilterLanguage.SqlWhere
+            : FeatureFilterLanguage.ProviderDefault;
 }


### PR DESCRIPTION
## Summary
- add a staging integration check that queries all configured feature providers through `IHonuaSource.QueryAsync`
- record the source facade as a covered protocol surface in staging evidence
- document source-facade staging coverage

Closes #31

## Validation
- `dotnet test tests/Honua.Sdk.IntegrationTests/Honua.Sdk.IntegrationTests.csproj --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet test Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal`
- `git diff --check`
- `dotnet pack Honua.Sdk.sln --configuration Release --no-build /p:TreatWarningsAsErrors=true`