### PR TITLE
ci: make SDK staging optional for manual publish

### DIFF
--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: true
         type: boolean
+      run_staging:
+        description: "Run staging integration before publishing"
+        required: false
+        default: false
+        type: boolean
   push:
     tags:
       - "dotnet-sdk-v*"
@@ -330,7 +335,7 @@ jobs:
   release-staging-integration:
     name: Release Staging Integration
     needs: release-smoke
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_staging == 'true') }}
     uses: ./.github/workflows/staging-integration.yml
     with:
       artifact-retention: 90
@@ -343,6 +348,7 @@ jobs:
       - release-staging-integration
     if: >-
       ${{
+        always() &&
         needs.release-smoke.result == 'success' &&
         (needs.release-staging-integration.result == 'success' || needs.release-staging-integration.result == 'skipped') &&
         !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true')
@@ -353,7 +359,7 @@ jobs:
       packages: write
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-packages
           path: ./nupkgs


### PR DESCRIPTION
## Summary
- adds an explicit `run_staging` input for manual SDK package publishes
- keeps tag publishes running staging by default
- allows manual non-dry-run publishes to proceed when staging is intentionally skipped
- updates package artifact download to `actions/download-artifact@v8`

## Root cause
Manual `dry_run=false` publishes always invoked staging integration. The package smoke job passed, but missing staging repository variables/secrets caused staging validation to fail before the publish job could run.

## Validation
- `git diff --check`
- parsed all workflow YAML files with Python/PyYAML
- verified `actions/download-artifact@v8` exists upstream
