### PR TITLE
ci(sdk): publish offline packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,37 @@ jobs:
       - name: Test
         run: dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
 
+  dotnet-offline-sdk:
+    name: .NET Offline SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Build abstractions
+        run: dotnet build src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
+
+      - name: Build engine
+        run: dotnet build src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
+
+      - name: Test
+        run: dotnet test tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
+
   dotnet-admin-bootstrap-sample:
     name: Admin Bootstrap Sample
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -61,6 +61,8 @@ jobs:
             "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
             "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj"
             "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj"
+            "src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj"
+            "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
           )
 
           errors=0
@@ -110,6 +112,8 @@ jobs:
             "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
             "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj"
             "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj"
+            "src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj"
+            "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
           )
 
           for project in "${projects[@]}"; do
@@ -125,6 +129,7 @@ jobs:
             "tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj"
             "tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj"
             "tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj"
+            "tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj"
           )
 
           for project in "${projects[@]}"; do
@@ -164,6 +169,8 @@ jobs:
             "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
             "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj"
             "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj"
+            "src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj"
+            "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
           )
 
           errors=0
@@ -193,6 +200,8 @@ jobs:
             "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj"
             "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj"
             "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj"
+            "src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj"
+            "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
           )
 
           for project in "${projects[@]}"; do
@@ -245,6 +254,8 @@ jobs:
           dotnet add package Honua.Sdk.Wfs --version "${PACKAGE_VERSION}"
           dotnet add package Honua.Sdk.GeoServices --version "${PACKAGE_VERSION}"
           dotnet add package Honua.Sdk.OgcFeatures --version "${PACKAGE_VERSION}"
+          dotnet add package Honua.Sdk.Offline.Abstractions --version "${PACKAGE_VERSION}"
+          dotnet add package Honua.Sdk.Offline --version "${PACKAGE_VERSION}"
 
           cat <<'EOF' > Program.cs
           using Honua.Sdk.Abstractions.Features;
@@ -257,6 +268,8 @@ jobs:
           using Honua.Sdk.Grpc;
           using Honua.Sdk.Grpc.Extensions;
           using Honua.Sdk.Grpc.Models;
+          using Honua.Sdk.Offline;
+          using Honua.Sdk.Offline.Abstractions;
           using Honua.Sdk.OgcFeatures;
           using Honua.Sdk.OgcFeatures.Extensions;
           using Honua.Sdk.OgcFeatures.Models;
@@ -311,6 +324,26 @@ jobs:
           {
               Limit = 1
           };
+
+          _ = OfflineDownloadPlanner.CreatePlan(new OfflinePackageManifest
+          {
+              PackageId = "smoke",
+              Sources =
+              [
+                  new OfflineSourceDescriptor
+                  {
+                      SourceId = "parks",
+                      Source = new SourceDescriptor
+                      {
+                          Id = "parks",
+                          Protocol = FeatureProtocolIds.OgcFeatures,
+                          Locator = new SourceLocator { CollectionId = "parks" }
+                      },
+                      OutFields = ["name"],
+                      PageSize = 10
+                  }
+              ]
+          });
           EOF
 
           dotnet build --configuration Release

--- a/scripts/validate-api-compat.sh
+++ b/scripts/validate-api-compat.sh
@@ -47,6 +47,8 @@ projects=(
   "src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj|Honua.Sdk.Wfs"
   "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj|Honua.Sdk.GeoServices"
   "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj|Honua.Sdk.OgcFeatures"
+  "src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj|Honua.Sdk.Offline.Abstractions"
+  "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj|Honua.Sdk.Offline"
 )
 
 for entry in "${projects[@]}"; do


### PR DESCRIPTION
## Summary
- add the new Offline SDK packages to CI coverage
- include Offline packages and tests in API compatibility, publish validation, pack, audit, and package install smoke
- ensures Honua.Sdk.Offline and Honua.Sdk.Offline.Abstractions are pushed to GitHub Packages for mobile consumption

## Verification
- dotnet test tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj --configuration Release
- dotnet pack Honua.Sdk.sln --configuration Release --no-restore
- local package install smoke for Honua.Sdk.Offline and Honua.Sdk.Offline.Abstractions
- bash -n scripts/validate-api-compat.sh
- git diff --check