### PR TITLE
Add shared time and statistics query facets

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -107,3 +107,12 @@ cross-provider application code: `SourceDescriptor`, `SourceLocator`,
 query/edit interfaces, normalizes protocol aliases such as
 `geoservices-featureserver` to `geoservices-feature-service`, and keeps native
 clients available through `IHonuaSource.Protocol<TClient>()`.
+
+Shared query support is intentionally provider-aware. GeoServices FeatureServer
+maps provider-neutral time filters, statistics, group-by, and having clauses to
+native query parameters. gRPC maps statistics and group-by through the
+geospatial proto, but rejects time filters and having clauses until those
+contracts exist in the proto. OGC API Features maps time filters to `datetime`
+and rejects provider-neutral statistics/group-by/having clauses. WFS rejects
+provider-neutral time and statistics facets until there is a dedicated shared
+mapping.

--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -39,6 +39,12 @@ var page = await source.QueryAsync(new SourceQuery
 });
 ```
 
+`SourceQuery` also carries the shared high-value query facets: output fields,
+order by, offset/count, distinct, count-only, IDs-only, extent-only, bounding
+boxes, output CRS, time filters, statistics, group-by fields, and having
+clauses. Adapters map only the facets their backing protocol supports. Unsupported
+facets fail with `NotSupportedException` instead of being ignored.
+
 ## Protocol IDs
 
 Use `FeatureProtocolIds` for stable protocol identifiers. The facade accepts

--- a/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
@@ -45,6 +45,84 @@ public sealed record FeatureBoundingBox
 }
 
 /// <summary>
+/// Temporal relationship for provider-neutral time filters.
+/// </summary>
+public enum FeatureTimeRelation
+{
+    /// <summary>Use the provider's default temporal relationship.</summary>
+    Unspecified = 0,
+
+    /// <summary>Features whose time extent overlaps the requested time or interval.</summary>
+    Overlaps = 1,
+
+    /// <summary>Features whose end time is after the requested start and whose start time is within the requested end.</summary>
+    AfterStartWithinEnd = 2,
+
+    /// <summary>Features whose time extent is fully within the requested time or interval.</summary>
+    Within = 3
+}
+
+/// <summary>
+/// Time instant or closed interval used by the shared feature query abstraction.
+/// </summary>
+public sealed record FeatureTimeFilter
+{
+    /// <summary>Inclusive start time, or the queried instant when <see cref="End"/> is not set.</summary>
+    public required DateTimeOffset Start { get; init; }
+
+    /// <summary>Inclusive end time for interval queries.</summary>
+    public DateTimeOffset? End { get; init; }
+
+    /// <summary>Optional temporal relationship to apply when the provider supports it.</summary>
+    public FeatureTimeRelation Relation { get; init; } = FeatureTimeRelation.Unspecified;
+}
+
+/// <summary>
+/// Aggregate statistic functions for provider-neutral feature queries.
+/// </summary>
+public enum FeatureStatisticType
+{
+    /// <summary>Unspecified statistic type.</summary>
+    Unspecified = 0,
+
+    /// <summary>Count of non-null values.</summary>
+    Count = 1,
+
+    /// <summary>Sum of values.</summary>
+    Sum = 2,
+
+    /// <summary>Minimum value.</summary>
+    Min = 3,
+
+    /// <summary>Maximum value.</summary>
+    Max = 4,
+
+    /// <summary>Average value.</summary>
+    Average = 5,
+
+    /// <summary>Standard deviation.</summary>
+    StandardDeviation = 6,
+
+    /// <summary>Variance.</summary>
+    Variance = 7
+}
+
+/// <summary>
+/// Provider-neutral aggregate statistic requested by a feature query.
+/// </summary>
+public sealed record FeatureQueryStatistic
+{
+    /// <summary>Field or provider-native expression to aggregate.</summary>
+    public required string OnField { get; init; }
+
+    /// <summary>Aggregate statistic to compute.</summary>
+    public required FeatureStatisticType StatisticType { get; init; }
+
+    /// <summary>Output field name that will contain the aggregate value.</summary>
+    public required string OutField { get; init; }
+}
+
+/// <summary>
 /// Provider-neutral feature query request for common read paths.
 /// </summary>
 public sealed record FeatureQueryRequest
@@ -90,6 +168,18 @@ public sealed record FeatureQueryRequest
 
     /// <summary>Whether to request only the matching feature extent.</summary>
     public bool? ReturnExtentOnly { get; init; }
+
+    /// <summary>Optional time instant or interval filter.</summary>
+    public FeatureTimeFilter? TimeFilter { get; init; }
+
+    /// <summary>Aggregate statistics to compute when the provider supports statistics queries.</summary>
+    public IReadOnlyList<FeatureQueryStatistic>? OutStatistics { get; init; }
+
+    /// <summary>Fields to group statistics by when the provider supports grouped statistics.</summary>
+    public IReadOnlyList<string>? GroupBy { get; init; }
+
+    /// <summary>Provider-native having expression for grouped statistics.</summary>
+    public string? Having { get; init; }
 
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }

--- a/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
@@ -47,6 +47,18 @@ public sealed record SourceQuery
     /// <summary>Whether to request only the matching feature extent.</summary>
     public bool? ReturnExtentOnly { get; init; }
 
+    /// <summary>Optional time instant or interval filter.</summary>
+    public FeatureTimeFilter? TimeFilter { get; init; }
+
+    /// <summary>Aggregate statistics to compute when the provider supports statistics queries.</summary>
+    public IReadOnlyList<FeatureQueryStatistic>? OutStatistics { get; init; }
+
+    /// <summary>Fields to group statistics by when the provider supports grouped statistics.</summary>
+    public IReadOnlyList<string>? GroupBy { get; init; }
+
+    /// <summary>Provider-native having expression for grouped statistics.</summary>
+    public string? Having { get; init; }
+
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }
 
@@ -70,6 +82,10 @@ public sealed record SourceQuery
             ReturnCountOnly = ReturnCountOnly,
             ReturnIdsOnly = ReturnIdsOnly,
             ReturnExtentOnly = ReturnExtentOnly,
+            TimeFilter = TimeFilter,
+            OutStatistics = OutStatistics,
+            GroupBy = GroupBy,
+            Having = Having,
             Bbox = Bbox,
             OutputCrs = OutputCrs
         };

--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
@@ -18,6 +18,7 @@ namespace Honua.Sdk.GeoServices.FeatureServer;
 [JsonSerializable(typeof(FeatureServerQueryResponse))]
 [JsonSerializable(typeof(FeatureServerEditResponse))]
 [JsonSerializable(typeof(FeatureServerFeature[]))]
+[JsonSerializable(typeof(FeatureServerStatisticDefinition[]))]
 [JsonSerializable(typeof(FeatureServerValidateSqlResponse))]
 [JsonSerializable(typeof(GeoServicesErrorResponse))]
 [JsonSerializable(typeof(JsonElement))]

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -540,6 +540,15 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         if (query.TimeRelation.HasValue)
             parameters.Add(("timeRelation", TimeRelationToString(query.TimeRelation.Value)));
 
+        if (query.OutStatistics is not null)
+            parameters.Add(("outStatistics", query.OutStatistics));
+
+        if (query.GroupByFieldsForStatistics is not null)
+            parameters.Add(("groupByFieldsForStatistics", query.GroupByFieldsForStatistics));
+
+        if (query.Having is not null)
+            parameters.Add(("having", query.Having));
+
         if (query.ReturnDistinctValues is true)
             parameters.Add(("returnDistinctValues", "true"));
 
@@ -668,6 +677,11 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             ReturnGeometry = request.ReturnGeometry,
             ResultOffset = request.Offset,
             ResultRecordCount = request.Limit,
+            Time = BuildFeatureServerTime(request.TimeFilter),
+            TimeRelation = ToFeatureServerTimeRelation(request.TimeFilter),
+            OutStatistics = BuildFeatureServerOutStatistics(request.OutStatistics),
+            GroupByFieldsForStatistics = request.GroupBy is { Count: > 0 } ? string.Join(",", request.GroupBy) : null,
+            Having = request.Having,
             ReturnDistinctValues = request.ReturnDistinct,
             ReturnCountOnly = request.ReturnCountOnly,
             ReturnIdsOnly = request.ReturnIdsOnly,
@@ -897,11 +911,82 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         }
 
         var separatorIndex = Math.Max(trimmed.LastIndexOf(':'), trimmed.LastIndexOf('/'));
-        return separatorIndex >= 0 &&
-            int.TryParse(trimmed[(separatorIndex + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wkid)
-                ? wkid
-                : null;
+        if (separatorIndex < 0)
+        {
+            return null;
+        }
+
+        return int.TryParse(trimmed[(separatorIndex + 1)..], NumberStyles.Integer, CultureInfo.InvariantCulture, out var wkid)
+            ? wkid
+            : null;
     }
+
+    private static string? BuildFeatureServerTime(FeatureTimeFilter? timeFilter)
+    {
+        if (timeFilter is null)
+        {
+            return null;
+        }
+
+        if (timeFilter.End is not { } end)
+        {
+            return timeFilter.Start.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (end < timeFilter.Start)
+        {
+            throw new ArgumentException("Feature query time filter end must be greater than or equal to start.", nameof(timeFilter));
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{timeFilter.Start.ToUnixTimeMilliseconds()},{end.ToUnixTimeMilliseconds()}");
+    }
+
+    private static TimeRelation? ToFeatureServerTimeRelation(FeatureTimeFilter? timeFilter)
+    {
+        return timeFilter?.Relation switch
+        {
+            FeatureTimeRelation.Overlaps => TimeRelation.Overlaps,
+            FeatureTimeRelation.AfterStartWithinEnd => TimeRelation.AfterStartWithinEnd,
+            FeatureTimeRelation.Within => TimeRelation.Within,
+            _ => null,
+        };
+    }
+
+    private static string? BuildFeatureServerOutStatistics(IReadOnlyList<FeatureQueryStatistic>? statistics)
+    {
+        if (statistics is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        var definitions = statistics.Select(statistic => new FeatureServerStatisticDefinition
+        {
+            StatisticType = ToFeatureServerStatisticType(statistic.StatisticType),
+            OnStatisticField = statistic.OnField,
+            OutStatisticFieldName = statistic.OutField,
+        }).ToArray();
+
+        return JsonSerializer.Serialize(
+            definitions,
+            FeatureServerJsonContext.Default.FeatureServerStatisticDefinitionArray);
+    }
+
+    private static string ToFeatureServerStatisticType(FeatureStatisticType statisticType) => statisticType switch
+    {
+        FeatureStatisticType.Count => "count",
+        FeatureStatisticType.Sum => "sum",
+        FeatureStatisticType.Min => "min",
+        FeatureStatisticType.Max => "max",
+        FeatureStatisticType.Average => "avg",
+        FeatureStatisticType.StandardDeviation => "stddev",
+        FeatureStatisticType.Variance => "var",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(statisticType),
+            statisticType,
+            "Feature statistic type must be specified."),
+    };
 
     private static bool IsCrs84(string crs) =>
         string.Equals(crs, "CRS84", StringComparison.OrdinalIgnoreCase) ||

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerQueryParams.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerQueryParams.cs
@@ -48,6 +48,15 @@ public sealed record FeatureServerQueryParams
     /// <summary>Temporal relationship for the time filter.</summary>
     public TimeRelation? TimeRelation { get; init; }
 
+    /// <summary>Statistics definitions as JSON array.</summary>
+    public string? OutStatistics { get; init; }
+
+    /// <summary>Comma-separated list of fields to group statistics by.</summary>
+    public string? GroupByFieldsForStatistics { get; init; }
+
+    /// <summary>SQL HAVING clause for filtering grouped statistics.</summary>
+    public string? Having { get; init; }
+
     /// <summary>Whether to return only distinct values.</summary>
     public bool? ReturnDistinctValues { get; init; }
 
@@ -59,6 +68,15 @@ public sealed record FeatureServerQueryParams
 
     /// <summary>Whether to return only the extent of matching features.</summary>
     public bool? ReturnExtentOnly { get; init; }
+}
+
+internal sealed record FeatureServerStatisticDefinition
+{
+    public required string StatisticType { get; init; }
+
+    public required string OnStatisticField { get; init; }
+
+    public required string OutStatisticFieldName { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -357,6 +357,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     {
         ArgumentNullException.ThrowIfNull(request);
         EnsureSupportedFilterLanguage(request.FilterLanguage);
+        EnsureSupportedSharedQueryFacets(request);
 
         if (string.IsNullOrWhiteSpace(request.Source.ServiceId))
         {
@@ -384,6 +385,8 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             ReturnCountOnly = request.ReturnCountOnly ?? false,
             ReturnIdsOnly = request.ReturnIdsOnly ?? false,
             ReturnExtentOnly = request.ReturnExtentOnly ?? false,
+            OutStatistics = BuildGrpcStatistics(request.OutStatistics),
+            GroupBy = request.GroupBy,
             SpatialFilter = BuildSpatialFilter(request.Bbox),
         };
     }
@@ -487,6 +490,50 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             throw new NotSupportedException("gRPC feature queries support provider-default or SQL WHERE filters.");
         }
     }
+
+    private static void EnsureSupportedSharedQueryFacets(FeatureQueryRequest request)
+    {
+        if (request.TimeFilter is not null)
+        {
+            throw new NotSupportedException("gRPC shared queries do not support provider-neutral time filters until the geospatial proto adds a time query contract.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Having))
+        {
+            throw new NotSupportedException("gRPC shared statistics queries do not support provider-neutral having clauses yet.");
+        }
+    }
+
+    private static List<Models.StatisticDefinition>? BuildGrpcStatistics(
+        IReadOnlyList<FeatureQueryStatistic>? statistics)
+    {
+        if (statistics is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        return statistics.Select(statistic => new Models.StatisticDefinition
+        {
+            OnStatisticField = statistic.OnField,
+            StatisticType = ToGrpcStatisticType(statistic.StatisticType),
+            OutStatisticFieldName = statistic.OutField,
+        }).ToList();
+    }
+
+    private static Models.StatisticType ToGrpcStatisticType(FeatureStatisticType statisticType) => statisticType switch
+    {
+        FeatureStatisticType.Count => Models.StatisticType.Count,
+        FeatureStatisticType.Sum => Models.StatisticType.Sum,
+        FeatureStatisticType.Min => Models.StatisticType.Min,
+        FeatureStatisticType.Max => Models.StatisticType.Max,
+        FeatureStatisticType.Average => Models.StatisticType.Avg,
+        FeatureStatisticType.StandardDeviation => Models.StatisticType.Stddev,
+        FeatureStatisticType.Variance => Models.StatisticType.Var,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(statisticType),
+            statisticType,
+            "Feature statistic type must be specified."),
+    };
 
     private static IReadOnlyList<long>? ResolveObjectIds(FeatureQueryRequest request)
     {

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -474,6 +474,7 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
                 request.FilterLanguage == FeatureFilterLanguage.Cql2Text
                     ? "cql2-text"
                     : null,
+            Datetime = BuildOgcDatetime(request.TimeFilter),
             Ids = BuildIds(request),
             Properties = request.OutFields is { Count: > 0 } ? string.Join(",", request.OutFields) : null,
             Sortby = request.OrderBy,
@@ -500,6 +501,42 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
             throw new NotSupportedException(
                 "OGC API Features shared queries do not support distinct, count-only, IDs-only, or extent-only modes yet.");
         }
+
+        if (request.OutStatistics is { Count: > 0 } ||
+            request.GroupBy is { Count: > 0 } ||
+            !string.IsNullOrWhiteSpace(request.Having))
+        {
+            throw new NotSupportedException(
+                "OGC API Features shared queries do not support provider-neutral statistics, group-by, or having clauses yet.");
+        }
+
+        if (request.TimeFilter?.Relation is FeatureTimeRelation.AfterStartWithinEnd or FeatureTimeRelation.Within)
+        {
+            throw new NotSupportedException(
+                "OGC API Features shared time filters support only provider-default or overlap datetime intervals.");
+        }
+    }
+
+    private static string? BuildOgcDatetime(FeatureTimeFilter? timeFilter)
+    {
+        if (timeFilter is null)
+        {
+            return null;
+        }
+
+        if (timeFilter.End is not { } end)
+        {
+            return timeFilter.Start.ToString("O", CultureInfo.InvariantCulture);
+        }
+
+        if (end < timeFilter.Start)
+        {
+            throw new ArgumentException("Feature query time filter end must be greater than or equal to start.", nameof(timeFilter));
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{timeFilter.Start:O}/{end:O}");
     }
 
     private static IReadOnlyList<string>? BuildIds(FeatureQueryRequest request)

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -494,6 +494,15 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
             throw new NotSupportedException(
                 "WFS shared queries do not support distinct, count-only, IDs-only, or extent-only modes yet.");
         }
+
+        if (request.TimeFilter is not null ||
+            request.OutStatistics is { Count: > 0 } ||
+            request.GroupBy is { Count: > 0 } ||
+            !string.IsNullOrWhiteSpace(request.Having))
+        {
+            throw new NotSupportedException(
+                "WFS shared queries do not support provider-neutral time filters, statistics, group-by, or having clauses yet.");
+        }
     }
 
     private static string? BuildResourceId(FeatureQueryRequest request)

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -147,6 +147,59 @@ public sealed class SourceFacadeTests
     }
 
     [Fact]
+    public async Task HonuaSource_QueryAsync_MapsTimeAndStatisticsFacets()
+    {
+        FeatureQueryRequest? capturedRequest = null;
+        var queryClient = new FakeQueryClient(
+            "geoservices-featureserver",
+            _ => throw new InvalidOperationException("Single-page query should not use paged streaming."),
+            request =>
+            {
+                capturedRequest = request;
+                return new FeatureQueryResult { ProviderName = "geoservices-featureserver" };
+            });
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parcels",
+                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 2 }
+            },
+            queryClient);
+        var timeFilter = new FeatureTimeFilter
+        {
+            Start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            End = new DateTimeOffset(2024, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            Relation = FeatureTimeRelation.Within
+        };
+
+        await source.QueryAsync(new SourceQuery
+        {
+            TimeFilter = timeFilter,
+            OutStatistics =
+            [
+                new FeatureQueryStatistic
+                {
+                    OnField = "OBJECTID",
+                    StatisticType = FeatureStatisticType.Count,
+                    OutField = "COUNT_OBJECTID"
+                }
+            ],
+            GroupBy = ["STATE"],
+            Having = "COUNT_OBJECTID > 10"
+        });
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(timeFilter, capturedRequest.TimeFilter);
+        Assert.Single(capturedRequest.OutStatistics!);
+        Assert.Equal("OBJECTID", capturedRequest.OutStatistics![0].OnField);
+        Assert.Equal(FeatureStatisticType.Count, capturedRequest.OutStatistics[0].StatisticType);
+        Assert.Equal("COUNT_OBJECTID", capturedRequest.OutStatistics[0].OutField);
+        Assert.Equal(["STATE"], capturedRequest.GroupBy);
+        Assert.Equal("COUNT_OBJECTID > 10", capturedRequest.Having);
+    }
+
+    [Fact]
     public async Task HonuaSource_QueryObjectIdsAsync_UsesFeatureIdsAndPrimaryKeyFallback()
     {
         var queryClient = new FakeQueryClient(

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -197,6 +197,8 @@ public class HonuaFeatureServerClientTests
             capturedUrl = req.RequestUri?.ToString();
             return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
         });
+        var start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2024, 1, 31, 0, 0, 0, TimeSpan.Zero);
 
         var result = await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
         {
@@ -212,11 +214,29 @@ public class HonuaFeatureServerClientTests
             ReturnCountOnly = true,
             ReturnIdsOnly = true,
             ReturnExtentOnly = true,
+            TimeFilter = new FeatureTimeFilter
+            {
+                Start = start,
+                End = end,
+                Relation = FeatureTimeRelation.Within
+            },
+            OutStatistics =
+            [
+                new FeatureQueryStatistic
+                {
+                    OnField = "POP",
+                    StatisticType = FeatureStatisticType.Sum,
+                    OutField = "SUM_POP"
+                }
+            ],
+            GroupBy = ["STATE"],
+            Having = "SUM_POP > 10",
             Bbox = new FeatureBoundingBox { MinX = -118, MinY = 33, MaxX = -117, MaxY = 34, Crs = "EPSG:4326" },
             OutputCrs = "EPSG:3857",
         });
 
         Assert.NotNull(capturedUrl);
+        var decodedUrl = WebUtility.UrlDecode(capturedUrl);
         Assert.Contains("where=POP", capturedUrl);
         Assert.Contains("outFields=NAME%2CPOP", capturedUrl);
         Assert.Contains("returnGeometry=false", capturedUrl);
@@ -227,6 +247,13 @@ public class HonuaFeatureServerClientTests
         Assert.Contains("returnCountOnly=true", capturedUrl);
         Assert.Contains("returnIdsOnly=true", capturedUrl);
         Assert.Contains("returnExtentOnly=true", capturedUrl);
+        Assert.Contains($"time={start.ToUnixTimeMilliseconds()},{end.ToUnixTimeMilliseconds()}", decodedUrl);
+        Assert.Contains("timeRelation=esriTimeRelationWithin", capturedUrl);
+        Assert.Contains("\"statisticType\":\"sum\"", decodedUrl);
+        Assert.Contains("\"onStatisticField\":\"POP\"", decodedUrl);
+        Assert.Contains("\"outStatisticFieldName\":\"SUM_POP\"", decodedUrl);
+        Assert.Contains("groupByFieldsForStatistics=STATE", capturedUrl);
+        Assert.Contains("having=SUM_POP > 10", decodedUrl);
         Assert.Contains("geometryType=esriGeometryEnvelope", capturedUrl);
         Assert.Contains("inSR=4326", capturedUrl);
         Assert.Contains("outSR=3857", capturedUrl);

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -142,6 +142,16 @@ public class HonuaGrpcClientTests
             ReturnCountOnly = true,
             ReturnIdsOnly = true,
             ReturnExtentOnly = true,
+            OutStatistics =
+            [
+                new FeatureQueryStatistic
+                {
+                    OnField = "POP",
+                    StatisticType = FeatureStatisticType.Average,
+                    OutField = "AVG_POP"
+                }
+            ],
+            GroupBy = ["STATE"],
             OutputCrs = "EPSG:3857",
         });
 
@@ -159,6 +169,11 @@ public class HonuaGrpcClientTests
         Assert.True(capturedRequest.ReturnCountOnly);
         Assert.True(capturedRequest.ReturnIdsOnly);
         Assert.True(capturedRequest.ReturnExtentOnly);
+        Assert.Single(capturedRequest.OutStatistics);
+        Assert.Equal("POP", capturedRequest.OutStatistics[0].OnStatisticField);
+        Assert.Equal(Proto.StatisticType.Avg, capturedRequest.OutStatistics[0].StatisticType);
+        Assert.Equal("AVG_POP", capturedRequest.OutStatistics[0].OutStatisticFieldName);
+        Assert.Equal(["STATE"], capturedRequest.GroupBy);
         Assert.Equal(3857, capturedRequest.OutSr.Wkid);
         Assert.Equal("grpc", result.ProviderName);
         Assert.Equal(12, result.NumberMatched);
@@ -169,6 +184,25 @@ public class HonuaGrpcClientTests
         Assert.Single(result.Features);
         Assert.Equal("42", result.Features[0].Id);
         Assert.Equal("Park", result.Features[0].Attributes["name"].GetString());
+    }
+
+    [Fact]
+    public async Task QueryAsync_SharedAbstraction_UnsupportedTimeFilterThrows()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { ServiceId = "test-svc", LayerId = 0 },
+                TimeFilter = new FeatureTimeFilter
+                {
+                    Start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                },
+            }));
+
+        Assert.Contains("time filters", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -238,6 +238,8 @@ public class HonuaOgcFeaturesClientTests
             capturedUrl = req.RequestUri?.ToString();
             return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
         });
+        var start = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero);
+        var end = new DateTimeOffset(2024, 2, 29, 0, 0, 0, TimeSpan.Zero);
 
         var result = await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
         {
@@ -249,6 +251,7 @@ public class HonuaOgcFeaturesClientTests
             Limit = 5,
             Offset = 10,
             OrderBy = "+name",
+            TimeFilter = new FeatureTimeFilter { Start = start, End = end },
             Bbox = new FeatureBoundingBox
             {
                 MinX = -118.5,
@@ -261,9 +264,11 @@ public class HonuaOgcFeaturesClientTests
         });
 
         Assert.NotNull(capturedUrl);
+        var decodedUrl = WebUtility.UrlDecode(capturedUrl);
         Assert.Contains("/ogc/features/collections/buildings/items", capturedUrl);
         Assert.Contains("limit=5", capturedUrl);
         Assert.Contains("offset=10", capturedUrl);
+        Assert.Contains($"datetime={start:O}/{end:O}", decodedUrl);
         Assert.Contains("filter=", capturedUrl);
         Assert.Contains("filter-lang=cql2-text", capturedUrl);
         Assert.Contains("ids=building-7", capturedUrl);
@@ -312,6 +317,29 @@ public class HonuaOgcFeaturesClientTests
             }));
 
         Assert.Contains("count-only", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetItemsAsync_SharedAbstraction_UnsupportedStatisticsThrows()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { CollectionId = "buildings" },
+                OutStatistics =
+                [
+                    new FeatureQueryStatistic
+                    {
+                        OnField = "height",
+                        StatisticType = FeatureStatisticType.Max,
+                        OutField = "MAX_HEIGHT"
+                    }
+                ],
+            }));
+
+        Assert.Contains("statistics", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -202,6 +202,34 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task GetFeatures_SharedAbstraction_UnsupportedTimeAndStatisticsThrow()
+    {
+        var client = TestHelpers.CreateClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { TypeName = "parcels" },
+                TimeFilter = new FeatureTimeFilter
+                {
+                    Start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                },
+                OutStatistics =
+                [
+                    new FeatureQueryStatistic
+                    {
+                        OnField = "parcel_id",
+                        StatisticType = FeatureStatisticType.Count,
+                        OutField = "COUNT_PARCELS"
+                    }
+                ],
+            }));
+
+        Assert.Contains("time filters", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("statistics", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesWfsClientAndSuppressesUnsupportedEdits()
     {
         string? capturedQuery = null;


### PR DESCRIPTION
## Summary
- add provider-neutral time filter, statistic, group-by, and having request contracts to Abstractions and SourceQuery
- map shared statistics/group-by through gRPC and GeoServices, with GeoServices also mapping time filters, time relations, and having clauses
- map OGC time filters to datetime, and add explicit unsupported-facet failures for gRPC time/having, OGC statistics/group-by/having, and WFS time/statistics/group-by/having
- document the provider-aware shared query support matrix

Part of #52.

## Validation
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release --no-restore
- dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --configuration Release --no-restore
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- git diff --check
- dotnet build Honua.Sdk.sln --configuration Release --no-restore
- dotnet test Honua.Sdk.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"
- dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore
- dotnet pack src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj --configuration Release --no-build --no-restore
- dotnet pack src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj --configuration Release --no-build --no-restore
- HONUA_API_COMPAT_BASE_REF=trunk scripts/validate-api-compat.sh