### PR TITLE
fix: correct release please tag separator

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
     ".": {
       "release-type": "simple",
       "component": "dotnet-sdk",
-      "tag-separator": "-v",
+      "tag-separator": "-",
       "include-component-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
## Summary
- change Release Please tag separator from `-v` to `-`
- avoids generating `dotnet-sdk-vv<version>` release tags
- keeps generated tags aligned with the publish workflow expectation: `dotnet-sdk-v<PackageVersion>`

## Verification
- jq . release-please-config.json >/dev/null
- git diff --check

## Release note
Merge this before Release Please PR #16 so the release tag becomes `dotnet-sdk-v0.1.1-alpha.1` instead of `dotnet-sdk-vv0.1.1-alpha.1`.