### PR TITLE
Add mobile contract harmonization fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,9 @@ third_party/
   pagination, and typed endpoint coverage behavior across packages
 - **[Spec Workspace Contracts](docs/spec-workspace-contracts.md)** -- package
   ownership, repo boundaries, and JSON fixtures for spec plan/apply contracts
+- **[Mobile Contract Harmonization](docs/mobile-contract-harmonization.md)** --
+  ownership map and fixture baseline for moving reusable mobile contracts to
+  published `Honua.Sdk.*` packages
 - **[Release and NuGet Publishing](docs/release.md)** -- package versioning,
   release tags, dry runs, and GitHub Packages publishing
 - **[INSTALL.md](INSTALL.md)** -- NuGet and GitHub Packages setup, version

--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -1,0 +1,283 @@
+{
+  "schemaVersion": "honua.mobile-contract-harmonization.v1",
+  "sdkIssue": "honua-sdk-dotnet#68",
+  "mobileIssue": "honua-mobile#48",
+  "status": "baseline",
+  "compatibility": {
+    "mobileBaseline": {
+      "repository": "honua-io/honua-mobile",
+      "ref": "main after honua-mobile#52",
+      "packageVersion": "unreleased-source"
+    },
+    "sdkBaseline": {
+      "repository": "honua-io/honua-sdk-dotnet",
+      "ref": "trunk",
+      "packages": [
+        {
+          "packageId": "Honua.Sdk.Abstractions",
+          "version": "0.1.2-alpha.1"
+        },
+        {
+          "packageId": "Honua.Sdk.Offline.Abstractions",
+          "version": "0.1.2-alpha.1"
+        },
+        {
+          "packageId": "Honua.Sdk.Offline",
+          "version": "0.1.2-alpha.1"
+        },
+        {
+          "packageId": "Honua.Sdk.Grpc",
+          "version": "0.1.2-alpha.1"
+        },
+        {
+          "packageId": "Honua.Sdk.GeoServices",
+          "version": "0.1.2-alpha.1"
+        },
+        {
+          "packageId": "Honua.Sdk.OgcFeatures",
+          "version": "0.1.2-alpha.1"
+        }
+      ]
+    }
+  },
+  "rules": [
+    "Sibling repos consume Honua.Sdk.* through published NuGet packages.",
+    "Do not copy SDK source into honua-mobile.",
+    "Do not add long-lived honua-mobile ProjectReference links to SDK projects.",
+    "Canonical proto definitions stay in geospatial-grpc.",
+    "Mobile owns MAUI, native storage, background scheduling, device services, display adapters, and renderer caches.",
+    "SDK owns provider-neutral contracts, portable clients, and host-neutral test fixtures."
+  ],
+  "modelFamilies": [
+    {
+      "id": "feature-query",
+      "displayName": "Feature query requests and result pages",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureQueryRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureQueryResult",
+        "Honua.Sdk.Abstractions.Features.FeatureRecord",
+        "Honua.Sdk.Abstractions.Features.FeatureSource",
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceQuery"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.QueryFeaturesRequest",
+        "Honua.Mobile.Sdk.Models.OgcItemsRequest",
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator"
+      ],
+      "mobileDisposition": "adapter-required",
+      "migrationIssue": "honua-mobile#54",
+      "notes": "Mobile request DTOs remain transport shims until callers construct Honua.Sdk.Abstractions feature queries directly."
+    },
+    {
+      "id": "feature-edit",
+      "displayName": "Feature edit envelopes and results",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.FeatureEditRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResponse",
+        "Honua.Sdk.Abstractions.Features.FeatureEditFeature",
+        "Honua.Sdk.Abstractions.Features.FeatureEditResult",
+        "Honua.Sdk.Abstractions.Features.FeatureEditError"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Models.ApplyEditsRequest",
+        "Honua.Mobile.Sdk.Models.OgcCreateItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcReplaceItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcPatchItemRequest",
+        "Honua.Mobile.Sdk.Models.OgcDeleteItemRequest",
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation"
+      ],
+      "mobileDisposition": "adapter-required",
+      "migrationIssue": "honua-mobile#54",
+      "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+    },
+    {
+      "id": "geometry",
+      "displayName": "Geometry and spatial reference values",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk geometry contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Grpc.GrpcFeatureTranslator",
+        "Honua.Mobile.Sdk.Routing.RoutingCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaMapCoordinate",
+        "Honua.Mobile.Maui.Annotations.HonuaAnnotationBounds"
+      ],
+      "mobileDisposition": "quarantine-until-sdk-geometry",
+      "migrationIssue": "honua-sdk-dotnet#55",
+      "notes": "Keep mobile coordinates at platform edges. Shared geometry should graduate through SDK contracts backed by NetTopologySuite and ProjNet where possible."
+    },
+    {
+      "id": "offline-sync-state",
+      "displayName": "Offline package, sync state, journal, and conflict state",
+      "owner": "shared-split",
+      "authoritativePackage": "Honua.Sdk.Offline.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Offline.Abstractions.OfflinePackageManifest",
+        "Honua.Sdk.Offline.Abstractions.OfflineSourceDescriptor",
+        "Honua.Sdk.Offline.Abstractions.OfflineSyncState",
+        "Honua.Sdk.Offline.Abstractions.OfflineSyncCheckpoint",
+        "Honua.Sdk.Offline.Abstractions.OfflineChangeJournalEntry",
+        "Honua.Sdk.Offline.Abstractions.OfflineConflictEnvelope",
+        "Honua.Sdk.Offline.Abstractions.OfflineRetryCheckpoint"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.GeoPackage.OfflineEditOperation",
+        "Honua.Mobile.Offline.GeoPackage.GeoPackageSdkOfflineStoreAdapter",
+        "Honua.Mobile.Offline.Sync.HonuaMobileSdkFeatureClient",
+        "Honua.Mobile.Offline.Sync.SdkOfflineSyncRunner",
+        "Honua.Mobile.Offline.Sync.SyncRunResult",
+        "Honua.Mobile.Offline.Sync.SyncFailure",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadOptions",
+        "Honua.Mobile.Offline.Sync.DeltaDownloadResult"
+      ],
+      "mobileDisposition": "mobile-runtime-adapter",
+      "migrationIssue": "honua-mobile#49",
+      "serverDependencyIssues": [
+        "honua-server#830",
+        "honua-server#831",
+        "honua-server#371"
+      ],
+      "notes": "Mobile owns native queue persistence, scheduling, and GeoPackage storage. SDK contracts define source descriptors, journals, checkpoints, retry checkpoints, and conflict envelopes."
+    },
+    {
+      "id": "form-feature-schema",
+      "displayName": "Form-related feature schemas and field workflows",
+      "owner": "shared-split",
+      "authoritativePackage": "Honua.Sdk.Abstractions for source schema; pending Honua.Sdk.Field for workflow contracts",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.SourceDescriptor",
+        "Honua.Sdk.Abstractions.Features.SourceSchema",
+        "Honua.Sdk.Abstractions.Features.SourceField"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Field.Forms.FormDefinition",
+        "Honua.Mobile.Field.Forms.FormField",
+        "Honua.Mobile.Field.Forms.FormValidation",
+        "Honua.Mobile.Field.Records.FieldRecord",
+        "Honua.Mobile.Field.Records.RecordWorkflow"
+      ],
+      "mobileDisposition": "mobile-workflow-owned",
+      "migrationIssue": "honua-sdk-dotnet#71",
+      "notes": "SDK source schema owns provider-neutral field metadata. Mobile owns device form rendering, calculated fields, duplicate detection, and capture workflow until field contracts graduate."
+    },
+    {
+      "id": "scene-metadata",
+      "displayName": "3D scene metadata and offline scene packages",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk.Scene contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveRequest",
+        "Honua.Mobile.Sdk.Scenes.HonuaSceneResolveResult",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageManifest",
+        "Honua.Mobile.Sdk.Scenes.HonuaScenePackageAsset",
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileDisposition": "mobile-authoritative-until-sdk-scene",
+      "migrationIssue": "honua-sdk-dotnet#70",
+      "serverDependencyIssues": [
+        "honua-server#530",
+        "honua-server#837",
+        "honua-server#838",
+        "honua-server#839",
+        "honua-server#840",
+        "honua-server#841",
+        "honua-server#842",
+        "honua-server#843",
+        "honua-server#844",
+        "honua-server#849"
+      ],
+      "notes": "Scene manifests should become portable SDK contracts once server scene APIs stabilize. Mobile and embed own renderer caches, downloads, and display execution."
+    },
+    {
+      "id": "routing",
+      "displayName": "Routing and network analysis requests",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk.Routing contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Routing.RouteDirectionsRequest",
+        "Honua.Mobile.Sdk.Routing.RouteOptimizationRequest",
+        "Honua.Mobile.Sdk.Routing.ServiceAreaRequest",
+        "Honua.Mobile.Sdk.Routing.ClosestFacilityRequest",
+        "Honua.Mobile.Sdk.Routing.RoutingLocation",
+        "Honua.Mobile.Sdk.Routing.HonuaRoutingClient",
+        "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider"
+      ],
+      "mobileDisposition": "mobile-authoritative-until-sdk-routing",
+      "migrationIssue": "honua-sdk-dotnet#60",
+      "serverDependencyIssues": [
+        "honua-server#366"
+      ],
+      "notes": "Routing contracts can move to SDK; device location providers and platform permission flows stay mobile-owned."
+    },
+    {
+      "id": "geopackage-sync",
+      "displayName": "GeoPackage storage and native offline adapters",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Mobile.Offline",
+      "authoritativeTypes": [
+        "Honua.Mobile.Offline.GeoPackage.IGeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.GeoPackageSyncStore",
+        "Honua.Mobile.Offline.GeoPackage.MapAreaPackage",
+        "Honua.Mobile.Offline.GeoPackage.ScenePackageRecord"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Offline.MapAreas.IMapAreaDownloader",
+        "Honua.Mobile.Offline.ScenePackages.IHonuaScenePackageDownloader",
+        "Honua.Mobile.Offline.Sync.BackgroundSyncOrchestrator"
+      ],
+      "mobileDisposition": "mobile-runtime-owned",
+      "notes": "SDK contracts may describe offline packages and journals, but mobile owns MAUI/native storage, GeoPackage tables, and background execution behavior."
+    },
+    {
+      "id": "display-embed",
+      "displayName": "Map and 3D display adapters",
+      "owner": "honua-mobile",
+      "authoritativePackage": "Honua.Embed",
+      "authoritativeTypes": [
+        "Honua.Embed"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Maui",
+        "Honua.Embed"
+      ],
+      "mobileDisposition": "display-owned",
+      "notes": "SDK returns portable contracts only. MapLibre, deck.gl, Cesium, Mapsui, WebGL/WebGPU, map controls, and renderer lifecycle stay outside SDK core."
+    },
+    {
+      "id": "plugin-contracts",
+      "displayName": "Non-UI plugin manifests and workflow hooks",
+      "owner": "shared-split",
+      "authoritativePackage": "pending Honua.Sdk.Plugin contracts",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "Honua.Mobile plugin host contracts"
+      ],
+      "mobileDisposition": "host-runtime-owned-until-sdk-plugin",
+      "migrationIssue": "honua-sdk-dotnet#72",
+      "serverDependencyIssues": [
+        "honua-server#347"
+      ],
+      "notes": "SDK should own manifests, declared permissions, compatibility requirements, and safe configuration envelopes. Hosts own runtime loading, UI registration, sandboxing, and code signing."
+    },
+    {
+      "id": "legacy-mobile-sdk",
+      "displayName": "Legacy honua-mobile-sdk contracts",
+      "owner": "quarantine",
+      "authoritativePackage": "none",
+      "authoritativeTypes": [],
+      "mobileTypes": [
+        "honua-mobile-sdk generated clients and demo DTOs"
+      ],
+      "mobileDisposition": "quarantine",
+      "notes": "Do not copy DTOs into honua-mobile or SDK without assigning explicit ownership in this fixture."
+    }
+  ]
+}

--- a/docs/cross-repo-sdk-sequencing.md
+++ b/docs/cross-repo-sdk-sequencing.md
@@ -117,6 +117,12 @@ Reusable service clients/contracts move to SDK first:
 - Mobile umbrella: https://github.com/honua-io/honua-mobile/issues/48
 - Replace mobile SDK clients: https://github.com/honua-io/honua-mobile/issues/54
 
+The SDK-side ownership map and compatibility baseline live in
+[Mobile Contract Harmonization](mobile-contract-harmonization.md) and
+`contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`. Keep the SDK
+fixture aligned with the mobile fixture before moving shared contracts or
+deleting mobile DTO shims.
+
 ### Gate 6: Capability Packages
 
 These move after foundation contracts are stable:

--- a/docs/mobile-contract-harmonization.md
+++ b/docs/mobile-contract-harmonization.md
@@ -1,0 +1,67 @@
+# Mobile Contract Harmonization
+
+Issue #68 aligns `honua-sdk-dotnet` and `honua-mobile` around one contract
+vocabulary for reusable clients and host-neutral DTOs. The SDK-side baseline
+fixture is `contracts/fixtures/mobile-sdk-contract-harmonization.v1.json`.
+
+The fixture is plain JSON by design. Mobile, SDK, server, and admin repos can
+read the same ownership map without referencing each other's assemblies.
+
+## Compatibility Baseline
+
+| Mobile baseline | Shared SDK baseline | Status |
+|-----------------|---------------------|--------|
+| `honua-mobile` source packages from `main` after `honua-mobile#52` | `Honua.Sdk.*` `0.1.2-alpha.1` | Fixture-level compatibility for shared feature, source, edit, and offline contracts |
+
+`honua-mobile` does not currently publish versioned NuGet packages. Until it
+does, compatibility is stated as source-baseline compatibility against the
+published `Honua.Sdk.*` package versions in the fixture.
+
+## Ownership Summary
+
+| Model family | Owner | Mobile disposition |
+|--------------|-------|--------------------|
+| Feature query requests/results | `Honua.Sdk.Abstractions` | Mobile DTOs become transport shims or adapters. |
+| Feature edit envelopes/results | `Honua.Sdk.Abstractions` | Mobile edit DTOs and queued offline payloads map to SDK edit contracts. |
+| Geometry and spatial references | Split pending SDK geometry contracts | Keep platform coordinates at mobile edges; use NetTopologySuite and ProjNet rather than custom geometry engines where possible. |
+| Offline sync state, journals, conflicts | `Honua.Sdk.Offline.Abstractions` plus mobile runtime adapters | Mobile owns native queues, GeoPackage persistence, scheduling, and background execution. |
+| Form-related feature schemas | `Honua.Sdk.Abstractions` now; pending field package for workflow contracts | Mobile owns form rendering, validation UX, capture workflow, and device media handling. |
+| Scene metadata and offline scene packages | Pending SDK scene contracts after server dependencies | Mobile and embed own renderers, caches, downloads, and display lifecycle. |
+| Routing and network analysis | Pending SDK routing contracts after server dependency | Mobile owns device location providers and platform permission flows. |
+| GeoPackage sync and native storage | `honua-mobile` | SDK describes portable manifests and journals only. |
+| Display/embed maps | `honua-mobile` / `Honua.Embed` | SDK returns portable contracts only; MapLibre, deck.gl, Cesium, Mapsui, WebGL/WebGPU, and map controls stay outside SDK core. |
+| Non-UI plugin contracts | Pending SDK plugin contracts after server dependency | Hosts own runtime loading, UI registration, sandboxing, and signing. |
+| Legacy `honua-mobile-sdk` contracts | Quarantine | Migrate concepts only after the fixture assigns ownership. |
+
+## Migration Rules
+
+- New provider-neutral feature read code targets
+  `Honua.Sdk.Abstractions.Features.FeatureQueryRequest`,
+  `FeatureQueryResult`, `FeatureSource`, `SourceDescriptor`, and `SourceQuery`.
+- New provider-neutral feature edit code targets `FeatureEditRequest`,
+  `FeatureEditResponse`, and related edit result models.
+- New portable offline code targets `Honua.Sdk.Offline.Abstractions` for
+  manifests, source descriptors, change journal entries, checkpoints, retry
+  checkpoints, and conflict envelopes.
+- Sibling repos consume SDK contracts through published NuGet packages from
+  GitHub Packages. Do not copy SDK source and do not add long-lived project
+  references.
+- Canonical `.proto` definitions stay in `geospatial-grpc`; SDK and mobile
+  consume generated or published protocol bindings instead of redefining them.
+- Mobile-only APIs may keep MAUI, camera, GPS/location provider, native storage,
+  GeoPackage, background execution, route-location-provider, and display
+  concerns.
+- Any migrated SDK contract that requires backend behavior must link the
+  corresponding `honua-server` dependency issue before implementation starts.
+
+## Follow-Up Work
+
+- `honua-mobile#54` replaces `Honua.Mobile.Sdk` service clients with published
+  `Honua.Sdk.*` packages.
+- `honua-mobile#49` maps current mobile offline queues and GeoPackage state to
+  SDK offline contracts while keeping runtime storage in mobile.
+- `honua-sdk-dotnet#55` defines geometry ownership and should lean on
+  NetTopologySuite and ProjNet rather than custom geometry/projection code.
+- `honua-sdk-dotnet#60`, `#70`, `#71`, and `#72` graduate routing, scene, field,
+  and plugin contracts into SDK packages after linked server dependencies are
+  ready.

--- a/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
+++ b/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Offline.Abstractions\Honua.Sdk.Offline.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Honua.Sdk.Abstractions.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Reflection;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Offline.Abstractions;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class MobileContractHarmonizationFixtureTests
+{
+    private static readonly Assembly[] SdkContractAssemblies =
+    [
+        typeof(SourceDescriptor).Assembly,
+        typeof(OfflinePackageManifest).Assembly
+    ];
+
+    private static readonly string[] ExpectedModelFamilyIds =
+    [
+        "feature-query",
+        "feature-edit",
+        "geometry",
+        "offline-sync-state",
+        "form-feature-schema",
+        "scene-metadata",
+        "routing",
+        "geopackage-sync",
+        "display-embed",
+        "plugin-contracts",
+        "legacy-mobile-sdk"
+    ];
+
+    private static readonly string[] ExpectedSdkPackageIds =
+    [
+        "Honua.Sdk.Abstractions",
+        "Honua.Sdk.Offline.Abstractions",
+        "Honua.Sdk.Offline",
+        "Honua.Sdk.Grpc",
+        "Honua.Sdk.GeoServices",
+        "Honua.Sdk.OgcFeatures"
+    ];
+
+    [Fact]
+    public void Fixture_DefinesExpectedSchemaAndModelFamilies()
+    {
+        using var document = LoadFixture();
+        var root = document.RootElement;
+
+        Assert.Equal("honua.mobile-contract-harmonization.v1", root.GetProperty("schemaVersion").GetString());
+        Assert.Equal("honua-sdk-dotnet#68", root.GetProperty("sdkIssue").GetString());
+        Assert.Equal("honua-mobile#48", root.GetProperty("mobileIssue").GetString());
+
+        var familyIds = root
+            .GetProperty("modelFamilies")
+            .EnumerateArray()
+            .Select(family => family.GetProperty("id").GetString())
+            .ToArray();
+
+        Assert.Equal(ExpectedModelFamilyIds, familyIds);
+    }
+
+    [Fact]
+    public void Fixture_SdkOwnedAuthoritativeTypesResolveToCurrentAssemblies()
+    {
+        using var document = LoadFixture();
+
+        var unresolvedTypes = document.RootElement
+            .GetProperty("modelFamilies")
+            .EnumerateArray()
+            .Where(IsSdkOwnedFamily)
+            .SelectMany(GetAuthoritativeTypeNames)
+            .Where(typeName => ResolveSdkType(typeName) is null)
+            .ToArray();
+
+        Assert.Empty(unresolvedTypes);
+    }
+
+    [Fact]
+    public void Fixture_UsesCurrentSdkPackageBaseline()
+    {
+        using var document = LoadFixture();
+
+        var packages = document.RootElement
+            .GetProperty("compatibility")
+            .GetProperty("sdkBaseline")
+            .GetProperty("packages")
+            .EnumerateArray()
+            .Select(package => new
+            {
+                PackageId = package.GetProperty("packageId").GetString(),
+                Version = package.GetProperty("version").GetString()
+            })
+            .ToArray();
+
+        Assert.Equal(ExpectedSdkPackageIds, packages.Select(package => package.PackageId));
+        Assert.All(packages, package => Assert.Equal("0.1.2-alpha.1", package.Version));
+    }
+
+    private static bool IsSdkOwnedFamily(JsonElement family)
+    {
+        var owner = family.GetProperty("owner").GetString();
+        var package = family.GetProperty("authoritativePackage").GetString() ?? string.Empty;
+
+        return owner == "honua-sdk-dotnet" ||
+            package == "Honua.Sdk.Abstractions" ||
+            package == "Honua.Sdk.Offline.Abstractions" ||
+            package.StartsWith("Honua.Sdk.Abstractions ", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<string> GetAuthoritativeTypeNames(JsonElement family)
+    {
+        if (!family.TryGetProperty("authoritativeTypes", out var types))
+        {
+            return [];
+        }
+
+        return types
+            .EnumerateArray()
+            .Select(type => type.GetString())
+            .OfType<string>()
+            .Where(type => !string.IsNullOrWhiteSpace(type));
+    }
+
+    private static Type? ResolveSdkType(string typeName)
+        => SdkContractAssemblies
+            .Select(assembly => assembly.GetType(typeName, throwOnError: false))
+            .FirstOrDefault(type => type is not null);
+
+    private static JsonDocument LoadFixture()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "contracts",
+                "fixtures",
+                "mobile-sdk-contract-harmonization.v1.json");
+
+            if (File.Exists(candidate))
+            {
+                return JsonDocument.Parse(File.ReadAllText(candidate));
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not find the mobile contract harmonization fixture.");
+    }
+}


### PR DESCRIPTION
## Summary
- add the SDK-side mobile contract harmonization fixture for honua-sdk-dotnet#68
- document the mobile/SDK ownership map, NuGet baseline, proto ownership, and runtime/display boundaries
- add abstraction tests that validate fixture schema, SDK-owned type resolution, and the current 0.1.2-alpha.1 package baseline

## Validation
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet format tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --verify-no-changes --verbosity minimal
- git diff --check

Closes #68