### PR TITLE
fix: address repo review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,5 +203,8 @@ jobs:
       - name: Build canonical sample
         run: dotnet build examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj --configuration Release /p:TreatWarningsAsErrors=true
 
+      - name: Build field data reference sample
+        run: dotnet build examples/FieldDataCollection/FieldDataCollection.csproj --configuration Release /p:TreatWarningsAsErrors=true
+
       - name: Test canonical sample workflow
         run: dotnet test tests/AdminBootstrapConsole.Tests/AdminBootstrapConsole.Tests.csproj --configuration Release

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Build canonical sample
         run: dotnet build examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj --configuration Release /p:TreatWarningsAsErrors=true
 
+      - name: Build field data reference sample
+        run: dotnet build examples/FieldDataCollection/FieldDataCollection.csproj --configuration Release /p:TreatWarningsAsErrors=true
+
       - name: Test canonical sample workflow
         run: dotnet test tests/AdminBootstrapConsole.Tests/AdminBootstrapConsole.Tests.csproj --configuration Release
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,15 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <HonuaSdkVersionPrefix>0.1.0</HonuaSdkVersionPrefix>
-    <HonuaSdkVersionSuffix>alpha.1</HonuaSdkVersionSuffix>
-    <VersionPrefix>$(HonuaSdkVersionPrefix)</VersionPrefix>
-    <VersionSuffix>$(HonuaSdkVersionSuffix)</VersionSuffix>
-    <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
-    <PackageVersion>$(Version)</PackageVersion>
-    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-    <FileVersion>$(VersionPrefix).0</FileVersion>
+    <HonuaSdkVersion>0.1.0-alpha.1</HonuaSdkVersion> <!-- x-release-please-version -->
+    <Version>$(HonuaSdkVersion)</Version>
+    <PackageVersion>$(HonuaSdkVersion)</PackageVersion>
     <InformationalVersion>$(Version)</InformationalVersion>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>

--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Abstractions", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Abstractions.Tests", "tests\Honua.Sdk.Abstractions.Tests\Honua.Sdk.Abstractions.Tests.csproj", "{975A5C94-0A96-4ED8-A244-69F33ED5A69A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FieldDataCollection", "examples\FieldDataCollection\FieldDataCollection.csproj", "{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +231,18 @@ Global
 		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x64.Build.0 = Release|Any CPU
 		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x86.ActiveCfg = Release|Any CPU
 		{975A5C94-0A96-4ED8-A244-69F33ED5A69A}.Release|x86.Build.0 = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|x64.Build.0 = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -249,5 +263,6 @@ Global
 		{BE25E03B-2BC4-4188-B9F1-D085686FF0FA} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{360ACBB7-1206-42F6-8040-7CEB13916D3C} = {2F8F8F8F-8F8F-8F8F-8F8F-8F8F8F8F8F8F}
 		{975A5C94-0A96-4ED8-A244-69F33ED5A69A} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
+		{13D96FD0-02DD-48DF-BBFB-6B78D6B5F9E9} = {4E4E4E4E-4E4E-4E4E-4E4E-4E4E4E4E4E4E}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -190,10 +190,11 @@ provider support, and unsupported-provider behavior.
 
 ## Retry
 
-The gRPC, WFS, GeoServices, and OGC API Features clients retry automatically on transient failures with
-exponential backoff and jitter. gRPC retries on `Unavailable` / `Internal`;
-HTTP clients retry on `429`, `502`, `503`. Each DI client also exposes a
-`Timeout` option that defaults to 100 seconds and accepts any value greater
+The gRPC, WFS, GeoServices, and OGC API Features clients retry automatically on
+transient read failures with exponential backoff and jitter. gRPC retries
+`QueryFeatures` and `QueryFeaturesStream` on `Unavailable` / `Internal`; HTTP
+clients retry safe methods on `429`, `502`, `503`. Each DI client also exposes
+a `Timeout` option that defaults to 100 seconds and accepts any value greater
 than 10 milliseconds and less than 24 hours. Configurable on each client:
 
 ```csharp
@@ -308,7 +309,7 @@ tests/
   Honua.Sdk.OgcFeatures.Tests/
 examples/
   AdminBootstrapConsole/     Canonical console sample for admin bootstrap + gRPC verification
-  FieldDataCollection/      Advanced .NET MAUI reference app (not the primary onboarding sample)
+  FieldDataCollection/       Archived MAUI reference assets; buildable as a marker project
 docs/
   quickstart.md             5-minute quickstart tutorial
   staging-integration.md    Staging CI inputs, evidence, and troubleshooting
@@ -339,8 +340,8 @@ third_party/
   policy and server compatibility baseline
 - **[Backlog cadence](docs/backlog-cadence.md)** -- weekly triage, scope gate,
   and close hygiene for this repository
-- **[Field Data Collection](examples/FieldDataCollection/)** -- full MAUI
-  reference app with offline sync and map views
+- **[Field Data Collection](examples/FieldDataCollection/)** -- archived MAUI
+  reference assets for offline sync and map views
 
 ## License
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -68,7 +68,7 @@ HTTP exception is loopback or `localhost` for local development.
 If a provider throws or its cancellation token is canceled, the current SDK call
 fails before the transport request is sent. Authentication failures from the
 server, such as `401` or `403`, are not retried by the SDK retry policy. HTTP
-clients retry only `429`, `502`, and `503`; the gRPC client retries only
-`Unavailable` and `Internal` according to its configured retry policy. Treat the
-provider as the place to refresh before a request, not as a response-time
-recovery hook for expired credentials.
+clients retry safe methods only on `429`, `502`, and `503`; the gRPC client
+retries read queries only on `Unavailable` and `Internal` according to its
+configured retry policy. Treat the provider as the place to refresh before a
+request, not as a response-time recovery hook for expired credentials.

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -37,8 +37,13 @@ Retries are enabled by default and can be disabled per client with
 
 | Client family | Retried failures |
 |---------------|------------------|
-| gRPC | `Unavailable`, `Internal` |
-| Admin, Geocoding, WFS, GeoServices, OGC API Features | HTTP `429`, `502`, `503` |
+| gRPC | `QueryFeatures` and `QueryFeaturesStream` retries on `Unavailable`, `Internal` |
+| Admin, Geocoding, WFS, GeoServices, OGC API Features | Safe HTTP methods (`GET`, `HEAD`, `OPTIONS`, `TRACE`) retry on `429`, `502`, `503` |
+
+Write operations such as Admin mutations, FeatureServer `applyEdits`, and OGC
+API Features create/update/delete calls are not retried by the default policy.
+Retrying writes should be an explicit application decision because a server may
+apply a mutation before returning a transient failure.
 
 Authentication failures, validation errors, unsupported operations, parser
 failures, and application-level protocol errors are not retried by the SDK.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -357,7 +357,7 @@ selected client in a source descriptor:
   aliases, capabilities, and native protocol escape hatches
 - **[INSTALL.md](../INSTALL.md)** -- package sources, GitHub Packages setup,
   and version policy
-- **[Field Data Collection example](../examples/FieldDataCollection/)** -- a
-  full .NET MAUI reference app with offline sync, forms, and map views
+- **[Field Data Collection example](../examples/FieldDataCollection/)** --
+  archived .NET MAUI reference assets for offline sync, forms, and map views
 - **[gRPC vs Forms comparison](../examples/FieldDataCollection/GRPC_FORMS_COMPARISON.md)**
   -- when to use gRPC queries versus OpenRosa/XForms for data collection

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,8 +1,8 @@
 # .NET SDK Release and NuGet Publishing
 
 The SDK packages share one version source in `Directory.Build.props`.
-Update `HonuaSdkVersionPrefix` and `HonuaSdkVersionSuffix` there before a
-release. Leave `HonuaSdkVersionSuffix` empty for stable releases.
+Release Please updates the `HonuaSdkVersion` property when it opens a release
+PR.
 
 ## Packages
 
@@ -17,12 +17,15 @@ The publish workflow builds and packs:
 
 ## Release Flow
 
-1. Update `Directory.Build.props`.
-2. Open a PR with the version bump and release notes.
-3. Run the `Publish .NET SDK Packages` workflow manually with `dry_run=true`.
+1. Merge changes to `trunk` using conventional commits.
+2. Let the Release Please workflow open or update the release PR.
+3. Confirm the release PR includes `Directory.Build.props`,
+   `.release-please-manifest.json`, and `CHANGELOG.md`.
+4. Run the `Publish .NET SDK Packages` workflow manually with `dry_run=true`.
    This builds, tests, validates API compatibility, audits dependencies, packs,
    and runs package install smoke without publishing.
-4. After merge, create and push a tag named `dotnet-sdk-v<PackageVersion>`.
+5. Merge the release PR so Release Please creates the tag named
+   `dotnet-sdk-v<PackageVersion>`.
    Example: `dotnet-sdk-v0.1.0-alpha.1`.
 
 The tag version must match the MSBuild `PackageVersion` resolved from the SDK
@@ -46,6 +49,10 @@ Resolve the package version:
 ```bash
 dotnet msbuild src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj -nologo -getProperty:PackageVersion
 ```
+
+For emergency manual releases, update `HonuaSdkVersion` in
+`Directory.Build.props` and create a matching `dotnet-sdk-v<PackageVersion>`
+tag.
 
 Pack all packages locally:
 

--- a/examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj
+++ b/examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/FieldDataCollection/FieldDataCollection.csproj
+++ b/examples/FieldDataCollection/FieldDataCollection.csproj
@@ -1,86 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<!-- Temporarily target net10.0 for compilation check -->
-		<TargetFramework>net10.0</TargetFramework>
-		<!-- Full MAUI targets (restore when building in proper environment): -->
-		<!-- <TargetFrameworks>net10.0-android</TargetFrameworks> -->
-		<!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst;net10.0-windows10.0.19041.0</TargetFrameworks> -->
-		<!-- <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">$(TargetFrameworks);net10.0-ios;net10.0-maccatalyst</TargetFrameworks> -->
-		<OutputType>Library</OutputType>
-		<RootNamespace>FieldDataCollection</RootNamespace>
-		<!-- <UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject> -->
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FieldDataCollection</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
 
-		<!-- Display Version -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
-
-		<!-- App Metadata -->
-		<ApplicationTitle>Honua Field Data Collection</ApplicationTitle>
-		<ApplicationId>com.honua.fielddata</ApplicationId>
-		<ApplicationIdGuid>C2482DA0-9DBE-4FBA-A5B6-2F96F15722D7</ApplicationIdGuid>
-
-		<!-- Platform Versions -->
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
-		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-
-		<!-- Disable warnings for example project -->
-		<NoWarn>$(NoWarn);CS1591;IDE0073;CA1720;CA1873;CA1848;CA1859;IDE0005;CA1305;CA1861;CA1826;CA1852</NoWarn>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
-
-		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
-
-		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
-
-		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
-
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<!-- MAUI packages for full mobile app (uncomment when building in MAUI environment) -->
-		<!-- <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.1" /> -->
-		<!-- <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.1" /> -->
-		<!-- <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="10.0.1" /> -->
-		<!-- <PackageReference Include="Microsoft.Maui.Essentials" Version="10.0.1" /> -->
-
-		<!-- Basic packages for compilation check -->
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-
-		<!-- SQLite and GeoPackage support -->
-		<PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.4" />
-		<PackageReference Include="NetTopologySuite" Version="2.5.0" />
-
-		<!-- gRPC support -->
-		<PackageReference Include="Grpc.Net.Client" Version="2.63.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.27.0" />
-		<PackageReference Include="System.Text.Json" Version="10.0.0" />
-
-		<!-- Community Toolkit packages don't support .NET 10 yet, commenting out for now -->
-		<!-- <PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" /> -->
-		<!-- <PackageReference Include="CommunityToolkit.Maui.Maps" Version="2.1.0" /> -->
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="../../../sdk/dotnet/Honua.Mobile.Core/Honua.Mobile.Core.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="ReferenceSampleMarker.cs" />
+    <None Include="**/*"
+          Exclude="bin/**;obj/**;FieldDataCollection.csproj;ReferenceSampleMarker.cs" />
+  </ItemGroup>
 
 </Project>

--- a/examples/FieldDataCollection/README.md
+++ b/examples/FieldDataCollection/README.md
@@ -1,5 +1,10 @@
 # Honua Field Data Collection - Reference MAUI App
 
+> Status: archived reference assets. The original app depends on
+> `Honua.Mobile.Core`, which is owned outside this SDK repository. The project
+> file in this folder is intentionally a buildable marker so solution and CI
+> restore/build checks do not depend on unavailable mobile-only assemblies.
+
 A comprehensive reference application demonstrating the capabilities of the Honua Mobile SDK for field data collection. This app implements all four screens specified in GitHub issue #406 and serves as a production-ready example of modern geospatial mobile development.
 
 ## Features

--- a/examples/FieldDataCollection/ReferenceSampleMarker.cs
+++ b/examples/FieldDataCollection/ReferenceSampleMarker.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace FieldDataCollection;
+
+/// <summary>
+/// Build marker for the archived FieldDataCollection reference assets.
+/// </summary>
+public static class ReferenceSampleMarker
+{
+    /// <summary>Short description of the archived reference sample.</summary>
+    public const string Description = "Archived .NET MAUI field data collection reference sample.";
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,12 @@
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Directory.Build.props"
+        }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -69,6 +69,7 @@ public sealed class HonuaSource : IHonuaSource
     {
         EnsureCapability(FeatureCapabilities.Query);
 
+        var limit = query?.Limit;
         var providerName = _queryClient.ProviderName;
         var features = new List<FeatureRecord>();
         long? numberMatched = null;
@@ -79,9 +80,20 @@ public sealed class HonuaSource : IHonuaSource
         {
             sawPage = true;
             providerName = page.ProviderName;
-            features.AddRange(page.Features);
+            var remaining = limit.HasValue ? limit.Value - features.Count : int.MaxValue;
+            if (remaining <= 0)
+            {
+                break;
+            }
+
+            features.AddRange(page.Features.Take(remaining));
             numberMatched ??= page.NumberMatched;
             objectIdFieldName ??= page.ObjectIdFieldName;
+
+            if (limit.HasValue && features.Count >= limit.Value)
+            {
+                break;
+            }
         }
 
         if (!sawPage)
@@ -113,6 +125,7 @@ public sealed class HonuaSource : IHonuaSource
             ? new SourceQuery { ReturnGeometry = false }
             : query with { ReturnGeometry = false };
         var request = BuildQueryRequest(objectIdQuery);
+        var limit = query?.Limit;
         var idFieldName = Descriptor.Schema?.PrimaryKey;
         var ids = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -125,6 +138,10 @@ public sealed class HonuaSource : IHonuaSource
                 if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))
                 {
                     ids.Add(id);
+                    if (limit.HasValue && ids.Count >= limit.Value)
+                    {
+                        return ids;
+                    }
                 }
             }
         }

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -126,6 +126,11 @@ public sealed class HonuaSource : IHonuaSource
             : query with { ReturnGeometry = false };
         var request = BuildQueryRequest(objectIdQuery);
         var limit = query?.Limit;
+        if (limit is <= 0)
+        {
+            return [];
+        }
+
         var idFieldName = Descriptor.Schema?.PrimaryKey;
         var ids = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -138,7 +143,7 @@ public sealed class HonuaSource : IHonuaSource
                 if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))
                 {
                     ids.Add(id);
-                    if (limit.HasValue && ids.Count >= limit.Value)
+                    if (ids.Count >= limit.GetValueOrDefault(int.MaxValue))
                     {
                         return ids;
                     }

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -87,12 +87,23 @@ public static class ServiceCollectionExtensions
             options.TotalRequestTimeout.Timeout = opts.Timeout;
             options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
-            options.Retry.ShouldHandle = args => ValueTask.FromResult(
-                args.Outcome.Result?.StatusCode is
-                    HttpStatusCode.TooManyRequests or
-                    HttpStatusCode.BadGateway or
-                    HttpStatusCode.ServiceUnavailable);
+            options.Retry.ShouldHandle = args => ValueTask.FromResult(ShouldRetry(args.Outcome.Result));
             options.Retry.UseJitter = true;
         });
     }
+
+    private static bool ShouldRetry(HttpResponseMessage? response)
+    {
+        return IsSafeRetryMethod(response?.RequestMessage?.Method) &&
+            response?.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable;
+    }
+
+    private static bool IsSafeRetryMethod(HttpMethod? method) =>
+        method == HttpMethod.Get ||
+        method == HttpMethod.Head ||
+        method == HttpMethod.Options ||
+        method == HttpMethod.Trace;
 }

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -62,12 +62,23 @@ public static class ServiceCollectionExtensions
             options.TotalRequestTimeout.Timeout = opts.Timeout;
             options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
-            options.Retry.ShouldHandle = args => ValueTask.FromResult(
-                args.Outcome.Result?.StatusCode is
-                    HttpStatusCode.TooManyRequests or
-                    HttpStatusCode.BadGateway or
-                    HttpStatusCode.ServiceUnavailable);
+            options.Retry.ShouldHandle = args => ValueTask.FromResult(ShouldRetry(args.Outcome.Result));
             options.Retry.UseJitter = true;
         });
     }
+
+    private static bool ShouldRetry(HttpResponseMessage? response)
+    {
+        return IsSafeRetryMethod(response?.RequestMessage?.Method) &&
+            response?.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable;
+    }
+
+    private static bool IsSafeRetryMethod(HttpMethod? method) =>
+        method == HttpMethod.Get ||
+        method == HttpMethod.Head ||
+        method == HttpMethod.Options ||
+        method == HttpMethod.Trace;
 }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -867,11 +867,28 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             return null;
         }
 
-        var digits = new string(crs.Where(char.IsDigit).ToArray());
-        return int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out var wkid)
-            ? wkid
-            : null;
+        var trimmed = crs.Trim();
+        if (IsCrs84(trimmed))
+        {
+            return 4326;
+        }
+
+        if (int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var bareWkid))
+        {
+            return bareWkid;
+        }
+
+        var separatorIndex = Math.Max(trimmed.LastIndexOf(':'), trimmed.LastIndexOf('/'));
+        return separatorIndex >= 0 &&
+            int.TryParse(trimmed[(separatorIndex + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wkid)
+                ? wkid
+                : null;
     }
+
+    private static bool IsCrs84(string crs) =>
+        string.Equals(crs, "CRS84", StringComparison.OrdinalIgnoreCase) ||
+        crs.EndsWith("/CRS84", StringComparison.OrdinalIgnoreCase) ||
+        crs.EndsWith(":CRS84", StringComparison.OrdinalIgnoreCase);
 
     private FeatureQueryResult ToFeatureQueryResult(FeatureServerQueryResponse response)
     {

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -18,6 +18,8 @@ namespace Honua.Sdk.Grpc;
 /// </summary>
 public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient, IDisposable
 {
+    private const string FeatureServiceName = "honua.v1.FeatureService";
+
     private static readonly JsonSerializerOptions FeatureJsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -228,7 +230,11 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
 
             serviceConfig.MethodConfigs.Add(new MethodConfig
             {
-                Names = { MethodName.Default },
+                Names =
+                {
+                    new MethodName { Service = FeatureServiceName, Method = "QueryFeatures" },
+                    new MethodName { Service = FeatureServiceName, Method = "QueryFeaturesStream" }
+                },
                 RetryPolicy = new RetryPolicy
                 {
                     MaxAttempts = maxAttempts,
@@ -520,14 +526,35 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             return null;
         }
 
-        var digits = new string(crs.Where(char.IsDigit).ToArray());
-        if (int.TryParse(digits, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var wkid))
+        var trimmed = crs.Trim();
+        if (IsCrs84(trimmed))
+        {
+            return new Models.SpatialReference { Wkid = 4326 };
+        }
+
+        if (int.TryParse(trimmed, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var bareWkid))
+        {
+            return new Models.SpatialReference { Wkid = bareWkid };
+        }
+
+        var separatorIndex = Math.Max(trimmed.LastIndexOf(':'), trimmed.LastIndexOf('/'));
+        if (separatorIndex >= 0 &&
+            int.TryParse(
+                trimmed[(separatorIndex + 1)..],
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var wkid))
         {
             return new Models.SpatialReference { Wkid = wkid };
         }
 
-        return new Models.SpatialReference { Wkt = crs };
+        return new Models.SpatialReference { Wkt = trimmed };
     }
+
+    private static bool IsCrs84(string crs) =>
+        string.Equals(crs, "CRS84", StringComparison.OrdinalIgnoreCase) ||
+        crs.EndsWith("/CRS84", StringComparison.OrdinalIgnoreCase) ||
+        crs.EndsWith(":CRS84", StringComparison.OrdinalIgnoreCase);
 
     private FeatureQueryResult ToFeatureQueryResult(Models.QueryFeaturesResponse response)
     {

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -61,12 +61,23 @@ public static class ServiceCollectionExtensions
             options.TotalRequestTimeout.Timeout = opts.Timeout;
             options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
-            options.Retry.ShouldHandle = args => ValueTask.FromResult(
-                args.Outcome.Result?.StatusCode is
-                    HttpStatusCode.TooManyRequests or
-                    HttpStatusCode.BadGateway or
-                    HttpStatusCode.ServiceUnavailable);
+            options.Retry.ShouldHandle = args => ValueTask.FromResult(ShouldRetry(args.Outcome.Result));
             options.Retry.UseJitter = true;
         });
     }
+
+    private static bool ShouldRetry(HttpResponseMessage? response)
+    {
+        return IsSafeRetryMethod(response?.RequestMessage?.Method) &&
+            response?.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable;
+    }
+
+    private static bool IsSafeRetryMethod(HttpMethod? method) =>
+        method == HttpMethod.Get ||
+        method == HttpMethod.Head ||
+        method == HttpMethod.Options ||
+        method == HttpMethod.Trace;
 }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -432,7 +432,10 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
             BboxCrs = request.Bbox?.Crs,
             Crs = request.OutputCrs,
             Filter = request.Filter,
-            FilterLang = string.IsNullOrWhiteSpace(request.Filter) ? null : "cql2-text",
+            FilterLang = !string.IsNullOrWhiteSpace(request.Filter) &&
+                request.FilterLanguage == FeatureFilterLanguage.Cql2Text
+                    ? "cql2-text"
+                    : null,
             Ids = BuildIds(request),
             Properties = request.OutFields is { Count: > 0 } ? string.Join(",", request.OutFields) : null,
             Sortby = request.OrderBy,

--- a/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -61,12 +61,23 @@ public static class ServiceCollectionExtensions
             options.TotalRequestTimeout.Timeout = opts.Timeout;
             options.AttemptTimeout.Timeout = opts.Timeout;
             options.Retry.MaxRetryAttempts = opts.MaxRetryAttempts;
-            options.Retry.ShouldHandle = args => ValueTask.FromResult(
-                args.Outcome.Result?.StatusCode is
-                    HttpStatusCode.TooManyRequests or
-                    HttpStatusCode.BadGateway or
-                    HttpStatusCode.ServiceUnavailable);
+            options.Retry.ShouldHandle = args => ValueTask.FromResult(ShouldRetry(args.Outcome.Result));
             options.Retry.UseJitter = true;
         });
     }
+
+    private static bool ShouldRetry(HttpResponseMessage? response)
+    {
+        return IsSafeRetryMethod(response?.RequestMessage?.Method) &&
+            response?.StatusCode is
+                HttpStatusCode.TooManyRequests or
+                HttpStatusCode.BadGateway or
+                HttpStatusCode.ServiceUnavailable;
+    }
+
+    private static bool IsSafeRetryMethod(HttpMethod? method) =>
+        method == HttpMethod.Get ||
+        method == HttpMethod.Head ||
+        method == HttpMethod.Options ||
+        method == HttpMethod.Trace;
 }

--- a/src/Honua.Sdk.Wfs/WfsJsonContext.cs
+++ b/src/Honua.Sdk.Wfs/WfsJsonContext.cs
@@ -25,7 +25,7 @@ internal sealed class WfsGeoJsonFeatureCollection
 {
     public string? Type { get; set; }
     public JsonElement NumberMatched { get; set; }
-    public int NumberReturned { get; set; }
+    public int? NumberReturned { get; set; }
     public List<WfsGeoJsonFeature>? Features { get; set; }
 
     public WfsFeatureCollection ToPublicModel()
@@ -45,7 +45,7 @@ internal sealed class WfsGeoJsonFeatureCollection
         {
             Features = features,
             NumberMatched = matched,
-            NumberReturned = NumberReturned,
+            NumberReturned = NumberReturned ?? features.Count,
         };
     }
 }

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -186,6 +186,34 @@ public sealed class SourceFacadeTests
     }
 
     [Fact]
+    public async Task HonuaSource_QueryObjectIdsAsync_ZeroLimitReturnsEmpty()
+    {
+        var queryClient = new FakeQueryClient(
+            "wfs",
+            _ =>
+            [
+                new FeatureQueryResult
+                {
+                    ProviderName = "wfs",
+                    Features = [new FeatureRecord { Id = "parcels.1" }],
+                    NumberReturned = 1
+                }
+            ]);
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.Wfs,
+                Locator = new SourceLocator { TypeName = "parcels" }
+            },
+            queryClient);
+
+        var ids = await source.QueryObjectIdsAsync(new SourceQuery { Limit = 0 });
+
+        Assert.Empty(ids);
+    }
+
+    [Fact]
     public async Task HonuaSource_QueryObjectIdsAsync_DoesNotRequireQueryCapability()
     {
         FeatureQueryRequest? capturedRequest = null;

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -104,6 +104,49 @@ public sealed class SourceFacadeTests
     }
 
     [Fact]
+    public async Task HonuaSource_QueryAllAsync_RespectsSourceQueryLimit()
+    {
+        var queryClient = new FakeQueryClient(
+            "grpc",
+            _ =>
+            [
+                new FeatureQueryResult
+                {
+                    ProviderName = "grpc",
+                    Features =
+                    [
+                        new FeatureRecord { Id = "1" },
+                        new FeatureRecord { Id = "2" }
+                    ],
+                    NumberMatched = 3,
+                    NumberReturned = 2,
+                    HasMoreResults = true
+                },
+                new FeatureQueryResult
+                {
+                    ProviderName = "grpc",
+                    Features = [new FeatureRecord { Id = "3" }],
+                    NumberMatched = 3,
+                    NumberReturned = 1
+                }
+            ]);
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.Grpc,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 }
+            },
+            queryClient);
+
+        var result = await source.QueryAllAsync(new SourceQuery { Limit = 1 });
+
+        Assert.Equal(["1"], result.Features.Select(feature => feature.Id));
+        Assert.Equal(3, result.NumberMatched);
+        Assert.Equal(1, result.NumberReturned);
+    }
+
+    [Fact]
     public async Task HonuaSource_QueryObjectIdsAsync_UsesFeatureIdsAndPrimaryKeyFallback()
     {
         var queryClient = new FakeQueryClient(

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -211,6 +211,37 @@ public class HonuaFeatureServerClientTests
     }
 
     [Fact]
+    public async Task QueryAsync_SharedAbstraction_Crs84MapsToWkid4326()
+    {
+        string? capturedUrl = null;
+        var json = """{ "features": [], "exceededTransferLimit": false }""";
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            capturedUrl = req.RequestUri?.ToString();
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+        {
+            Source = new FeatureSource { ServiceId = "svc", LayerId = 0 },
+            Bbox = new FeatureBoundingBox
+            {
+                MinX = -118,
+                MinY = 33,
+                MaxX = -117,
+                MaxY = 34,
+                Crs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            },
+            OutputCrs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        });
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("inSR=4326", capturedUrl);
+        Assert.Contains("outSR=4326", capturedUrl);
+        Assert.DoesNotContain("1384", capturedUrl);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesFeatureServerClientAndMatchesProviderAlias()
     {
         string? capturedUrl = null;

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -150,6 +150,41 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task QueryAsync_SharedAbstraction_Crs84MapsToWkid4326()
+    {
+        Proto.QueryFeaturesRequest? capturedRequest = null;
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>((req, _, _, _) => capturedRequest = req)
+            .Returns(CreateAsyncUnaryCall(new Proto.QueryFeaturesResponse()));
+
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+        {
+            Source = new FeatureSource { ServiceId = "test-svc", LayerId = 0 },
+            Bbox = new FeatureBoundingBox
+            {
+                MinX = -118,
+                MinY = 33,
+                MaxX = -117,
+                MaxY = 34,
+                Crs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            },
+            OutputCrs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        });
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(4326, capturedRequest.OutSr.Wkid);
+        Assert.Equal(4326, capturedRequest.SpatialFilter.SpatialReference.Wkid);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesGrpcClientAndExposesNativeProtocol()
     {
         Proto.QueryFeaturesRequest? capturedRequest = null;

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -278,6 +278,28 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task GetItemsAsync_SharedAbstraction_ProviderDefaultFilter_DoesNotSendFilterLang()
+    {
+        string? capturedUrl = null;
+        var json = """{ "type": "FeatureCollection", "features": [] }""";
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            capturedUrl = req.RequestUri?.ToString();
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+        {
+            Source = new FeatureSource { CollectionId = "buildings" },
+            Filter = "height > 10",
+        });
+
+        Assert.NotNull(capturedUrl);
+        Assert.Contains("filter=", capturedUrl);
+        Assert.DoesNotContain("filter-lang=", capturedUrl);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesOgcFeaturesClientAndExposesEditCapabilities()
     {
         string? capturedUrl = null;

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -69,6 +69,29 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task GetFeatures_MissingNumberReturned_FallsBackToFeatureCount()
+    {
+        const string response = """
+            {
+                "type": "FeatureCollection",
+                "numberMatched": 42,
+                "features": [
+                    { "type": "Feature", "id": "parcels.1", "geometry": null, "properties": {} },
+                    { "type": "Feature", "id": "parcels.2", "geometry": null, "properties": {} }
+                ]
+            }
+            """;
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateGeoJsonResponse(response)));
+
+        var result = await client.GetFeaturesAsync(new GetFeaturesRequest { TypeNames = "parcels" });
+
+        Assert.Equal(2, result.NumberReturned);
+        Assert.True(result.HasMoreResults);
+        Assert.Equal(2, result.Features.Count);
+    }
+
+    [Fact]
     public async Task GetFeatures_ParsesFeatureProperties()
     {
         var client = TestHelpers.CreateClient(_ =>


### PR DESCRIPTION
## Summary
- wire Release Please to update the shared SDK package version and keep examples out of NuGet packing
- make the archived FieldDataCollection reference sample buildable/CI-covered without unavailable mobile dependencies
- fix CRS84 parsing, WFS numberReturned fallback, OGC provider-default filter language, source facade limits, and default retry scoping for writes

## Verification
- dotnet build Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release --no-build /p:TreatWarningsAsErrors=true
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal
- git diff --check
- dotnet list Honua.Sdk.sln package --vulnerable --include-transitive
- dotnet pack Honua.Sdk.sln --configuration Release --no-build -o /tmp/honua-pack-check-* /p:TreatWarningsAsErrors=true