### PR TITLE
feat: add feature REST parity knobs

### DIFF
--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -541,6 +541,15 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         if (query.ReturnDistinctValues is true)
             parameters.Add(("returnDistinctValues", "true"));
 
+        if (query.ReturnCountOnly is true)
+            parameters.Add(("returnCountOnly", "true"));
+
+        if (query.ReturnIdsOnly is true)
+            parameters.Add(("returnIdsOnly", "true"));
+
+        if (query.ReturnExtentOnly is true)
+            parameters.Add(("returnExtentOnly", "true"));
+
         return parameters;
     }
 
@@ -551,6 +560,11 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             ("f", "json"),
             ("rollbackOnFailure", request.RollbackOnFailure ? "true" : "false"),
         };
+
+        if (request.ForceWrite)
+        {
+            parameters.Add(("forceWrite", "true"));
+        }
 
         if (request.Adds is { Count: > 0 })
         {
@@ -700,17 +714,13 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         FeatureEditRequest request,
         string? objectIdField)
     {
-        if (request.ForceWrite)
-        {
-            throw new NotSupportedException("FeatureServer edits do not support force-write conflict overrides.");
-        }
-
         return new FeatureServerEditRequest
         {
             Adds = request.Adds.Select(feature => ToFeatureServerFeature(feature, objectIdField: null)).ToList(),
             Updates = request.Updates.Select(feature => ToFeatureServerFeature(feature, objectIdField)).ToList(),
             Deletes = ResolveDeleteObjectIds(request),
             RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
         };
     }
 

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerEditModels.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerEditModels.cs
@@ -21,6 +21,9 @@ public sealed class FeatureServerEditRequest
 
     /// <summary>Whether the server should roll back all edits if any individual edit fails.</summary>
     public bool RollbackOnFailure { get; init; } = true;
+
+    /// <summary>Whether the server should force conflict-overriding writes when supported.</summary>
+    public bool ForceWrite { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerQueryParams.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerQueryParams.cs
@@ -50,6 +50,15 @@ public sealed record FeatureServerQueryParams
 
     /// <summary>Whether to return only distinct values.</summary>
     public bool? ReturnDistinctValues { get; init; }
+
+    /// <summary>Whether to return only the count of matching features.</summary>
+    public bool? ReturnCountOnly { get; init; }
+
+    /// <summary>Whether to return only matching object IDs.</summary>
+    public bool? ReturnIdsOnly { get; init; }
+
+    /// <summary>Whether to return only the extent of matching features.</summary>
+    public bool? ReturnExtentOnly { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -192,6 +192,15 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
     }
 
     /// <inheritdoc />
+    public Task<OgcFeature> PatchItemAsync(string collectionId, string featureId, JsonElement patch, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionId);
+        ArgumentNullException.ThrowIfNull(featureId);
+        var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items/{Uri.EscapeDataString(featureId)}?f=json";
+        return SendMergePatchAsync(url, featureId, patch, ct);
+    }
+
+    /// <inheritdoc />
     public async Task DeleteItemAsync(string collectionId, string featureId, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(collectionId);
@@ -276,10 +285,38 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
             ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize edited feature.", body);
     }
 
+    private async Task<OgcFeature> SendMergePatchAsync(string url, string featureId, JsonElement patch, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Patch, url)
+        {
+            Content = CreateMergePatchContent(patch)
+        };
+        using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return new OgcFeature
+            {
+                Id = JsonSerializer.SerializeToElement(featureId)
+            };
+        }
+
+        return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeature)
+            ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize patched feature.", body);
+    }
+
     private static StringContent CreateGeoJsonContent(OgcFeature feature)
     {
         var json = JsonSerializer.Serialize(feature, OgcFeaturesJsonContext.Default.OgcFeature);
         return new StringContent(json, Encoding.UTF8, "application/geo+json");
+    }
+
+    private static StringContent CreateMergePatchContent(JsonElement patch)
+    {
+        var json = JsonSerializer.Serialize(patch, OgcFeaturesJsonContext.Default.JsonElement);
+        return new StringContent(json, Encoding.UTF8, "application/merge-patch+json");
     }
 
     private static void EnsureSuccess(HttpResponseMessage response, string body)

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -119,6 +119,10 @@ public class HonuaFeatureServerClientTests
             ResultRecordCount = 5,
             OrderByFields = "POP DESC",
             OutSR = 3857,
+            ReturnDistinctValues = true,
+            ReturnCountOnly = true,
+            ReturnIdsOnly = true,
+            ReturnExtentOnly = true,
         };
 
         await client.QueryAsync("svc", 0, query);
@@ -131,6 +135,10 @@ public class HonuaFeatureServerClientTests
         Assert.Contains("resultRecordCount=5", capturedUrl);
         Assert.Contains("orderByFields=POP", capturedUrl);
         Assert.Contains("outSR=3857", capturedUrl);
+        Assert.Contains("returnDistinctValues=true", capturedUrl);
+        Assert.Contains("returnCountOnly=true", capturedUrl);
+        Assert.Contains("returnIdsOnly=true", capturedUrl);
+        Assert.Contains("returnExtentOnly=true", capturedUrl);
     }
 
     [Fact]
@@ -338,6 +346,7 @@ public class HonuaFeatureServerClientTests
             ],
             Deletes = [103],
             RollbackOnFailure = false,
+            ForceWrite = true,
         });
 
         Assert.Equal(HttpMethod.Post, capturedMethod);
@@ -345,6 +354,7 @@ public class HonuaFeatureServerClientTests
         Assert.NotNull(capturedForm);
         Assert.Equal("json", capturedForm!["f"]);
         Assert.Equal("false", capturedForm["rollbackOnFailure"]);
+        Assert.Equal("true", capturedForm["forceWrite"]);
         Assert.Equal("103", capturedForm["deletes"]);
 
         using var adds = JsonDocument.Parse(capturedForm["adds"]!);
@@ -412,11 +422,13 @@ public class HonuaFeatureServerClientTests
                 }
             ],
             DeleteIds = ["203"],
+            ForceWrite = true,
         });
 
         Assert.Equal(2, callCount);
         Assert.NotNull(capturedForm);
         Assert.Equal("203", capturedForm!["deletes"]);
+        Assert.Equal("true", capturedForm["forceWrite"]);
 
         using var updates = JsonDocument.Parse(capturedForm["updates"]!);
         var attributes = updates.RootElement[0].GetProperty("attributes");

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -413,6 +413,42 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task PatchItemAsync_SendsJsonMergePatch()
+    {
+        string? capturedBody = null;
+        string? capturedMediaType = null;
+        var client = TestHelpers.CreateOgcFeaturesClient(async req =>
+        {
+            Assert.Equal(HttpMethod.Patch, req.Method);
+            Assert.Contains("/ogc/features/collections/buildings/items/building-7", req.RequestUri?.ToString());
+            capturedMediaType = req.Content?.Headers.ContentType?.MediaType;
+            capturedBody = await req.Content!.ReadAsStringAsync();
+
+            return TestHelpers.CreateRawJsonResponse("""
+            {
+                "type": "Feature",
+                "id": "building-7",
+                "properties": { "name": "Patched" }
+            }
+            """);
+        });
+
+        var patch = JsonSerializer.SerializeToElement(new
+        {
+            properties = new
+            {
+                name = "Patched"
+            }
+        });
+
+        var result = await client.PatchItemAsync("buildings", "building-7", patch);
+
+        Assert.Equal("application/merge-patch+json", capturedMediaType);
+        Assert.Contains("\"Patched\"", capturedBody);
+        Assert.Equal("building-7", result.Id?.GetString());
+    }
+
+    [Fact]
     public async Task DeleteItemAsync_SendsDelete()
     {
         var client = TestHelpers.CreateOgcFeaturesClient(req =>


### PR DESCRIPTION
## Summary
- add native FeatureServer query flags for count-only, IDs-only, and extent-only query shapes
- propagate FeatureServer `forceWrite` through native and shared edit request paths
- add OGC API Features JSON Merge Patch support for item updates

This unblocks the next `honua-mobile#54` REST/OGC package-consumption slice without dropping existing mobile query/edit behavior.

Refs #52.
Refs #54.
Related: honua-io/honua-mobile#54.

## Validation
- dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release
- dotnet format --verify-no-changes --verbosity minimal --no-restore
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- git diff --check

## Release note
- No manual version bump in this PR; Release Please owns `HonuaSdkVersion`.