### PR TITLE
Add browser WASM support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,31 @@ jobs:
       - name: Test
         run: dotnet test tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
 
+  browser-wasm-smoke:
+    name: Browser WASM Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ github.repository }}-${{ runner.os }}-nuget-
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Configure GitHub Packages
+        run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Build browser smoke app
+        run: dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
+
   dotnet-admin-bootstrap-sample:
     name: Admin Bootstrap Sample
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ through GeoServices FeatureServer and OGC API Features endpoints.
 | **Honua.Sdk.OgcFeatures** | OGC API Features read/query client -- landing page, conformance, collections, queryables, items |
 | *Geocoding* (in Admin) | Forward/reverse geocoding and autocomplete via `IHonuaGeocodingClient` |
 
+Browser and WebAssembly consumers should start with
+[docs/browser-wasm-support.md](docs/browser-wasm-support.md). The browser-safe
+surface is contracts plus REST clients over browser `HttpClient`; native gRPC,
+local storage engines, background schedulers, and display renderers stay out of
+SDK core.
+
 ## Install
 
 ```bash

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -49,6 +49,14 @@ application-owned stores:
 The SDK does not persist credentials. Provider delegates should read from your
 secure store or token cache and return the current API key or bearer token.
 
+Browser and Blazor WebAssembly apps need a stricter boundary: every value in
+static browser configuration is visible to clients. Do not ship privileged
+admin API keys, refresh tokens, client secrets, or server-side service tokens in
+`wwwroot`, environment-generated static assets, or downloaded appsettings
+files. Browser hosts should use delegated user bearer tokens, a same-origin
+BFF that injects privileged credentials server-side, or another application-
+owned auth flow that never exposes server-only secrets to JavaScript or WASM.
+
 ## Rotation and Revocation
 
 Use providers when credentials can change while the process is running. A

--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -1,0 +1,55 @@
+# Browser And WebAssembly Support
+
+This matrix defines what `honua-sdk-dotnet` considers browser-safe today. The
+line is intentionally conservative: DTOs, abstractions, and REST clients that
+run through the host's browser `HttpClient` are candidates; native transport,
+local storage engines, background schedulers, certificate stores, and display
+rendering stay in host applications or downstream adapter packages.
+
+## Support Matrix
+
+| Package or capability | Browser/WASM status | Notes |
+| --- | --- | --- |
+| `Honua.Sdk.Abstractions` | Supported | Pure contracts and source/query/edit abstractions. No transport, storage, or native runtime dependency. |
+| `Honua.Sdk.Offline.Abstractions` | Supported | Offline manifests, checkpoints, sync state, change journals, storage interfaces, and conflict contracts only. |
+| `Honua.Sdk.Offline` | Conditional | Planner and sync engine are portable, but the host must provide browser-safe storage, scheduling, conflict-review, and auth adapters. This package is not a GeoPackage, SQLite, service-worker, or background-sync implementation. |
+| `Honua.Sdk.Admin` | Candidate | REST client over injected `HttpClient`. Browser hosts must use same-origin/BFF credentials or delegated bearer tokens, and the server must allow the required CORS policy when cross-origin. Static privileged admin API keys must not be shipped in browser config. |
+| Geocoding client in `Honua.Sdk.Admin` | Candidate | Same REST, CORS, and browser credential requirements as `Honua.Sdk.Admin`. |
+| `Honua.Sdk.Spec` | Candidate | REST validation/plan/cancel paths are browser candidates. Apply streaming uses SSE-style responses and still needs runtime validation under Blazor WebAssembly before being called supported. |
+| `Honua.Sdk.Wfs` | Candidate | REST/XML/GeoJSON client over browser `HttpClient`; requires server CORS and browser-owned auth. |
+| `Honua.Sdk.GeoServices` | Candidate | REST/JSON FeatureServer client over browser `HttpClient`; requires server CORS and browser-owned auth. |
+| `Honua.Sdk.OgcFeatures` | Candidate | REST/JSON OGC API Features client over browser `HttpClient`; requires server CORS and browser-owned auth. |
+| `Honua.Sdk.Grpc` | Not supported for browser runtime | Native gRPC/HTTP2 is not a supported browser path. Treat current browser builds as compile-only. Add gRPC-Web support only after `honua-server` exposes a compatible endpoint and the SDK has a browser-specific transport plan. |
+| Routing, scene metadata, realtime feeds, field forms, plugins | Not implemented | Future packages should split pure contracts from runtime adapters and update this matrix before browser consumption. |
+| Display/maps | Out of SDK core | MapLibre/deck.gl, Cesium, Mapsui, renderer caches, controls, and AR/VR anchors belong in viewer/mobile/admin apps or display adapter packages. SDK packages should hand back portable data/contracts. |
+
+## Explicit Browser Exclusions
+
+Do not add these directly to browser-safe SDK packages:
+
+- GeoPackage or SQLite engines;
+- direct filesystem or OS secure-store access;
+- native background schedulers, MAUI lifecycle hooks, or platform services;
+- client certificate authentication or OS certificate-store discovery;
+- raw sockets or native gRPC/HTTP2 browser assumptions;
+- map rendering, scene rendering, or display state.
+
+Browser implementations can still use SDK contracts by supplying their own
+adapters, such as IndexedDB storage behind `IOfflineFeatureStore` or a BFF that
+injects privileged admin credentials server-side.
+
+## Validation Gates
+
+The SDK keeps a Blazor WebAssembly compile smoke in
+`tests/Honua.Sdk.BrowserSmoke`. It references the supported/candidate browser
+packages and registers the REST clients with retry disabled. That gate proves
+the packages can be consumed by a browser app without native compile-time
+dependencies.
+
+Runtime validation still belongs to the consuming app or a follow-up SDK sample:
+
+- browser `HttpClient` requests against a real or fake Honua server;
+- cross-origin CORS behavior where the deployment is not same-origin;
+- delegated bearer-token or BFF authentication;
+- `Honua.Sdk.Spec` apply-stream behavior;
+- offline storage adapters such as IndexedDB.

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -2,6 +2,8 @@
 
 This page documents the cross-cutting behavior that applies to the Honua SDK
 clients: timeouts, retries, errors, pagination, and current endpoint coverage.
+Runtime support is tracked separately in
+[Browser And WebAssembly Support](browser-wasm-support.md).
 
 ## Timeouts and cancellation
 

--- a/docs/cross-repo-sdk-sequencing.md
+++ b/docs/cross-repo-sdk-sequencing.md
@@ -87,6 +87,11 @@ Foundation work should land before repo cutovers:
 - Server transport alignment: https://github.com/honua-io/honua-sdk-dotnet/issues/73
 - Browser/WASM matrix: https://github.com/honua-io/honua-sdk-dotnet/issues/62
 
+The browser/WASM package boundary lives in
+[Browser And WebAssembly Support](browser-wasm-support.md). Browser consumers
+should treat REST packages as candidates until runtime `HttpClient`, CORS, and
+auth validation exists in the consuming app.
+
 The SDK-side server transport inventory and first converter fixture slice lives
 in [Server Transport Ownership](server-transport-ownership.md).
 

--- a/tests/Honua.Sdk.BrowserSmoke/App.razor
+++ b/tests/Honua.Sdk.BrowserSmoke/App.razor
@@ -1,0 +1,7 @@
+@using Honua.Sdk.Offline.Abstractions
+@inject OfflinePackageManifest Manifest
+
+<main>
+    <h1>Honua SDK browser smoke</h1>
+    <p>@Manifest.PackageId</p>
+</main>

--- a/tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj
+++ b/tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Honua.Sdk.BrowserSmoke</RootNamespace>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Admin\Honua.Sdk.Admin.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.GeoServices\Honua.Sdk.GeoServices.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Offline.Abstractions\Honua.Sdk.Offline.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Offline\Honua.Sdk.Offline.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.OgcFeatures\Honua.Sdk.OgcFeatures.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Spec\Honua.Sdk.Spec.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Wfs\Honua.Sdk.Wfs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Sdk.BrowserSmoke/Program.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/Program.cs
@@ -1,0 +1,126 @@
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Admin;
+using Honua.Sdk.Admin.Extensions;
+using Honua.Sdk.BrowserSmoke;
+using Honua.Sdk.GeoServices;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.Offline;
+using Honua.Sdk.Offline.Abstractions;
+using Honua.Sdk.OgcFeatures;
+using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.Spec;
+using Honua.Sdk.Spec.Extensions;
+using Honua.Sdk.Wfs;
+using Honua.Sdk.Wfs.Extensions;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+
+var server = new Uri("https://honua.example.test/");
+ConfigureRestClients(builder.Services, server);
+RegisterOfflineContracts(builder.Services);
+
+await builder.Build().RunAsync().ConfigureAwait(false);
+
+static void ConfigureRestClients(IServiceCollection services, Uri server)
+{
+    services.AddHonuaAdmin(options =>
+    {
+        ConfigureAdminBrowserCandidate(options, server);
+    });
+    services.AddHonuaGeocoding(options =>
+    {
+        ConfigureAdminBrowserCandidate(options, server);
+    });
+    services.AddHonuaSpec(options =>
+    {
+        ConfigureSpecBrowserCandidate(options, server);
+    });
+    services.AddHonuaWfs(options =>
+    {
+        ConfigureWfsBrowserCandidate(options, server);
+    });
+    services.AddHonuaFeatureServer(options =>
+    {
+        ConfigureGeoServicesBrowserCandidate(options, server);
+    });
+    services.AddHonuaOgcFeatures(options =>
+    {
+        ConfigureOgcFeaturesBrowserCandidate(options, server);
+    });
+}
+
+static void ConfigureAdminBrowserCandidate(HonuaAdminClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
+static void ConfigureSpecBrowserCandidate(HonuaSpecClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
+static void ConfigureWfsBrowserCandidate(HonuaWfsClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
+static void ConfigureGeoServicesBrowserCandidate(HonuaGeoServicesClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
+static void ConfigureOgcFeaturesBrowserCandidate(HonuaOgcFeaturesClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
+static Task<string?> NoBrowserTokenAsync(CancellationToken cancellationToken)
+{
+    cancellationToken.ThrowIfCancellationRequested();
+    return Task.FromResult<string?>(null);
+}
+
+static void RegisterOfflineContracts(IServiceCollection services)
+{
+    var source = new SourceDescriptor
+    {
+        Id = "parks",
+        Protocol = FeatureProtocolIds.OgcFeatures,
+        Locator = new SourceLocator { CollectionId = "parks" },
+    };
+
+    var manifest = new OfflinePackageManifest
+    {
+        PackageId = "browser-smoke",
+        DisplayName = "Browser smoke",
+        Sources =
+        [
+            new OfflineSourceDescriptor
+            {
+                SourceId = "parks",
+                Source = source,
+                Where = "status = 'open'",
+                FilterLanguage = FeatureFilterLanguage.Cql2Text,
+                OutFields = ["name", "status"],
+                PageSize = 100,
+            },
+        ],
+    };
+
+    services.AddSingleton(source);
+    services.AddSingleton(manifest);
+    services.AddSingleton(new OfflineSyncEngineOptions());
+}

--- a/tests/Honua.Sdk.BrowserSmoke/wwwroot/index.html
+++ b/tests/Honua.Sdk.BrowserSmoke/wwwroot/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Honua SDK browser smoke</title>
+</head>
+<body>
+    <div id="app">Loading...</div>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an explicit browser/WASM support matrix for SDK packages and exclusions
- add a Blazor WebAssembly compile-smoke app for browser-safe/candidate REST and contract packages
- add a targeted CI job for the browser smoke build without native gRPC/runtime storage assumptions

## Validation
- dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet format tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --verify-no-changes --verbosity minimal
- git diff --check

Refs #62