### PR TITLE
Add gRPC geometry converters

### DIFF
--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -11,7 +11,7 @@ rendering stay in host applications or downstream adapter packages.
 | Package or capability | Browser/WASM status | Notes |
 | --- | --- | --- |
 | `Honua.Sdk.Abstractions` | Supported | Pure contracts and source/query/edit abstractions. No transport, storage, or native runtime dependency. |
-| `Honua.Sdk.Geometry` | Candidate | NetTopologySuite and ProjNET-backed geometry, CRS, and transform helpers. Pure managed compile smoke is covered, but host apps should still validate their projection set and payload sizes under their browser runtime. No display or map-rendering responsibility. |
+| `Honua.Sdk.Geometry` | Candidate | NetTopologySuite and ProjNET-backed geometry, CRS, transform helpers, and generated Geospatial gRPC geometry conversion. Pure managed compile smoke is covered, but host apps should still validate their projection set and payload sizes under their browser runtime. No display, map-rendering, or gRPC transport responsibility. |
 | `Honua.Sdk.Offline.Abstractions` | Supported | Offline manifests, checkpoints, sync state, change journals, storage interfaces, and conflict contracts only. |
 | `Honua.Sdk.Offline` | Conditional | Planner and sync engine are portable, but the host must provide browser-safe storage, scheduling, conflict-review, and auth adapters. This package is not a GeoPackage, SQLite, service-worker, or background-sync implementation. |
 | `Honua.Sdk.Admin` | Candidate | REST client over injected `HttpClient`. Browser hosts must use same-origin/BFF credentials or delegated bearer tokens, and the server must allow the required CORS policy when cross-origin. Static privileged admin API keys must not be shipped in browser config. |

--- a/src/Honua.Sdk.Geometry/GrpcGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GrpcGeometryConverter.cs
@@ -1,0 +1,358 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using Proto = Geospatial.V1;
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// Converts between Geospatial gRPC geometry messages and NetTopologySuite geometries.
+/// </summary>
+public static class GrpcGeometryConverter
+{
+    private static readonly GeometryFactory DefaultGeometryFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory();
+
+    /// <summary>
+    /// Reads a Geospatial gRPC geometry message.
+    /// </summary>
+    /// <param name="geometry">The gRPC geometry message.</param>
+    /// <param name="spatialReference">Optional spatial reference used to set the geometry SRID.</param>
+    /// <param name="geometryFactory">Optional factory used to construct the geometry.</param>
+    /// <returns>The parsed geometry.</returns>
+    public static NetTopologySuite.Geometries.Geometry ReadGeometry(
+        Proto.Geometry geometry,
+        HonuaSpatialReference? spatialReference = null,
+        GeometryFactory? geometryFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+
+        var factory = geometryFactory ?? ResolveGeometryFactory(spatialReference);
+        return geometry.ShapeCase switch
+        {
+            Proto.Geometry.ShapeOneofCase.Point => ReadPoint(geometry.Point, factory),
+            Proto.Geometry.ShapeOneofCase.MultiPoint => ReadMultiPoint(geometry.MultiPoint, factory),
+            Proto.Geometry.ShapeOneofCase.Polyline => ReadPolyline(geometry.Polyline, factory),
+            Proto.Geometry.ShapeOneofCase.Polygon => ReadPolygon(geometry.Polygon, factory),
+            Proto.Geometry.ShapeOneofCase.MultiPolygon => ReadMultiPolygon(geometry.MultiPolygon, factory),
+            _ => throw new ArgumentException("gRPC geometry did not contain a supported shape.", nameof(geometry)),
+        };
+    }
+
+    /// <summary>
+    /// Writes a NetTopologySuite geometry as a Geospatial gRPC geometry message.
+    /// </summary>
+    /// <param name="geometry">The geometry to write.</param>
+    /// <returns>The gRPC geometry message.</returns>
+    public static Proto.Geometry WriteGeometry(NetTopologySuite.Geometries.Geometry geometry)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+
+        return geometry switch
+        {
+            Point point => new Proto.Geometry { Point = WritePoint(point) },
+            MultiPoint multiPoint => new Proto.Geometry { MultiPoint = WriteMultiPoint(multiPoint) },
+            LineString lineString => new Proto.Geometry { Polyline = WritePolyline([lineString]) },
+            MultiLineString multiLineString => new Proto.Geometry
+            {
+                Polyline = WritePolyline(multiLineString.Geometries.OfType<LineString>()),
+            },
+            Polygon polygon => new Proto.Geometry { Polygon = WritePolygon(polygon) },
+            MultiPolygon multiPolygon => new Proto.Geometry { MultiPolygon = WriteMultiPolygon(multiPolygon) },
+            _ => throw new NotSupportedException(
+                $"Geospatial gRPC does not support {geometry.GeometryType} geometries."),
+        };
+    }
+
+    /// <summary>
+    /// Reads a Geospatial gRPC spatial reference message.
+    /// </summary>
+    /// <param name="spatialReference">The gRPC spatial reference message.</param>
+    /// <returns>The parsed spatial reference, or null when the proto message is empty.</returns>
+    public static HonuaSpatialReference? ReadSpatialReference(Proto.SpatialReference? spatialReference)
+    {
+        if (spatialReference is null ||
+            (spatialReference.Wkid <= 0 &&
+             spatialReference.LatestWkid <= 0 &&
+             string.IsNullOrWhiteSpace(spatialReference.Wkt)))
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(spatialReference.Wkt))
+        {
+            return spatialReference.Wkid > 0
+                ? HonuaSpatialReference.FromWkt(spatialReference.Wkt, "EPSG", spatialReference.Wkid)
+                : HonuaSpatialReference.FromWkt(spatialReference.Wkt);
+        }
+
+        if (spatialReference.Wkid > 0)
+        {
+            return HonuaSpatialReference.FromWkid(
+                spatialReference.Wkid,
+                spatialReference.LatestWkid > 0 ? spatialReference.LatestWkid : null);
+        }
+
+        return spatialReference.LatestWkid > 0
+            ? HonuaSpatialReference.FromWkid(spatialReference.LatestWkid)
+            : null;
+    }
+
+    /// <summary>
+    /// Writes a spatial reference as a Geospatial gRPC spatial reference message.
+    /// </summary>
+    /// <param name="spatialReference">The spatial reference to write.</param>
+    /// <returns>The gRPC spatial reference message, or null when no spatial reference is supplied.</returns>
+    public static Proto.SpatialReference? WriteSpatialReference(HonuaSpatialReference? spatialReference)
+    {
+        if (spatialReference is null)
+        {
+            return null;
+        }
+
+        var proto = new Proto.SpatialReference();
+        if (spatialReference.Wkid is int wkid)
+        {
+            proto.Wkid = wkid;
+        }
+
+        if (spatialReference.LatestWkid is int latestWkid)
+        {
+            proto.LatestWkid = latestWkid;
+        }
+
+        if (!string.IsNullOrWhiteSpace(spatialReference.Wkt))
+        {
+            proto.Wkt = spatialReference.Wkt;
+        }
+
+        return proto;
+    }
+
+    private static GeometryFactory ResolveGeometryFactory(HonuaSpatialReference? spatialReference)
+    {
+        return spatialReference?.Wkid is int wkid && wkid > 0
+            ? DefaultGeometryFactory.WithSRID(wkid)
+            : DefaultGeometryFactory;
+    }
+
+    private static Point ReadPoint(Proto.PointGeometry point, GeometryFactory factory)
+    {
+        return factory.CreatePoint(CreateCoordinate(point.X, point.Y, point.HasZ, point.Z, point.HasM, point.M));
+    }
+
+    private static MultiPoint ReadMultiPoint(Proto.MultiPointGeometry multiPoint, GeometryFactory factory)
+    {
+        var points = multiPoint.Points
+            .Select(point => ReadPoint(point, factory))
+            .ToArray();
+        return factory.CreateMultiPoint(points);
+    }
+
+    private static NetTopologySuite.Geometries.Geometry ReadPolyline(
+        Proto.PolylineGeometry polyline,
+        GeometryFactory factory)
+    {
+        var lines = polyline.Paths
+            .Select(path => factory.CreateLineString(ReadCoordinateSequence(path)))
+            .ToArray();
+        return lines.Length == 1
+            ? lines[0]
+            : factory.CreateMultiLineString(lines);
+    }
+
+    private static Polygon ReadPolygon(Proto.PolygonGeometry polygon, GeometryFactory factory)
+    {
+        if (polygon.Rings.Count == 0)
+        {
+            return factory.CreatePolygon();
+        }
+
+        var shell = factory.CreateLinearRing(CloseRing(ReadCoordinateSequence(polygon.Rings[0])));
+        var holes = polygon.Rings
+            .Skip(1)
+            .Select(ring => factory.CreateLinearRing(CloseRing(ReadCoordinateSequence(ring))))
+            .ToArray();
+        return factory.CreatePolygon(shell, holes);
+    }
+
+    private static MultiPolygon ReadMultiPolygon(Proto.MultiPolygonGeometry multiPolygon, GeometryFactory factory)
+    {
+        var polygons = multiPolygon.Polygons
+            .Select(polygon => ReadPolygon(polygon, factory))
+            .ToArray();
+        return factory.CreateMultiPolygon(polygons);
+    }
+
+    private static Coordinate[] ReadCoordinateSequence(Proto.CoordinateSequence sequence)
+    {
+        return sequence.Coords
+            .Select(coordinate => CreateCoordinate(
+                coordinate.X,
+                coordinate.Y,
+                coordinate.HasZ,
+                coordinate.Z,
+                coordinate.HasM,
+                coordinate.M))
+            .ToArray();
+    }
+
+    private static Proto.PointGeometry WritePoint(Point point)
+    {
+        if (point.IsEmpty || point.CoordinateSequence.Count == 0)
+        {
+            throw new NotSupportedException("Geospatial gRPC does not support empty point geometries.");
+        }
+
+        var sequence = point.CoordinateSequence;
+        var proto = new Proto.PointGeometry
+        {
+            X = sequence.GetX(0),
+            Y = sequence.GetY(0),
+        };
+        WriteOptionalOrdinates(proto, sequence, 0);
+        return proto;
+    }
+
+    private static Proto.MultiPointGeometry WriteMultiPoint(MultiPoint multiPoint)
+    {
+        var proto = new Proto.MultiPointGeometry();
+        foreach (Point point in multiPoint.Geometries)
+        {
+            proto.Points.Add(WritePoint(point));
+        }
+
+        return proto;
+    }
+
+    private static Proto.PolylineGeometry WritePolyline(IEnumerable<LineString> lines)
+    {
+        var proto = new Proto.PolylineGeometry();
+        foreach (var line in lines)
+        {
+            proto.Paths.Add(WriteCoordinateSequence(line.CoordinateSequence));
+        }
+
+        return proto;
+    }
+
+    private static Proto.PolygonGeometry WritePolygon(Polygon polygon)
+    {
+        var proto = new Proto.PolygonGeometry();
+        if (polygon.IsEmpty)
+        {
+            return proto;
+        }
+
+        proto.Rings.Add(WriteCoordinateSequence(polygon.ExteriorRing.CoordinateSequence));
+        for (var index = 0; index < polygon.NumInteriorRings; index++)
+        {
+            proto.Rings.Add(WriteCoordinateSequence(polygon.GetInteriorRingN(index).CoordinateSequence));
+        }
+
+        return proto;
+    }
+
+    private static Proto.MultiPolygonGeometry WriteMultiPolygon(MultiPolygon multiPolygon)
+    {
+        var proto = new Proto.MultiPolygonGeometry();
+        foreach (Polygon polygon in multiPolygon.Geometries)
+        {
+            proto.Polygons.Add(WritePolygon(polygon));
+        }
+
+        return proto;
+    }
+
+    private static Proto.CoordinateSequence WriteCoordinateSequence(CoordinateSequence sequence)
+    {
+        var proto = new Proto.CoordinateSequence();
+        for (var index = 0; index < sequence.Count; index++)
+        {
+            var coordinate = new Proto.Coordinate
+            {
+                X = sequence.GetX(index),
+                Y = sequence.GetY(index),
+            };
+            WriteOptionalOrdinates(coordinate, sequence, index);
+            proto.Coords.Add(coordinate);
+        }
+
+        return proto;
+    }
+
+    private static void WriteOptionalOrdinates(
+        Proto.PointGeometry point,
+        CoordinateSequence sequence,
+        int index)
+    {
+        var z = sequence.GetOrdinate(index, Ordinate.Z);
+        if (!double.IsNaN(z))
+        {
+            point.Z = z;
+        }
+
+        var m = sequence.GetOrdinate(index, Ordinate.M);
+        if (!double.IsNaN(m))
+        {
+            point.M = m;
+        }
+    }
+
+    private static void WriteOptionalOrdinates(
+        Proto.Coordinate coordinate,
+        CoordinateSequence sequence,
+        int index)
+    {
+        var z = sequence.GetOrdinate(index, Ordinate.Z);
+        if (!double.IsNaN(z))
+        {
+            coordinate.Z = z;
+        }
+
+        var m = sequence.GetOrdinate(index, Ordinate.M);
+        if (!double.IsNaN(m))
+        {
+            coordinate.M = m;
+        }
+    }
+
+    private static Coordinate CreateCoordinate(
+        double x,
+        double y,
+        bool hasZ,
+        double z,
+        bool hasM,
+        double m)
+    {
+        return (hasZ, hasM) switch
+        {
+            (true, true) => new CoordinateZM(x, y, z, m),
+            (true, false) => new CoordinateZ(x, y, z),
+            (false, true) => new CoordinateM(x, y, m),
+            _ => new Coordinate(x, y),
+        };
+    }
+
+    private static Coordinate[] CloseRing(Coordinate[] coordinates)
+    {
+        if (coordinates.Length == 0 ||
+            coordinates[0].Equals2D(coordinates[^1]))
+        {
+            return coordinates;
+        }
+
+        var closed = new Coordinate[coordinates.Length + 1];
+        Array.Copy(coordinates, closed, coordinates.Length);
+        closed[^1] = CreateCoordinate(
+            coordinates[0].X,
+            coordinates[0].Y,
+            !double.IsNaN(coordinates[0].Z),
+            coordinates[0].Z,
+            !double.IsNaN(coordinates[0].M),
+            coordinates[0].M);
+        return closed;
+    }
+}

--- a/src/Honua.Sdk.Geometry/GrpcGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GrpcGeometryConverter.cs
@@ -83,9 +83,15 @@ public static class GrpcGeometryConverter
 
         if (!string.IsNullOrWhiteSpace(spatialReference.Wkt))
         {
-            return spatialReference.Wkid > 0
-                ? HonuaSpatialReference.FromWkt(spatialReference.Wkt, "EPSG", spatialReference.Wkid)
-                : HonuaSpatialReference.FromWkt(spatialReference.Wkt);
+            var wkid = spatialReference.Wkid > 0 ? spatialReference.Wkid : (int?)null;
+            var latestWkid = spatialReference.LatestWkid > 0
+                ? spatialReference.LatestWkid
+                : (int?)null;
+            return HonuaSpatialReference.FromWktWithLatestWkid(
+                spatialReference.Wkt,
+                wkid is null ? null : "EPSG",
+                wkid,
+                latestWkid);
         }
 
         if (spatialReference.Wkid > 0)

--- a/src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj
+++ b/src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Geospatial.Grpc" Version="$(GeospatialGrpcVersion)" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />
     <PackageReference Include="ProjNET" Version="2.1.0" />

--- a/src/Honua.Sdk.Geometry/HonuaSpatialReference.cs
+++ b/src/Honua.Sdk.Geometry/HonuaSpatialReference.cs
@@ -137,6 +137,15 @@ public sealed record HonuaSpatialReference
     /// <returns>The spatial reference.</returns>
     public static HonuaSpatialReference FromWkt(string wkt, string? authority = null, int? code = null)
     {
+        return FromWktWithLatestWkid(wkt, authority, code, latestWkid: null);
+    }
+
+    internal static HonuaSpatialReference FromWktWithLatestWkid(
+        string wkt,
+        string? authority,
+        int? code,
+        int? latestWkid)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(wkt);
         if (authority is not null)
         {
@@ -148,12 +157,20 @@ public sealed record HonuaSpatialReference
             throw new ArgumentOutOfRangeException(nameof(code), code, "Authority code must be greater than zero.");
         }
 
+        if (latestWkid is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(latestWkid),
+                latestWkid,
+                "Latest WKID must be greater than zero.");
+        }
+
         var normalizedAuthority = authority?.Trim();
         var wkid = normalizedAuthority is not null &&
             normalizedAuthority.Equals("EPSG", StringComparison.OrdinalIgnoreCase)
             ? code
             : null;
-        return new HonuaSpatialReference(normalizedAuthority, code, wkid, wkid, wkt.Trim());
+        return new HonuaSpatialReference(normalizedAuthority, code, wkid, latestWkid ?? wkid, wkt.Trim());
     }
 
     /// <summary>

--- a/tests/Honua.Sdk.Geometry.Tests/GrpcGeometryConverterTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GrpcGeometryConverterTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry;
+using NetTopologySuite.Geometries;
+using Proto = Geospatial.V1;
+
+namespace Honua.Sdk.Geometry.Tests;
+
+public class GrpcGeometryConverterTests
+{
+    [Fact]
+    public void ReadGeometry_PointPreservesZAndM()
+    {
+        var proto = new Proto.Geometry
+        {
+            Point = new Proto.PointGeometry
+            {
+                X = -157.8583,
+                Y = 21.3069,
+                Z = 12.5,
+                M = 4.25,
+            },
+        };
+
+        var geometry = GrpcGeometryConverter.ReadGeometry(proto, HonuaSpatialReference.Wgs84);
+
+        var point = Assert.IsType<Point>(geometry);
+        Assert.Equal(4326, point.SRID);
+        Assert.Equal(12.5, point.Coordinate.Z);
+        Assert.Equal(4.25, point.Coordinate.M);
+    }
+
+    [Fact]
+    public void WriteGeometry_LineStringPreservesMeasure()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+        var line = factory.CreateLineString(
+            [
+                new CoordinateM(-158, 21, 1),
+                new CoordinateM(-157, 22, 2),
+            ]);
+
+        var proto = GrpcGeometryConverter.WriteGeometry(line);
+
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.Polyline, proto.ShapeCase);
+        var coordinate = proto.Polyline.Paths[0].Coords[0];
+        Assert.False(coordinate.HasZ);
+        Assert.True(coordinate.HasM);
+        Assert.Equal(1, coordinate.M);
+    }
+
+    [Fact]
+    public void ReadGeometry_PolygonPreservesInteriorRings()
+    {
+        var polygon = new Proto.PolygonGeometry();
+        polygon.Rings.Add(CreateSequence(
+            (0, 0),
+            (0, 10),
+            (10, 10),
+            (10, 0),
+            (0, 0)));
+        polygon.Rings.Add(CreateSequence(
+            (2, 2),
+            (8, 2),
+            (8, 8),
+            (2, 8),
+            (2, 2)));
+        var proto = new Proto.Geometry { Polygon = polygon };
+
+        var geometry = GrpcGeometryConverter.ReadGeometry(proto);
+
+        var result = Assert.IsType<Polygon>(geometry);
+        Assert.Equal(1, result.NumInteriorRings);
+    }
+
+    [Fact]
+    public void WriteGeometry_MultiPolygonPreservesPolygonBoundaries()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+        var first = factory.CreatePolygon(
+            factory.CreateLinearRing(
+                [
+                    new Coordinate(0, 0),
+                    new Coordinate(0, 10),
+                    new Coordinate(10, 10),
+                    new Coordinate(10, 0),
+                    new Coordinate(0, 0),
+                ]),
+            [
+                factory.CreateLinearRing(
+                    [
+                        new Coordinate(2, 2),
+                        new Coordinate(8, 2),
+                        new Coordinate(8, 8),
+                        new Coordinate(2, 8),
+                        new Coordinate(2, 2),
+                    ]),
+            ]);
+        var second = factory.CreatePolygon(
+            [
+                new Coordinate(20, 0),
+                new Coordinate(20, 10),
+                new Coordinate(30, 10),
+                new Coordinate(30, 0),
+                new Coordinate(20, 0),
+            ]);
+        var multiPolygon = factory.CreateMultiPolygon([first, second]);
+
+        var proto = GrpcGeometryConverter.WriteGeometry(multiPolygon);
+
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.MultiPolygon, proto.ShapeCase);
+        Assert.Equal(2, proto.MultiPolygon.Polygons.Count);
+        Assert.Equal(2, proto.MultiPolygon.Polygons[0].Rings.Count);
+        Assert.Single(proto.MultiPolygon.Polygons[1].Rings);
+    }
+
+    [Fact]
+    public void WriteGeometry_EmptyPolygonWritesNoRings()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+        var polygon = factory.CreatePolygon();
+
+        var proto = GrpcGeometryConverter.WriteGeometry(polygon);
+
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.Polygon, proto.ShapeCase);
+        Assert.Empty(proto.Polygon.Rings);
+    }
+
+    [Fact]
+    public void SpatialReference_RoundTripsWkid()
+    {
+        var proto = GrpcGeometryConverter.WriteSpatialReference(HonuaSpatialReference.FromWkid(3857));
+
+        var spatialReference = GrpcGeometryConverter.ReadSpatialReference(proto);
+
+        Assert.NotNull(spatialReference);
+        Assert.Equal(3857, spatialReference.Wkid);
+        Assert.Equal(3857, spatialReference.LatestWkid);
+    }
+
+    [Fact]
+    public void WriteGeometry_GeometryCollectionThrows()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+        var collection = factory.CreateGeometryCollection([]);
+
+        Assert.Throws<NotSupportedException>(() => GrpcGeometryConverter.WriteGeometry(collection));
+    }
+
+    private static Proto.CoordinateSequence CreateSequence(params (double X, double Y)[] values)
+    {
+        var sequence = new Proto.CoordinateSequence();
+        foreach (var value in values)
+        {
+            sequence.Coords.Add(new Proto.Coordinate { X = value.X, Y = value.Y });
+        }
+
+        return sequence;
+    }
+}

--- a/tests/Honua.Sdk.Geometry.Tests/GrpcGeometryConverterTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GrpcGeometryConverterTests.cs
@@ -140,6 +140,24 @@ public class GrpcGeometryConverterTests
     }
 
     [Fact]
+    public void ReadSpatialReference_WktPreservesLatestWkid()
+    {
+        var proto = new Proto.SpatialReference
+        {
+            Wkid = 102100,
+            LatestWkid = 3857,
+            Wkt = "PROJCS[\"WGS_1984_Web_Mercator_Auxiliary_Sphere\"]",
+        };
+
+        var spatialReference = GrpcGeometryConverter.ReadSpatialReference(proto);
+
+        Assert.NotNull(spatialReference);
+        Assert.Equal(102100, spatialReference.Wkid);
+        Assert.Equal(3857, spatialReference.LatestWkid);
+        Assert.Equal(proto.Wkt, spatialReference.Wkt);
+    }
+
+    [Fact]
     public void WriteGeometry_GeometryCollectionThrows()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);


### PR DESCRIPTION
## Summary
- add Geospatial.Grpc-backed conversion helpers in Honua.Sdk.Geometry for NTS point, multipoint, polyline, polygon, and multipolygon shapes
- preserve Z/M ordinates, WKID spatial references, polygon holes, multipolygon boundaries, and empty polygon semantics
- update Browser/WASM support notes to clarify this is generated proto conversion, not map display or gRPC transport

Part of #55.

## Validation
- dotnet test tests/Honua.Sdk.Geometry.Tests/Honua.Sdk.Geometry.Tests.csproj --configuration Release
- dotnet build Honua.Sdk.sln --configuration Release --no-restore
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- dotnet test Honua.Sdk.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"
- dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore
- dotnet pack src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj --configuration Release --no-build --no-restore
- git diff --check