### PR TITLE
Add shared query mode flags

### DIFF
--- a/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
@@ -79,6 +79,18 @@ public sealed record FeatureQueryRequest
     /// <summary>Provider-native order-by expression.</summary>
     public string? OrderBy { get; init; }
 
+    /// <summary>Whether to request distinct rows only when the provider supports it.</summary>
+    public bool? ReturnDistinct { get; init; }
+
+    /// <summary>Whether to request only the total matching count.</summary>
+    public bool? ReturnCountOnly { get; init; }
+
+    /// <summary>Whether to request only matching object or feature IDs.</summary>
+    public bool? ReturnIdsOnly { get; init; }
+
+    /// <summary>Whether to request only the matching feature extent.</summary>
+    public bool? ReturnExtentOnly { get; init; }
+
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }
 
@@ -118,6 +130,12 @@ public sealed record FeatureQueryResult
 
     /// <summary>Number of features returned in this page.</summary>
     public int NumberReturned { get; init; }
+
+    /// <summary>Matching object IDs when the provider reports an IDs-only response.</summary>
+    public IReadOnlyList<long> ObjectIds { get; init; } = [];
+
+    /// <summary>Matching feature extent when the provider reports an extent-only response.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
 
     /// <summary>Whether the provider indicates more results may be available.</summary>
     public bool HasMoreResults { get; init; }

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -137,33 +137,29 @@ public sealed class HonuaSource : IHonuaSource
         var idFieldName = Descriptor.Schema?.PrimaryKey;
         var ids = new List<string>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        var maxIds = limit.GetValueOrDefault(int.MaxValue);
+
+        if (useIdsOnlyMode)
+        {
+            var result = await _queryClient.QueryAsync(request, ct).ConfigureAwait(false);
+            idFieldName ??= result.ObjectIdFieldName;
+            if (AddPageObjectIds(result, ids, seen, maxIds) ||
+                AddPageFeatureIds(result, idFieldName, ids, seen, maxIds) ||
+                !result.HasMoreResults)
+            {
+                return ids;
+            }
+
+            request = BuildQueryRequest(objectIdQuery with { ReturnIdsOnly = false });
+        }
 
         await foreach (var page in _queryClient.QueryPagesAsync(request, ct).ConfigureAwait(false))
         {
             idFieldName ??= page.ObjectIdFieldName;
-            foreach (var objectId in page.ObjectIds)
+            if (AddPageObjectIds(page, ids, seen, maxIds) ||
+                AddPageFeatureIds(page, idFieldName, ids, seen, maxIds))
             {
-                var id = objectId.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                if (seen.Add(id))
-                {
-                    ids.Add(id);
-                    if (ids.Count >= limit.GetValueOrDefault(int.MaxValue))
-                    {
-                        return ids;
-                    }
-                }
-            }
-
-            foreach (var feature in page.Features)
-            {
-                if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))
-                {
-                    ids.Add(id);
-                    if (ids.Count >= limit.GetValueOrDefault(int.MaxValue))
-                    {
-                        return ids;
-                    }
-                }
+                return ids;
             }
         }
 
@@ -260,6 +256,50 @@ public sealed class HonuaSource : IHonuaSource
     private bool MatchesProtocol(string protocolId)
         => FeatureProtocolIds.Matches(Descriptor.Protocol, protocolId) ||
            FeatureProtocolIds.Matches(_queryClient.ProviderName, protocolId);
+
+    private static bool AddPageObjectIds(
+        FeatureQueryResult page,
+        List<string> ids,
+        HashSet<string> seen,
+        int maxIds)
+    {
+        foreach (var objectId in page.ObjectIds)
+        {
+            var id = objectId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            if (seen.Add(id))
+            {
+                ids.Add(id);
+                if (ids.Count >= maxIds)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool AddPageFeatureIds(
+        FeatureQueryResult page,
+        string? idFieldName,
+        List<string> ids,
+        HashSet<string> seen,
+        int maxIds)
+    {
+        foreach (var feature in page.Features)
+        {
+            if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))
+            {
+                ids.Add(id);
+                if (ids.Count >= maxIds)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     private static string? ResolveFeatureId(FeatureRecord feature, string? idFieldName)
     {

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -121,9 +121,12 @@ public sealed class HonuaSource : IHonuaSource
     {
         EnsureCapability(FeatureCapabilities.QueryObjectIds);
 
+        var useIdsOnlyMode =
+            FeatureProtocolIds.Matches(Descriptor.Protocol, FeatureProtocolIds.Grpc) ||
+            FeatureProtocolIds.Matches(Descriptor.Protocol, FeatureProtocolIds.GeoServicesFeatureService);
         var objectIdQuery = query is null
-            ? new SourceQuery { ReturnGeometry = false }
-            : query with { ReturnGeometry = false };
+            ? new SourceQuery { ReturnGeometry = false, ReturnIdsOnly = useIdsOnlyMode ? true : null }
+            : query with { ReturnGeometry = false, ReturnIdsOnly = useIdsOnlyMode ? true : query.ReturnIdsOnly };
         var request = BuildQueryRequest(objectIdQuery);
         var limit = query?.Limit;
         if (limit is <= 0)
@@ -138,6 +141,19 @@ public sealed class HonuaSource : IHonuaSource
         await foreach (var page in _queryClient.QueryPagesAsync(request, ct).ConfigureAwait(false))
         {
             idFieldName ??= page.ObjectIdFieldName;
+            foreach (var objectId in page.ObjectIds)
+            {
+                var id = objectId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                if (seen.Add(id))
+                {
+                    ids.Add(id);
+                    if (ids.Count >= limit.GetValueOrDefault(int.MaxValue))
+                    {
+                        return ids;
+                    }
+                }
+            }
+
             foreach (var feature in page.Features)
             {
                 if (ResolveFeatureId(feature, idFieldName) is { } id && seen.Add(id))

--- a/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
@@ -35,6 +35,18 @@ public sealed record SourceQuery
     /// <summary>Provider-native order-by expression.</summary>
     public string? OrderBy { get; init; }
 
+    /// <summary>Whether to request distinct rows only when the provider supports it.</summary>
+    public bool? ReturnDistinct { get; init; }
+
+    /// <summary>Whether to request only the total matching count.</summary>
+    public bool? ReturnCountOnly { get; init; }
+
+    /// <summary>Whether to request only matching object or feature IDs.</summary>
+    public bool? ReturnIdsOnly { get; init; }
+
+    /// <summary>Whether to request only the matching feature extent.</summary>
+    public bool? ReturnExtentOnly { get; init; }
+
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }
 
@@ -54,6 +66,10 @@ public sealed record SourceQuery
             Offset = Offset,
             Limit = Limit,
             OrderBy = OrderBy,
+            ReturnDistinct = ReturnDistinct,
+            ReturnCountOnly = ReturnCountOnly,
+            ReturnIdsOnly = ReturnIdsOnly,
+            ReturnExtentOnly = ReturnExtentOnly,
             Bbox = Bbox,
             OutputCrs = OutputCrs
         };

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -666,6 +666,10 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             ReturnGeometry = request.ReturnGeometry,
             ResultOffset = request.Offset,
             ResultRecordCount = request.Limit,
+            ReturnDistinctValues = request.ReturnDistinct,
+            ReturnCountOnly = request.ReturnCountOnly,
+            ReturnIdsOnly = request.ReturnIdsOnly,
+            ReturnExtentOnly = request.ReturnExtentOnly,
             SpatialFilter = BuildSpatialFilter(request.Bbox),
             OutSR = ParseWkid(request.OutputCrs),
             InSR = ParseWkid(request.Bbox?.Crs),
@@ -911,9 +915,26 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         {
             ProviderName = ProviderName,
             Features = features,
+            NumberMatched = response.Count,
             NumberReturned = features.Count,
+            ObjectIds = response.ObjectIds ?? [],
+            Extent = response.Extent is not null ? ToFeatureBoundingBox(response.Extent) : null,
             HasMoreResults = response.ExceededTransferLimit,
             ObjectIdFieldName = response.ObjectIdFieldName,
+        };
+    }
+
+    private static FeatureBoundingBox ToFeatureBoundingBox(FeatureServerExtent extent)
+    {
+        return new FeatureBoundingBox
+        {
+            MinX = extent.Xmin,
+            MinY = extent.Ymin,
+            MaxX = extent.Xmax,
+            MaxY = extent.Ymax,
+            Crs = extent.SpatialReference?.Wkid > 0
+                ? string.Create(CultureInfo.InvariantCulture, $"EPSG:{extent.SpatialReference.Wkid}")
+                : null,
         };
     }
 

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -282,7 +282,9 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             var page = await QueryAsync(serviceId, layerId, currentQuery, ct).ConfigureAwait(false);
             yield return page;
 
-            var count = page.Features?.Count ?? 0;
+            var count = currentQuery.ReturnIdsOnly is true
+                ? page.ObjectIds?.Count ?? 0
+                : page.Features?.Count ?? 0;
             if (count == 0 || !page.ExceededTransferLimit)
             {
                 yield break;

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -133,8 +133,9 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     public async Task<FeatureQueryResult> QueryAsync(
         FeatureQueryRequest request, CancellationToken ct = default)
     {
-        var response = await QueryFeaturesAsync(BuildGrpcQuery(request), ct).ConfigureAwait(false);
-        return ToFeatureQueryResult(response);
+        var grpcRequest = BuildGrpcQuery(request);
+        var response = await QueryFeaturesAsync(grpcRequest, ct).ConfigureAwait(false);
+        return ToFeatureQueryResult(response, grpcRequest.ReturnCountOnly);
     }
 
     /// <inheritdoc />
@@ -379,6 +380,10 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             ResultOffset = request.Offset ?? 0,
             ResultRecordCount = request.Limit ?? 0,
             OrderBy = request.OrderBy ?? string.Empty,
+            ReturnDistinct = request.ReturnDistinct ?? false,
+            ReturnCountOnly = request.ReturnCountOnly ?? false,
+            ReturnIdsOnly = request.ReturnIdsOnly ?? false,
+            ReturnExtentOnly = request.ReturnExtentOnly ?? false,
             SpatialFilter = BuildSpatialFilter(request.Bbox),
         };
     }
@@ -567,13 +572,18 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         crs.EndsWith("/CRS84", StringComparison.OrdinalIgnoreCase) ||
         crs.EndsWith(":CRS84", StringComparison.OrdinalIgnoreCase);
 
-    private FeatureQueryResult ToFeatureQueryResult(Models.QueryFeaturesResponse response)
+    private FeatureQueryResult ToFeatureQueryResult(
+        Models.QueryFeaturesResponse response,
+        bool countRequested = false)
     {
         return new FeatureQueryResult
         {
             ProviderName = ProviderName,
             Features = response.Features.Select(feature => ToFeatureRecord(feature)).ToList(),
+            NumberMatched = countRequested || response.Count > 0 ? response.Count : null,
             NumberReturned = response.Features.Count,
+            ObjectIds = response.ObjectIds,
+            Extent = response.Extent is not null ? ToFeatureBoundingBox(response.Extent) : null,
             HasMoreResults = response.ExceededTransferLimit,
             ObjectIdFieldName = response.ObjectIdFieldName,
         };
@@ -588,6 +598,22 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             NumberReturned = page.Features.Count,
             HasMoreResults = !page.IsLastPage,
             ObjectIdFieldName = string.IsNullOrWhiteSpace(page.ObjectIdFieldName) ? null : page.ObjectIdFieldName,
+        };
+    }
+
+    private static FeatureBoundingBox ToFeatureBoundingBox(Models.Extent extent)
+    {
+        return new FeatureBoundingBox
+        {
+            MinX = extent.Xmin,
+            MinY = extent.Ymin,
+            MaxX = extent.Xmax,
+            MaxY = extent.Ymax,
+            Crs = extent.SpatialReference?.Wkid > 0
+                ? string.Create(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    $"EPSG:{extent.SpatialReference.Wkid}")
+                : null,
         };
     }
 

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -453,6 +453,7 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureSupportedFilterLanguage(request.FilterLanguage);
+        EnsureSupportedSharedQueryModes(request);
 
         if (string.IsNullOrWhiteSpace(request.Source.CollectionId))
         {
@@ -486,6 +487,18 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
         if (language is not FeatureFilterLanguage.ProviderDefault and not FeatureFilterLanguage.Cql2Text)
         {
             throw new NotSupportedException("OGC API Features queries support provider-default or CQL2 text filters.");
+        }
+    }
+
+    private static void EnsureSupportedSharedQueryModes(FeatureQueryRequest request)
+    {
+        if (request.ReturnDistinct is true ||
+            request.ReturnCountOnly is true ||
+            request.ReturnIdsOnly is true ||
+            request.ReturnExtentOnly is true)
+        {
+            throw new NotSupportedException(
+                "OGC API Features shared queries do not support distinct, count-only, IDs-only, or extent-only modes yet.");
         }
     }
 

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -446,6 +446,7 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureSupportedFilterLanguage(request.FilterLanguage);
+        EnsureSupportedSharedQueryModes(request);
 
         if (string.IsNullOrWhiteSpace(request.Source.TypeName))
         {
@@ -480,6 +481,18 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
         if (language is not FeatureFilterLanguage.ProviderDefault and not FeatureFilterLanguage.FesXml)
         {
             throw new NotSupportedException("WFS feature queries support provider-default or FES XML filters.");
+        }
+    }
+
+    private static void EnsureSupportedSharedQueryModes(FeatureQueryRequest request)
+    {
+        if (request.ReturnDistinct is true ||
+            request.ReturnCountOnly is true ||
+            request.ReturnIdsOnly is true ||
+            request.ReturnExtentOnly is true)
+        {
+            throw new NotSupportedException(
+                "WFS shared queries do not support distinct, count-only, IDs-only, or extent-only modes yet.");
         }
     }
 

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -186,6 +186,41 @@ public sealed class SourceFacadeTests
     }
 
     [Fact]
+    public async Task HonuaSource_QueryObjectIdsAsync_UsesIdsOnlyResultWhenAvailable()
+    {
+        FeatureQueryRequest? capturedRequest = null;
+        var queryClient = new FakeQueryClient(
+            "grpc",
+            request =>
+            {
+                capturedRequest = request;
+                return
+            [
+                new FeatureQueryResult
+                {
+                    ProviderName = "grpc",
+                    ObjectIds = [10, 20, 10],
+                    NumberReturned = 0
+                }
+            ];
+            });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.Grpc,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 }
+            },
+            queryClient);
+
+        var ids = await source.QueryObjectIdsAsync();
+
+        Assert.NotNull(capturedRequest);
+        Assert.True(capturedRequest.ReturnIdsOnly);
+        Assert.Equal(["10", "20"], ids);
+    }
+
+    [Fact]
     public async Task HonuaSource_QueryObjectIdsAsync_ZeroLimitReturnsEmpty()
     {
         var queryClient = new FakeQueryClient(

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -191,18 +191,16 @@ public sealed class SourceFacadeTests
         FeatureQueryRequest? capturedRequest = null;
         var queryClient = new FakeQueryClient(
             "grpc",
+            _ => throw new InvalidOperationException("IDs-only object-id queries should not use paged feature streaming."),
             request =>
             {
                 capturedRequest = request;
-                return
-            [
-                new FeatureQueryResult
+                return new FeatureQueryResult
                 {
                     ProviderName = "grpc",
                     ObjectIds = [10, 20, 10],
                     NumberReturned = 0
-                }
-            ];
+                };
             });
         var source = new HonuaSource(
             new SourceDescriptor
@@ -353,12 +351,13 @@ public sealed class SourceFacadeTests
 
     private sealed class FakeQueryClient(
         string providerName,
-        Func<FeatureQueryRequest, IReadOnlyList<FeatureQueryResult>> queryPages) : IHonuaFeatureQueryClient
+        Func<FeatureQueryRequest, IReadOnlyList<FeatureQueryResult>> queryPages,
+        Func<FeatureQueryRequest, FeatureQueryResult>? query = null) : IHonuaFeatureQueryClient
     {
         public string ProviderName { get; } = providerName;
 
         public Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken ct = default)
-            => Task.FromResult(queryPages(request).FirstOrDefault() ?? new FeatureQueryResult { ProviderName = ProviderName });
+            => Task.FromResult(query?.Invoke(request) ?? queryPages(request).FirstOrDefault() ?? new FeatureQueryResult { ProviderName = ProviderName });
 
         public async IAsyncEnumerable<FeatureQueryResult> QueryPagesAsync(
             FeatureQueryRequest request,

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -177,6 +177,15 @@ public class HonuaFeatureServerClientTests
         var json = """
         {
             "objectIdFieldName": "OBJECTID",
+            "count": 12,
+            "objectIds": [7, 8],
+            "extent": {
+                "xmin": -180,
+                "ymin": -90,
+                "xmax": 180,
+                "ymax": 90,
+                "spatialReference": { "wkid": 4326 }
+            },
             "features": [
                 { "attributes": { "OBJECTID": 7, "NAME": "Point A" }, "geometry": { "x": -118.0, "y": 34.0 } }
             ],
@@ -199,6 +208,10 @@ public class HonuaFeatureServerClientTests
             Offset = 5,
             Limit = 10,
             OrderBy = "POP DESC",
+            ReturnDistinct = true,
+            ReturnCountOnly = true,
+            ReturnIdsOnly = true,
+            ReturnExtentOnly = true,
             Bbox = new FeatureBoundingBox { MinX = -118, MinY = 33, MaxX = -117, MaxY = 34, Crs = "EPSG:4326" },
             OutputCrs = "EPSG:3857",
         });
@@ -210,10 +223,18 @@ public class HonuaFeatureServerClientTests
         Assert.Contains("resultOffset=5", capturedUrl);
         Assert.Contains("resultRecordCount=10", capturedUrl);
         Assert.Contains("orderByFields=POP", capturedUrl);
+        Assert.Contains("returnDistinctValues=true", capturedUrl);
+        Assert.Contains("returnCountOnly=true", capturedUrl);
+        Assert.Contains("returnIdsOnly=true", capturedUrl);
+        Assert.Contains("returnExtentOnly=true", capturedUrl);
         Assert.Contains("geometryType=esriGeometryEnvelope", capturedUrl);
         Assert.Contains("inSR=4326", capturedUrl);
         Assert.Contains("outSR=3857", capturedUrl);
         Assert.Equal("geoservices-featureserver", result.ProviderName);
+        Assert.Equal(12, result.NumberMatched);
+        Assert.Equal([7L, 8L], result.ObjectIds);
+        Assert.NotNull(result.Extent);
+        Assert.Equal("EPSG:4326", result.Extent.Crs);
         Assert.Single(result.Features);
         Assert.Equal("7", result.Features[0].Id);
     }

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -697,6 +697,51 @@ public class HonuaFeatureServerClientTests
         Assert.Single(pages);
     }
 
+    [Fact]
+    public async Task QueryPagesAsync_ContinuesIdsOnlyPagesWhenTransferLimitExceeded()
+    {
+        var callCount = 0;
+        var requestUrls = new List<string>();
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            callCount++;
+            requestUrls.Add(req.RequestUri?.ToString() ?? "");
+            var json = callCount switch
+            {
+                1 => """
+                {
+                    "objectIds": [1, 2],
+                    "exceededTransferLimit": true
+                }
+                """,
+                2 => """
+                {
+                    "objectIds": [3],
+                    "exceededTransferLimit": false
+                }
+                """,
+                _ => """{ "objectIds": [], "exceededTransferLimit": false }"""
+            };
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<FeatureServerQueryResponse>();
+        await foreach (var page in client.QueryPagesAsync(
+                           "svc",
+                           0,
+                           new FeatureServerQueryParams { ReturnIdsOnly = true }))
+        {
+            pages.Add(page);
+        }
+
+        Assert.Equal(2, pages.Count);
+        Assert.Equal([1L, 2L], pages[0].ObjectIds);
+        Assert.Equal([3L], pages[1].ObjectIds);
+        Assert.Contains("returnIdsOnly=true", requestUrls[0]);
+        Assert.Contains("resultOffset=2", requestUrls[1]);
+        Assert.Equal(2, callCount);
+    }
+
     // ── QueryStatisticsAsync ────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -100,7 +100,17 @@ public class HonuaGrpcClientTests
             ObjectIdFieldName = "OBJECTID",
             GeometryType = Proto.GeometryType.Point,
             ExceededTransferLimit = true,
+            Count = 12,
+            Extent = new Proto.Extent
+            {
+                Xmin = -180,
+                Ymin = -90,
+                Xmax = 180,
+                Ymax = 90,
+                SpatialReference = new Proto.SpatialReference { Wkid = 4326 },
+            },
         };
+        protoResponse.ObjectIds.AddRange([42L, 43L]);
         var feature = new Proto.Feature { Id = 42 };
         feature.Attributes["name"] = new Proto.AttributeValue { StringValue = "Park" };
         protoResponse.Features.Add(feature);
@@ -128,6 +138,10 @@ public class HonuaGrpcClientTests
             Offset = 5,
             Limit = 10,
             OrderBy = "name ASC",
+            ReturnDistinct = true,
+            ReturnCountOnly = true,
+            ReturnIdsOnly = true,
+            ReturnExtentOnly = true,
             OutputCrs = "EPSG:3857",
         });
 
@@ -141,8 +155,16 @@ public class HonuaGrpcClientTests
         Assert.Equal(5, capturedRequest.ResultOffset);
         Assert.Equal(10, capturedRequest.ResultRecordCount);
         Assert.Equal("name ASC", capturedRequest.OrderBy);
+        Assert.True(capturedRequest.ReturnDistinct);
+        Assert.True(capturedRequest.ReturnCountOnly);
+        Assert.True(capturedRequest.ReturnIdsOnly);
+        Assert.True(capturedRequest.ReturnExtentOnly);
         Assert.Equal(3857, capturedRequest.OutSr.Wkid);
         Assert.Equal("grpc", result.ProviderName);
+        Assert.Equal(12, result.NumberMatched);
+        Assert.Equal([42L, 43L], result.ObjectIds);
+        Assert.NotNull(result.Extent);
+        Assert.Equal("EPSG:4326", result.Extent.Crs);
         Assert.True(result.HasMoreResults);
         Assert.Single(result.Features);
         Assert.Equal("42", result.Features[0].Id);

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -300,6 +300,21 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task GetItemsAsync_SharedAbstraction_UnsupportedQueryModeThrows()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { CollectionId = "buildings" },
+                ReturnCountOnly = true,
+            }));
+
+        Assert.Contains("count-only", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesOgcFeaturesClientAndExposesEditCapabilities()
     {
         string? capturedUrl = null;

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -187,6 +187,21 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task GetFeatures_SharedAbstraction_UnsupportedQueryModeThrows()
+    {
+        var client = TestHelpers.CreateClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { TypeName = "parcels" },
+                ReturnIdsOnly = true,
+            }));
+
+        Assert.Contains("IDs-only", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesWfsClientAndSuppressesUnsupportedEdits()
     {
         string? capturedQuery = null;


### PR DESCRIPTION
## Summary
- add provider-neutral query mode flags for distinct, count-only, IDs-only, and extent-only requests
- surface IDs-only and extent-only results through `FeatureQueryResult`, and let `HonuaSource.QueryObjectIdsAsync` consume native IDs-only pages when available
- map the new flags through gRPC and GeoServices FeatureServer, with explicit `NotSupportedException` fallbacks for OGC API Features and WFS shared adapters

Part of #52.

## Validation
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --configuration Release
- dotnet build Honua.Sdk.sln --configuration Release --no-restore
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- dotnet test Honua.Sdk.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"
- dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore
- dotnet pack src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj --configuration Release --no-build --no-restore
- git diff --check