### PR TITLE
[codex] Start SDK transport/proto ownership cleanup

### DIFF
--- a/docs/cross-repo-sdk-sequencing.md
+++ b/docs/cross-repo-sdk-sequencing.md
@@ -87,6 +87,9 @@ Foundation work should land before repo cutovers:
 - Server transport alignment: https://github.com/honua-io/honua-sdk-dotnet/issues/73
 - Browser/WASM matrix: https://github.com/honua-io/honua-sdk-dotnet/issues/62
 
+The SDK-side server transport inventory and first converter fixture slice lives
+in [Server Transport Ownership](server-transport-ownership.md).
+
 ### Gate 4: Admin Cutover
 
 Admin should keep Blazor/MudBlazor UI state, local stubs, workspace state

--- a/docs/server-transport-ownership.md
+++ b/docs/server-transport-ownership.md
@@ -1,0 +1,47 @@
+# Server Transport Ownership
+
+This document tracks the first SDK-side slice for
+[`honua-sdk-dotnet#73`](https://github.com/honua-io/honua-sdk-dotnet/issues/73)
+and the companion server cleanup
+[`honua-server#854`](https://github.com/honua-io/honua-server/issues/854).
+
+Canonical `.proto` definitions stay in
+[`geospatial-grpc`](https://github.com/honua-io/geospatial-grpc). This SDK
+consumes the generated `Geospatial.Grpc` package and owns reusable .NET clients,
+SDK models, and converter fixtures.
+
+## Inventory
+
+| Server file | Classification | SDK replacement or target |
+|-------------|----------------|---------------------------|
+| `src/Honua.Core/Transport/Clients/GrpcFeatureServiceClient.cs` | Portable feature gRPC client wrapper | Replace consumer-facing use with `Honua.Sdk.Grpc.HonuaGrpcClient`, `IHonuaGrpcClient`, `IHonuaFeatureQueryClient`, and `IHonuaFeatureEditClient`. Keep server-only logging/retry wrappers in server only if they are part of server runtime wiring. |
+| `src/Honua.Core/Transport/Clients/IFeatureServiceClient.cs` | Portable feature query/edit abstraction plus DTOs | Replace reusable client contracts with `Honua.Sdk.Abstractions.Features` and protocol-native `Honua.Sdk.Grpc.Models`. Keep server-domain query/edit models in server. |
+| `src/Honua.Core/Transport/Clients/IFormServiceClient.cs` | Portable form client and field/form DTO sketch | Align with the field/form package tracked by `honua-sdk-dotnet#71`; keep form persistence, validation execution, collaboration runtime, and endpoint behavior in server. |
+| `src/Honua.Core/Transport/Converters/AttributeConverter.cs` | Domain-to-protobuf adapter | SDK owns canonical SDK model to protobuf conversion through `HonuaGrpcProtoConverter`; server may keep domain-to-SDK mapping or server-domain adapters. |
+| `src/Honua.Core/Transport/Converters/ExtentConverter.cs` | Domain-to-protobuf adapter | SDK owns SDK extent/protobuf parity in `Honua.Sdk.Grpc`; server-specific `FeatureExtent` mapping stays server-owned. |
+| `src/Honua.Core/Transport/Converters/FeatureConverter.cs` | Server domain feature/query adapter | Keep server-domain query/edit pipeline mapping in server; use SDK fixtures to verify protocol parity. |
+| `src/Honua.Core/Transport/Converters/GeometryConverter.cs` | Server NTS/WKB/protobuf adapter | Keep server WKB/NTS domain mapping in server until SDK geometry/NTS work in `honua-sdk-dotnet#55` provides reusable geometry contracts. |
+| `src/Honua.Core/Transport/Converters/SpatialFilterConverter.cs` | Server domain spatial filter adapter | Keep server-domain mapping in server; SDK owns SDK spatial filter to protobuf conversion. |
+| `src/Honua.Core/Transport/Converters/SpatialReferenceConverter.cs` | Domain-to-protobuf adapter | SDK owns SDK spatial reference to protobuf conversion; server-specific `Honua.Core.Models.SpatialReference` mapping stays server-owned. |
+| `src/Honua.Core/Transport/Converters/StatisticDefinitionConverter.cs` | Server domain statistics adapter | Keep server-domain statistics mapping in server; SDK owns SDK query statistics to protobuf conversion. |
+| `src/Honua.Core/Transport/Proto/geospatial/v1/*.proto` | Generated/snapshot protocol material | Remove as canonical source after server consumes `Geospatial.Grpc`; protocol changes start in `geospatial-grpc`. |
+
+## SDK Surface Added
+
+- `Honua.Sdk.Grpc.Conversion.HonuaGrpcProtoConverter` exposes the stable SDK
+  model to `geospatial.v1` protobuf conversion boundary without making server
+  or mobile copy internal SDK adapter code.
+- `tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/*.json` are the first shared
+  gRPC contract fixtures for feature queries, feature edits, spatial reference
+  handling, datetime attributes, and edit errors.
+
+## Remaining Work
+
+- Replace server-local portable feature client usage with the published
+  `Honua.Sdk.Grpc` NuGet package after `honua-server#854` lands on trunk.
+- Add form client/contracts in the SDK field/form package tracked by
+  `honua-sdk-dotnet#71`; do not treat the server-local `IFormServiceClient<T>`
+  as the long-term public contract.
+- Add server-side fixture tests that parse the same JSON fixtures or equivalent
+  protobuf payloads and compare server protocol adapters with the SDK converter
+  behavior.

--- a/src/Honua.Sdk.Grpc/Conversion/HonuaGrpcProtoConverter.cs
+++ b/src/Honua.Sdk.Grpc/Conversion/HonuaGrpcProtoConverter.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Grpc.Models;
+using Proto = Geospatial.V1;
+
+namespace Honua.Sdk.Grpc.Conversion;
+
+/// <summary>
+/// Converts between Honua SDK gRPC models and canonical <c>geospatial.v1</c> protobuf messages.
+/// </summary>
+public static class HonuaGrpcProtoConverter
+{
+    /// <summary>
+    /// Converts a feature query request to the canonical protobuf request.
+    /// </summary>
+    /// <param name="request">SDK feature query request.</param>
+    /// <returns>Canonical protobuf feature query request.</returns>
+    public static Proto.QueryFeaturesRequest ToProto(QueryFeaturesRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ProtoAdapter.ToProtoRequest(request);
+    }
+
+    /// <summary>
+    /// Converts a canonical protobuf query response to the SDK query response model.
+    /// </summary>
+    /// <param name="response">Canonical protobuf feature query response.</param>
+    /// <returns>SDK feature query response.</returns>
+    public static QueryFeaturesResponse FromProto(Proto.QueryFeaturesResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return ProtoAdapter.FromProtoResponse(response);
+    }
+
+    /// <summary>
+    /// Converts a canonical protobuf streaming feature page to the SDK feature page model.
+    /// </summary>
+    /// <param name="page">Canonical protobuf feature page.</param>
+    /// <returns>SDK feature page.</returns>
+    public static FeaturePage FromProto(Proto.FeaturePage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        return ProtoAdapter.FromProtoPage(page);
+    }
+
+    /// <summary>
+    /// Converts a feature edit request to the canonical protobuf edit request.
+    /// </summary>
+    /// <param name="request">SDK feature edit request.</param>
+    /// <returns>Canonical protobuf feature edit request.</returns>
+    public static Proto.ApplyEditsRequest ToProto(ApplyEditsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return ProtoAdapter.ToProtoApplyEditsRequest(request);
+    }
+
+    /// <summary>
+    /// Converts a canonical protobuf edit response to the SDK edit response model.
+    /// </summary>
+    /// <param name="response">Canonical protobuf feature edit response.</param>
+    /// <returns>SDK feature edit response.</returns>
+    public static ApplyEditsResponse FromProto(Proto.ApplyEditsResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return ProtoAdapter.FromProtoApplyEditsResponse(response);
+    }
+}

--- a/src/Honua.Sdk.Grpc/Conversion/ProtoAdapter.cs
+++ b/src/Honua.Sdk.Grpc/Conversion/ProtoAdapter.cs
@@ -211,6 +211,12 @@ internal static class ProtoAdapter
             case bool b:
                 attr.BoolValue = b;
                 break;
+            case DateTime dateTime:
+                attr.DatetimeValue = new DateTimeOffset(dateTime).ToUnixTimeMilliseconds();
+                break;
+            case DateTimeOffset dateTimeOffset:
+                attr.DatetimeValue = dateTimeOffset.ToUnixTimeMilliseconds();
+                break;
             case byte[] bytes:
                 attr.BytesValue = Google.Protobuf.ByteString.CopyFrom(bytes);
                 break;
@@ -267,7 +273,7 @@ internal static class ProtoAdapter
             Proto.AttributeValue.ValueOneofCase.DoubleValue => attr.DoubleValue,
             Proto.AttributeValue.ValueOneofCase.FloatValue => (double)attr.FloatValue,
             Proto.AttributeValue.ValueOneofCase.BoolValue => attr.BoolValue,
-            Proto.AttributeValue.ValueOneofCase.DatetimeValue => attr.DatetimeValue,
+            Proto.AttributeValue.ValueOneofCase.DatetimeValue => DateTimeOffset.FromUnixTimeMilliseconds(attr.DatetimeValue).DateTime,
             Proto.AttributeValue.ValueOneofCase.BytesValue => attr.BytesValue.ToByteArray(),
             Proto.AttributeValue.ValueOneofCase.NullValue => null,
             Proto.AttributeValue.ValueOneofCase.None => null,

--- a/tests/Honua.Sdk.Grpc.Tests/Fixtures/GrpcFixtureReader.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/Fixtures/GrpcFixtureReader.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Grpc.Tests.Fixtures;
+
+internal static class GrpcFixtureReader
+{
+    public static string ReadJson(string fileName)
+        => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Json", fileName));
+}

--- a/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/apply-edits-request.json
+++ b/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/apply-edits-request.json
@@ -1,0 +1,41 @@
+{
+  "serviceId": "parks",
+  "layerId": 2,
+  "adds": [
+    {
+      "attributes": {
+        "name": {
+          "stringValue": "New Park"
+        },
+        "active": {
+          "boolValue": true
+        },
+        "opened_at": {
+          "datetimeValue": "1700000000000"
+        }
+      },
+      "geometry": {
+        "point": {
+          "x": -157.85,
+          "y": 21.3
+        }
+      }
+    }
+  ],
+  "updates": [
+    {
+      "id": "77",
+      "attributes": {
+        "name": {
+          "stringValue": "Renamed Park"
+        }
+      }
+    }
+  ],
+  "deletes": [
+    "88",
+    "89"
+  ],
+  "rollbackOnFailure": true,
+  "forceWrite": true
+}

--- a/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/apply-edits-response.json
+++ b/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/apply-edits-response.json
@@ -1,0 +1,27 @@
+{
+  "addResults": [
+    {
+      "objectId": "101",
+      "success": true
+    }
+  ],
+  "updateResults": [
+    {
+      "objectId": "102",
+      "error": {
+        "code": 409,
+        "message": "Edit conflict"
+      }
+    }
+  ],
+  "deleteResults": [
+    {
+      "objectId": "103",
+      "success": true
+    }
+  ],
+  "error": {
+    "code": 400,
+    "message": "Batch rejected"
+  }
+}

--- a/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/query-features-request.json
+++ b/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/query-features-request.json
@@ -1,0 +1,72 @@
+{
+  "serviceId": "parks",
+  "layerId": 2,
+  "where": "status = 'open'",
+  "objectIds": [
+    "101",
+    "102"
+  ],
+  "outFields": [
+    "name",
+    "status",
+    "opened_at"
+  ],
+  "returnGeometry": true,
+  "outSr": {
+    "wkid": 3857,
+    "latestWkid": 3857
+  },
+  "resultOffset": 5,
+  "resultRecordCount": 25,
+  "orderBy": "name ASC",
+  "returnDistinct": true,
+  "outStatistics": [
+    {
+      "onStatisticField": "visitors",
+      "statisticType": "STATISTIC_TYPE_SUM",
+      "outStatisticFieldName": "total_visitors"
+    }
+  ],
+  "groupBy": [
+    "status"
+  ],
+  "geometryPrecision": 6,
+  "maxAllowableOffset": 0.25,
+  "spatialFilter": {
+    "geometry": {
+      "polygon": {
+        "rings": [
+          {
+            "coords": [
+              {
+                "x": -123.5,
+                "y": 37.5
+              },
+              {
+                "x": -122.5,
+                "y": 37.5
+              },
+              {
+                "x": -122.5,
+                "y": 38.5
+              },
+              {
+                "x": -123.5,
+                "y": 38.5
+              },
+              {
+                "x": -123.5,
+                "y": 37.5
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "spatialRelationship": "SPATIAL_RELATIONSHIP_INTERSECTS",
+    "spatialReference": {
+      "wkid": 4326
+    },
+    "distanceUnit": "DISTANCE_UNIT_METERS"
+  }
+}

--- a/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/query-features-response.json
+++ b/tests/Honua.Sdk.Grpc.Tests/Fixtures/Json/query-features-response.json
@@ -1,0 +1,50 @@
+{
+  "objectIdFieldName": "OBJECTID",
+  "geometryType": "GEOMETRY_TYPE_POINT",
+  "spatialReference": {
+    "wkid": 4326,
+    "latestWkid": 4326
+  },
+  "fields": [
+    {
+      "name": "OBJECTID",
+      "fieldType": "FIELD_TYPE_INTEGER",
+      "nullable": false
+    },
+    {
+      "name": "name",
+      "fieldType": "FIELD_TYPE_STRING",
+      "length": 128,
+      "nullable": true
+    },
+    {
+      "name": "opened_at",
+      "fieldType": "FIELD_TYPE_DATE_TIME",
+      "nullable": true
+    }
+  ],
+  "features": [
+    {
+      "id": "101",
+      "attributes": {
+        "name": {
+          "stringValue": "Ala Moana Regional Park"
+        },
+        "visitors": {
+          "int64Value": "2500"
+        },
+        "opened_at": {
+          "datetimeValue": "1700000000000"
+        }
+      },
+      "geometry": {
+        "point": {
+          "x": -157.849,
+          "y": 21.291
+        }
+      }
+    }
+  ],
+  "exceededTransferLimit": true,
+  "count": "1"
+}

--- a/tests/Honua.Sdk.Grpc.Tests/GrpcContractFixtureTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/GrpcContractFixtureTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Google.Protobuf;
+using Honua.Sdk.Grpc.Conversion;
+using Honua.Sdk.Grpc.Models;
+using Honua.Sdk.Grpc.Tests.Fixtures;
+using Proto = Geospatial.V1;
+
+namespace Honua.Sdk.Grpc.Tests;
+
+public class GrpcContractFixtureTests
+{
+    [Fact]
+    public void QueryFeaturesRequestFixture_MatchesPublicProtoConverter()
+    {
+        var sdkRequest = new QueryFeaturesRequest
+        {
+            ServiceId = "parks",
+            LayerId = 2,
+            Where = "status = 'open'",
+            ObjectIds = [101, 102],
+            OutFields = ["name", "status", "opened_at"],
+            ReturnGeometry = true,
+            OutSr = new SpatialReference { Wkid = 3857, LatestWkid = 3857 },
+            ResultOffset = 5,
+            ResultRecordCount = 25,
+            OrderBy = "name ASC",
+            ReturnDistinct = true,
+            OutStatistics =
+            [
+                new StatisticDefinition
+                {
+                    OnStatisticField = "visitors",
+                    StatisticType = StatisticType.Sum,
+                    OutStatisticFieldName = "total_visitors",
+                },
+            ],
+            GroupBy = ["status"],
+            GeometryPrecision = 6,
+            MaxAllowableOffset = 0.25,
+            SpatialFilter = new SpatialFilter
+            {
+                Geometry = new Dictionary<string, object?>
+                {
+                    ["rings"] = new List<object?>
+                    {
+                        new List<object?>
+                        {
+                            new List<object?> { -123.5, 37.5 },
+                            new List<object?> { -122.5, 37.5 },
+                            new List<object?> { -122.5, 38.5 },
+                            new List<object?> { -123.5, 38.5 },
+                            new List<object?> { -123.5, 37.5 },
+                        },
+                    },
+                },
+                SpatialRelationship = SpatialRelationship.Intersects,
+                SpatialReference = new SpatialReference { Wkid = 4326 },
+                DistanceUnit = DistanceUnit.Meters,
+            },
+        };
+
+        var expected = ParseProto<Proto.QueryFeaturesRequest>("query-features-request.json");
+
+        Assert.Equal(expected, HonuaGrpcProtoConverter.ToProto(sdkRequest));
+    }
+
+    [Fact]
+    public void QueryFeaturesResponseFixture_MatchesPublicProtoConverter()
+    {
+        var protoResponse = ParseProto<Proto.QueryFeaturesResponse>("query-features-response.json");
+
+        var response = HonuaGrpcProtoConverter.FromProto(protoResponse);
+
+        Assert.Equal("OBJECTID", response.ObjectIdFieldName);
+        Assert.Equal(GeometryType.Point, response.GeometryType);
+        Assert.Equal(4326, response.SpatialReference?.Wkid);
+        Assert.Equal(4326, response.SpatialReference?.LatestWkid);
+        Assert.Equal(3, response.Fields.Count);
+        Assert.Equal(FieldType.DateTime, response.Fields[2].FieldType);
+        Assert.Single(response.Features);
+        Assert.Equal(101, response.Features[0].Id);
+        Assert.Equal("Ala Moana Regional Park", response.Features[0].Attributes["name"]);
+        Assert.Equal(2500L, response.Features[0].Attributes["visitors"]);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000000L).DateTime, response.Features[0].Attributes["opened_at"]);
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.Point, protoResponse.Features[0].Geometry.ShapeCase);
+        Assert.True(response.ExceededTransferLimit);
+        Assert.Equal(1, response.Count);
+    }
+
+    [Fact]
+    public void ApplyEditsRequestFixture_MatchesPublicProtoConverter()
+    {
+        var openedAt = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000L);
+        var sdkRequest = new ApplyEditsRequest
+        {
+            ServiceId = "parks",
+            LayerId = 2,
+            Adds =
+            [
+                new Feature
+                {
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = "New Park",
+                        ["active"] = true,
+                        ["opened_at"] = openedAt,
+                    },
+                    Geometry = new Dictionary<string, object?>
+                    {
+                        ["x"] = -157.85,
+                        ["y"] = 21.3,
+                    },
+                },
+            ],
+            Updates =
+            [
+                new Feature
+                {
+                    Id = 77,
+                    Attributes = new Dictionary<string, object?>
+                    {
+                        ["name"] = "Renamed Park",
+                    },
+                },
+            ],
+            Deletes = [88, 89],
+            RollbackOnFailure = true,
+            ForceWrite = true,
+        };
+
+        var expected = ParseProto<Proto.ApplyEditsRequest>("apply-edits-request.json");
+
+        Assert.Equal(expected, HonuaGrpcProtoConverter.ToProto(sdkRequest));
+    }
+
+    [Fact]
+    public void ApplyEditsResponseFixture_MatchesPublicProtoConverter()
+    {
+        var protoResponse = ParseProto<Proto.ApplyEditsResponse>("apply-edits-response.json");
+
+        var response = HonuaGrpcProtoConverter.FromProto(protoResponse);
+
+        Assert.Single(response.AddResults);
+        Assert.True(response.AddResults[0].Success);
+        Assert.Equal(101, response.AddResults[0].ObjectId);
+        Assert.Single(response.UpdateResults);
+        Assert.False(response.UpdateResults[0].Success);
+        Assert.Equal(409, response.UpdateResults[0].Error?.Code);
+        Assert.Equal("Edit conflict", response.UpdateResults[0].Error?.Message);
+        Assert.Single(response.DeleteResults);
+        Assert.True(response.DeleteResults[0].Success);
+        Assert.Equal(400, response.Error?.Code);
+        Assert.Equal("Batch rejected", response.Error?.Message);
+    }
+
+    private static T ParseProto<T>(string fileName)
+        where T : IMessage<T>, new()
+    {
+        var parser = new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(false));
+        return parser.Parse<T>(GrpcFixtureReader.ReadJson(fileName));
+    }
+}

--- a/tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj
+++ b/tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\..\src\Honua.Sdk.Grpc\Honua.Sdk.Grpc.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Fixtures\Json\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Honua.Sdk.Grpc.Tests/ProtoAdapterTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/ProtoAdapterTests.cs
@@ -430,11 +430,26 @@ public class ProtoAdapterTests
     }
 
     [Fact]
-    public void ConvertAttribute_DatetimeValue_ReturnsLong()
+    public void ConvertAttribute_DatetimeValue_ReturnsDateTime()
     {
         var attr = new Proto.AttributeValue { DatetimeValue = 1700000000000L };
         var result = ProtoAdapter.ConvertAttribute(attr);
-        Assert.Equal(1700000000000L, result);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1700000000000L).DateTime, result);
+    }
+
+    [Fact]
+    public void ConvertAttributeToProto_DateTimeValues_ReturnDatetimeValue()
+    {
+        var dateTimeOffset = DateTimeOffset.FromUnixTimeMilliseconds(1700000000000L);
+        var dateTime = dateTimeOffset.UtcDateTime;
+
+        var fromDateTime = ProtoAdapter.ConvertAttributeToProto(dateTime);
+        var fromDateTimeOffset = ProtoAdapter.ConvertAttributeToProto(dateTimeOffset);
+
+        Assert.Equal(Proto.AttributeValue.ValueOneofCase.DatetimeValue, fromDateTime.ValueCase);
+        Assert.Equal(1700000000000L, fromDateTime.DatetimeValue);
+        Assert.Equal(Proto.AttributeValue.ValueOneofCase.DatetimeValue, fromDateTimeOffset.ValueCase);
+        Assert.Equal(1700000000000L, fromDateTimeOffset.DatetimeValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Starts the SDK-side slice for honua-io/honua-sdk-dotnet#73.

- Adds a public `HonuaGrpcProtoConverter` facade so consuming repos can use the SDK-owned conversion boundary instead of copying internal gRPC adapter code.
- Aligns SDK datetime attribute conversion with the server transport converter behavior by mapping protobuf `datetime_value` to `DateTime` and `DateTime`/`DateTimeOffset` back to protobuf milliseconds.
- Adds gRPC JSON fixture tests for query requests, query responses, apply-edits requests, apply-edits responses, spatial reference handling, datetime attributes, and edit errors.
- Documents the server transport inventory and migration targets, with server runtime mapping staying in `honua-server` and canonical proto ownership staying in `geospatial-grpc`.

## Related

- Part of honua-io/honua-sdk-dotnet#73
- Companion server cleanup: honua-io/honua-server#854
- Canonical proto source: honua-io/geospatial-grpc#12

## Validation

- `dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release`
- `dotnet test Honua.Sdk.sln --configuration Release`
- `scripts/validate-api-compat.sh origin/trunk`
- `git diff --check`