### PR TITLE
Add explicit shared spatial filters

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -110,9 +110,12 @@ clients available through `IHonuaSource.Protocol<TClient>()`.
 
 Shared query support is intentionally provider-aware. GeoServices FeatureServer
 maps provider-neutral time filters, statistics, group-by, and having clauses to
-native query parameters. gRPC maps statistics and group-by through the
-geospatial proto, but rejects time filters and having clauses until those
-contracts exist in the proto. OGC API Features maps time filters to `datetime`
-and rejects provider-neutral statistics/group-by/having clauses. WFS rejects
-provider-neutral time and statistics facets until there is a dedicated shared
-mapping.
+native query parameters. GeoServices FeatureServer and gRPC map explicit
+geometry spatial filters with CRS and spatial relationship values; simple bbox
+filters remain available as the cross-provider envelope path. gRPC maps
+statistics and group-by through the geospatial proto, but rejects time filters
+and having clauses until those contracts exist in the proto. OGC API Features
+maps time filters to `datetime` and rejects provider-neutral statistics,
+group-by, having, and explicit geometry spatial filters. WFS rejects
+provider-neutral time, statistics, and explicit geometry spatial-filter facets
+until there is a dedicated shared mapping.

--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -41,7 +41,8 @@ var page = await source.QueryAsync(new SourceQuery
 
 `SourceQuery` also carries the shared high-value query facets: output fields,
 order by, offset/count, distinct, count-only, IDs-only, extent-only, bounding
-boxes, output CRS, time filters, statistics, group-by fields, and having
+boxes, explicit geometry spatial filters, output CRS, time filters, statistics,
+group-by fields, and having
 clauses. Adapters map only the facets their backing protocol supports. Unsupported
 facets fail with `NotSupportedException` instead of being ignored.
 

--- a/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureQueryModels.cs
@@ -45,6 +45,81 @@ public sealed record FeatureBoundingBox
 }
 
 /// <summary>
+/// Geometry shape type for provider-neutral spatial filters.
+/// </summary>
+public enum FeatureSpatialGeometryType
+{
+    /// <summary>Infer the geometry type from the geometry object.</summary>
+    Unspecified = 0,
+
+    /// <summary>Point geometry.</summary>
+    Point = 1,
+
+    /// <summary>Envelope geometry.</summary>
+    Envelope = 2,
+
+    /// <summary>Multi-point geometry.</summary>
+    MultiPoint = 3,
+
+    /// <summary>Line or polyline geometry.</summary>
+    Polyline = 4,
+
+    /// <summary>Polygon geometry.</summary>
+    Polygon = 5
+}
+
+/// <summary>
+/// Spatial relationship for provider-neutral spatial filters.
+/// </summary>
+public enum FeatureSpatialRelationship
+{
+    /// <summary>Use the provider default, normally intersects.</summary>
+    Unspecified = 0,
+
+    /// <summary>Features intersect the filter geometry.</summary>
+    Intersects = 1,
+
+    /// <summary>Features are within the filter geometry.</summary>
+    Within = 2,
+
+    /// <summary>Features contain the filter geometry.</summary>
+    Contains = 3,
+
+    /// <summary>Feature envelopes intersect the filter geometry envelope.</summary>
+    EnvelopeIntersects = 4,
+
+    /// <summary>Features cross the filter geometry.</summary>
+    Crosses = 5,
+
+    /// <summary>Features touch the filter geometry.</summary>
+    Touches = 6,
+
+    /// <summary>Features overlap the filter geometry.</summary>
+    Overlaps = 7,
+
+    /// <summary>Features are found by the provider's spatial index intersect behavior.</summary>
+    IndexIntersects = 8
+}
+
+/// <summary>
+/// Explicit geometry spatial filter used by the shared feature query abstraction.
+/// </summary>
+public sealed record FeatureSpatialFilter
+{
+    /// <summary>Filter geometry object using GeoServices-style JSON shape keys.</summary>
+    public required JsonElement Geometry { get; init; }
+
+    /// <summary>Geometry shape type, or <see cref="FeatureSpatialGeometryType.Unspecified"/> to infer from <see cref="Geometry"/>.</summary>
+    public FeatureSpatialGeometryType GeometryType { get; init; } = FeatureSpatialGeometryType.Unspecified;
+
+    /// <summary>Optional coordinate reference system identifier for the filter geometry.</summary>
+    public string? Crs { get; init; }
+
+    /// <summary>Spatial relationship to apply between queried features and the filter geometry.</summary>
+    public FeatureSpatialRelationship Relationship { get; init; } = FeatureSpatialRelationship.Intersects;
+}
+
+/// <summary>
 /// Temporal relationship for provider-neutral time filters.
 /// </summary>
 public enum FeatureTimeRelation
@@ -183,6 +258,9 @@ public sealed record FeatureQueryRequest
 
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }
+
+    /// <summary>Optional explicit geometry spatial filter.</summary>
+    public FeatureSpatialFilter? SpatialFilter { get; init; }
 
     /// <summary>Optional output coordinate reference system identifier.</summary>
     public string? OutputCrs { get; init; }

--- a/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceQuery.cs
@@ -62,6 +62,9 @@ public sealed record SourceQuery
     /// <summary>Optional bounding box spatial filter.</summary>
     public FeatureBoundingBox? Bbox { get; init; }
 
+    /// <summary>Optional explicit geometry spatial filter.</summary>
+    public FeatureSpatialFilter? SpatialFilter { get; init; }
+
     /// <summary>Optional output coordinate reference system identifier.</summary>
     public string? OutputCrs { get; init; }
 
@@ -87,6 +90,7 @@ public sealed record SourceQuery
             GroupBy = GroupBy,
             Having = Having,
             Bbox = Bbox,
+            SpatialFilter = SpatialFilter,
             OutputCrs = OutputCrs
         };
 }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -686,9 +686,9 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             ReturnCountOnly = request.ReturnCountOnly,
             ReturnIdsOnly = request.ReturnIdsOnly,
             ReturnExtentOnly = request.ReturnExtentOnly,
-            SpatialFilter = BuildSpatialFilter(request.Bbox),
+            SpatialFilter = BuildSpatialFilter(request.SpatialFilter, request.Bbox),
             OutSR = ParseWkid(request.OutputCrs),
-            InSR = ParseWkid(request.Bbox?.Crs),
+            InSR = ParseWkid(request.SpatialFilter?.Crs ?? request.Bbox?.Crs),
         };
 
         return (request.Source.ServiceId, request.Source.LayerId.Value, query);
@@ -869,8 +869,23 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         return objectIds;
     }
 
-    private static FeatureServerSpatialFilter? BuildSpatialFilter(FeatureBoundingBox? bbox)
+    private static FeatureServerSpatialFilter? BuildSpatialFilter(
+        FeatureSpatialFilter? spatialFilter,
+        FeatureBoundingBox? bbox)
     {
+        EnsureSingleSpatialFilter(spatialFilter, bbox);
+
+        if (spatialFilter is not null)
+        {
+            EnsureSpatialGeometryObject(spatialFilter.Geometry);
+            return new FeatureServerSpatialFilter
+            {
+                Geometry = spatialFilter.Geometry.GetRawText(),
+                GeometryType = ToFeatureServerGeometryType(spatialFilter),
+                SpatialRel = ToFeatureServerSpatialRelationship(spatialFilter.Relationship)
+            };
+        }
+
         if (bbox is null)
         {
             return null;
@@ -891,6 +906,105 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
             SpatialRel = SpatialRelationship.Intersects
         };
     }
+
+    private static void EnsureSingleSpatialFilter(FeatureSpatialFilter? spatialFilter, FeatureBoundingBox? bbox)
+    {
+        if (spatialFilter is not null && bbox is not null)
+        {
+            throw new ArgumentException("Feature query cannot specify both Bbox and SpatialFilter.");
+        }
+    }
+
+    private static void EnsureSpatialGeometryObject(JsonElement geometry)
+    {
+        if (geometry.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("Feature query spatial filter geometry must be a JSON object.", nameof(geometry));
+        }
+    }
+
+    private static string ToFeatureServerGeometryType(FeatureSpatialFilter spatialFilter)
+    {
+        var inferred = InferSpatialGeometryType(spatialFilter.Geometry);
+        var geometryType = spatialFilter.GeometryType == FeatureSpatialGeometryType.Unspecified
+            ? inferred
+            : spatialFilter.GeometryType;
+
+        if (geometryType != inferred)
+        {
+            throw new ArgumentException(
+                "Feature query spatial filter geometry type does not match the geometry object.",
+                nameof(spatialFilter));
+        }
+
+        return geometryType switch
+        {
+            FeatureSpatialGeometryType.Point => "esriGeometryPoint",
+            FeatureSpatialGeometryType.Envelope => "esriGeometryEnvelope",
+            FeatureSpatialGeometryType.MultiPoint => "esriGeometryMultipoint",
+            FeatureSpatialGeometryType.Polyline => "esriGeometryPolyline",
+            FeatureSpatialGeometryType.Polygon => "esriGeometryPolygon",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(spatialFilter),
+                spatialFilter.GeometryType,
+                "Feature spatial filter geometry type is not supported by FeatureServer shared queries."),
+        };
+    }
+
+    private static FeatureSpatialGeometryType InferSpatialGeometryType(JsonElement geometry)
+    {
+        EnsureSpatialGeometryObject(geometry);
+
+        if (geometry.TryGetProperty("x", out _) && geometry.TryGetProperty("y", out _))
+        {
+            return FeatureSpatialGeometryType.Point;
+        }
+
+        if (geometry.TryGetProperty("xmin", out _) &&
+            geometry.TryGetProperty("ymin", out _) &&
+            geometry.TryGetProperty("xmax", out _) &&
+            geometry.TryGetProperty("ymax", out _))
+        {
+            return FeatureSpatialGeometryType.Envelope;
+        }
+
+        if (geometry.TryGetProperty("points", out _))
+        {
+            return FeatureSpatialGeometryType.MultiPoint;
+        }
+
+        if (geometry.TryGetProperty("paths", out _))
+        {
+            return FeatureSpatialGeometryType.Polyline;
+        }
+
+        if (geometry.TryGetProperty("rings", out _))
+        {
+            return FeatureSpatialGeometryType.Polygon;
+        }
+
+        throw new ArgumentException(
+            "Feature query spatial filter geometry type could not be inferred from the geometry object.",
+            nameof(geometry));
+    }
+
+    private static SpatialRelationship ToFeatureServerSpatialRelationship(FeatureSpatialRelationship relationship)
+        => relationship switch
+        {
+            FeatureSpatialRelationship.Unspecified => SpatialRelationship.Intersects,
+            FeatureSpatialRelationship.Intersects => SpatialRelationship.Intersects,
+            FeatureSpatialRelationship.Within => SpatialRelationship.Within,
+            FeatureSpatialRelationship.Contains => SpatialRelationship.Contains,
+            FeatureSpatialRelationship.EnvelopeIntersects => SpatialRelationship.EnvelopeIntersects,
+            FeatureSpatialRelationship.Crosses => SpatialRelationship.Crosses,
+            FeatureSpatialRelationship.Touches => SpatialRelationship.Touches,
+            FeatureSpatialRelationship.Overlaps => SpatialRelationship.Overlaps,
+            FeatureSpatialRelationship.IndexIntersects => SpatialRelationship.IndexIntersects,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(relationship),
+                relationship,
+                "Feature spatial relationship is not supported by FeatureServer shared queries."),
+        };
 
     private static int? ParseWkid(string? crs)
     {

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -387,7 +387,7 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             ReturnExtentOnly = request.ReturnExtentOnly ?? false,
             OutStatistics = BuildGrpcStatistics(request.OutStatistics),
             GroupBy = request.GroupBy,
-            SpatialFilter = BuildSpatialFilter(request.Bbox),
+            SpatialFilter = BuildSpatialFilter(request.SpatialFilter, request.Bbox),
         };
     }
 
@@ -561,8 +561,22 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
         return objectIds;
     }
 
-    private static Models.SpatialFilter? BuildSpatialFilter(FeatureBoundingBox? bbox)
+    private static Models.SpatialFilter? BuildSpatialFilter(
+        FeatureSpatialFilter? spatialFilter,
+        FeatureBoundingBox? bbox)
     {
+        EnsureSingleSpatialFilter(spatialFilter, bbox);
+
+        if (spatialFilter is not null)
+        {
+            return new Models.SpatialFilter
+            {
+                Geometry = BuildSpatialGeometry(spatialFilter),
+                SpatialRelationship = ToGrpcSpatialRelationship(spatialFilter.Relationship),
+                SpatialReference = ParseSpatialReference(spatialFilter.Crs),
+            };
+        }
+
         if (bbox is null)
         {
             return null;
@@ -581,6 +595,102 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
             SpatialReference = ParseSpatialReference(bbox.Crs),
         };
     }
+
+    private static void EnsureSingleSpatialFilter(FeatureSpatialFilter? spatialFilter, FeatureBoundingBox? bbox)
+    {
+        if (spatialFilter is not null && bbox is not null)
+        {
+            throw new ArgumentException("Feature query cannot specify both Bbox and SpatialFilter.");
+        }
+    }
+
+    private static IReadOnlyDictionary<string, object?> BuildSpatialGeometry(FeatureSpatialFilter spatialFilter)
+    {
+        var geometry = spatialFilter.Geometry;
+        if (geometry.ValueKind != JsonValueKind.Object)
+        {
+            throw new ArgumentException("Feature query spatial filter geometry must be a JSON object.", nameof(spatialFilter));
+        }
+
+        EnsureSpatialGeometryTypeMatches(spatialFilter);
+
+        if (ProtoAdapter.UnwrapJsonValue(geometry) is IReadOnlyDictionary<string, object?> dictionary)
+        {
+            return dictionary;
+        }
+
+        throw new ArgumentException("Feature query spatial filter geometry must be a JSON object.", nameof(spatialFilter));
+    }
+
+    private static void EnsureSpatialGeometryTypeMatches(FeatureSpatialFilter spatialFilter)
+    {
+        if (spatialFilter.GeometryType is FeatureSpatialGeometryType.Unspecified)
+        {
+            return;
+        }
+
+        var inferred = InferSpatialGeometryType(spatialFilter.Geometry);
+        if (inferred != spatialFilter.GeometryType)
+        {
+            throw new ArgumentException(
+                "Feature query spatial filter geometry type does not match the geometry object.",
+                nameof(spatialFilter));
+        }
+    }
+
+    private static FeatureSpatialGeometryType InferSpatialGeometryType(JsonElement geometry)
+    {
+        if (geometry.TryGetProperty("x", out _) && geometry.TryGetProperty("y", out _))
+        {
+            return FeatureSpatialGeometryType.Point;
+        }
+
+        if (geometry.TryGetProperty("xmin", out _) &&
+            geometry.TryGetProperty("ymin", out _) &&
+            geometry.TryGetProperty("xmax", out _) &&
+            geometry.TryGetProperty("ymax", out _))
+        {
+            return FeatureSpatialGeometryType.Envelope;
+        }
+
+        if (geometry.TryGetProperty("points", out _))
+        {
+            return FeatureSpatialGeometryType.MultiPoint;
+        }
+
+        if (geometry.TryGetProperty("paths", out _))
+        {
+            return FeatureSpatialGeometryType.Polyline;
+        }
+
+        if (geometry.TryGetProperty("rings", out _))
+        {
+            return FeatureSpatialGeometryType.Polygon;
+        }
+
+        throw new ArgumentException(
+            "Feature query spatial filter geometry type could not be inferred from the geometry object.",
+            nameof(geometry));
+    }
+
+    private static Models.SpatialRelationship ToGrpcSpatialRelationship(FeatureSpatialRelationship relationship)
+        => relationship switch
+        {
+            FeatureSpatialRelationship.Unspecified => Models.SpatialRelationship.Intersects,
+            FeatureSpatialRelationship.Intersects => Models.SpatialRelationship.Intersects,
+            FeatureSpatialRelationship.Within => Models.SpatialRelationship.Within,
+            FeatureSpatialRelationship.Contains => Models.SpatialRelationship.Contains,
+            FeatureSpatialRelationship.EnvelopeIntersects => Models.SpatialRelationship.EnvelopeIntersects,
+            FeatureSpatialRelationship.Crosses => Models.SpatialRelationship.Crosses,
+            FeatureSpatialRelationship.Touches => Models.SpatialRelationship.Touches,
+            FeatureSpatialRelationship.Overlaps => Models.SpatialRelationship.Overlaps,
+            FeatureSpatialRelationship.IndexIntersects => throw new NotSupportedException(
+                "gRPC shared spatial filters do not support index-intersects relationships."),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(relationship),
+                relationship,
+                "Feature spatial relationship is not supported by gRPC shared queries."),
+        };
 
     private static Models.SpatialReference? ParseSpatialReference(string? crs)
     {

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -510,6 +510,12 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
                 "OGC API Features shared queries do not support provider-neutral statistics, group-by, or having clauses yet.");
         }
 
+        if (request.SpatialFilter is not null)
+        {
+            throw new NotSupportedException(
+                "OGC API Features shared queries do not support explicit geometry spatial filters yet. Use Bbox for envelope filters.");
+        }
+
         if (request.TimeFilter?.Relation is FeatureTimeRelation.AfterStartWithinEnd or FeatureTimeRelation.Within)
         {
             throw new NotSupportedException(

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -503,6 +503,12 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
             throw new NotSupportedException(
                 "WFS shared queries do not support provider-neutral time filters, statistics, group-by, or having clauses yet.");
         }
+
+        if (request.SpatialFilter is not null)
+        {
+            throw new NotSupportedException(
+                "WFS shared queries do not support explicit geometry spatial filters yet. Use Bbox for envelope filters.");
+        }
     }
 
     private static string? BuildResourceId(FeatureQueryRequest request)

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -172,6 +172,7 @@ public sealed class SourceFacadeTests
             End = new DateTimeOffset(2024, 1, 31, 0, 0, 0, TimeSpan.Zero),
             Relation = FeatureTimeRelation.Within
         };
+        var spatialGeometry = JsonSerializer.SerializeToElement(new { x = -118.0, y = 34.0 });
 
         await source.QueryAsync(new SourceQuery
         {
@@ -186,7 +187,14 @@ public sealed class SourceFacadeTests
                 }
             ],
             GroupBy = ["STATE"],
-            Having = "COUNT_OBJECTID > 10"
+            Having = "COUNT_OBJECTID > 10",
+            SpatialFilter = new FeatureSpatialFilter
+            {
+                Geometry = spatialGeometry,
+                GeometryType = FeatureSpatialGeometryType.Point,
+                Crs = "EPSG:4326",
+                Relationship = FeatureSpatialRelationship.Within
+            }
         });
 
         Assert.NotNull(capturedRequest);
@@ -197,6 +205,11 @@ public sealed class SourceFacadeTests
         Assert.Equal("COUNT_OBJECTID", capturedRequest.OutStatistics[0].OutField);
         Assert.Equal(["STATE"], capturedRequest.GroupBy);
         Assert.Equal("COUNT_OBJECTID > 10", capturedRequest.Having);
+        Assert.NotNull(capturedRequest.SpatialFilter);
+        Assert.Equal(FeatureSpatialGeometryType.Point, capturedRequest.SpatialFilter.GeometryType);
+        Assert.Equal("EPSG:4326", capturedRequest.SpatialFilter.Crs);
+        Assert.Equal(FeatureSpatialRelationship.Within, capturedRequest.SpatialFilter.Relationship);
+        Assert.Equal(-118.0, capturedRequest.SpatialFilter.Geometry.GetProperty("x").GetDouble());
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -298,6 +298,38 @@ public class HonuaFeatureServerClientTests
     }
 
     [Fact]
+    public async Task QueryAsync_SharedAbstraction_MapsExplicitSpatialFilter()
+    {
+        string? capturedUrl = null;
+        var json = """{ "features": [], "exceededTransferLimit": false }""";
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            capturedUrl = req.RequestUri?.ToString();
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+        {
+            Source = new FeatureSource { ServiceId = "svc", LayerId = 0 },
+            SpatialFilter = new FeatureSpatialFilter
+            {
+                Geometry = JsonSerializer.SerializeToElement(new { x = -118.0, y = 34.0 }),
+                GeometryType = FeatureSpatialGeometryType.Point,
+                Crs = "EPSG:4326",
+                Relationship = FeatureSpatialRelationship.Contains
+            }
+        });
+
+        Assert.NotNull(capturedUrl);
+        var decodedUrl = WebUtility.UrlDecode(capturedUrl);
+        Assert.Contains("geometryType=esriGeometryPoint", capturedUrl);
+        Assert.Contains("spatialRel=esriSpatialRelContains", capturedUrl);
+        Assert.Contains("\"x\":-118", decodedUrl);
+        Assert.Contains("\"y\":34", decodedUrl);
+        Assert.Contains("inSR=4326", capturedUrl);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesFeatureServerClientAndMatchesProviderAlias()
     {
         string? capturedUrl = null;

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -241,6 +241,43 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task QueryAsync_SharedAbstraction_MapsExplicitSpatialFilter()
+    {
+        Proto.QueryFeaturesRequest? capturedRequest = null;
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>((req, _, _, _) => capturedRequest = req)
+            .Returns(CreateAsyncUnaryCall(new Proto.QueryFeaturesResponse()));
+
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        await ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+        {
+            Source = new FeatureSource { ServiceId = "test-svc", LayerId = 0 },
+            SpatialFilter = new FeatureSpatialFilter
+            {
+                Geometry = JsonSerializer.SerializeToElement(new { x = -118.0, y = 34.0 }),
+                GeometryType = FeatureSpatialGeometryType.Point,
+                Crs = "EPSG:4326",
+                Relationship = FeatureSpatialRelationship.Within
+            }
+        });
+
+        Assert.NotNull(capturedRequest);
+        Assert.NotNull(capturedRequest.SpatialFilter);
+        Assert.Equal(Proto.SpatialRelationship.Within, capturedRequest.SpatialFilter.SpatialRelationship);
+        Assert.Equal(4326, capturedRequest.SpatialFilter.SpatialReference.Wkid);
+        Assert.Equal(Proto.Geometry.ShapeOneofCase.Point, capturedRequest.SpatialFilter.Geometry.ShapeCase);
+        Assert.Equal(-118.0, capturedRequest.SpatialFilter.Geometry.Point.X);
+        Assert.Equal(34.0, capturedRequest.SpatialFilter.Geometry.Point.Y);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesGrpcClientAndExposesNativeProtocol()
     {
         Proto.QueryFeaturesRequest? capturedRequest = null;

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -343,6 +343,27 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task GetItemsAsync_SharedAbstraction_UnsupportedExplicitSpatialFilterThrows()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { CollectionId = "buildings" },
+                SpatialFilter = new FeatureSpatialFilter
+                {
+                    Geometry = JsonSerializer.SerializeToElement(new { x = -118.0, y = 34.0 }),
+                    GeometryType = FeatureSpatialGeometryType.Point,
+                    Crs = "EPSG:4326",
+                    Relationship = FeatureSpatialRelationship.Intersects
+                },
+            }));
+
+        Assert.Contains("spatial filters", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesOgcFeaturesClientAndExposesEditCapabilities()
     {
         string? capturedUrl = null;

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -230,6 +230,27 @@ public sealed class GetFeaturesTests
     }
 
     [Fact]
+    public async Task GetFeatures_SharedAbstraction_UnsupportedExplicitSpatialFilterThrows()
+    {
+        var client = TestHelpers.CreateClient(_ => throw new InvalidOperationException("HTTP should not be called."));
+
+        var ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => ((IHonuaFeatureQueryClient)client).QueryAsync(new FeatureQueryRequest
+            {
+                Source = new FeatureSource { TypeName = "parcels" },
+                SpatialFilter = new FeatureSpatialFilter
+                {
+                    Geometry = JsonSerializer.SerializeToElement(new { x = -122.0, y = 38.0 }),
+                    GeometryType = FeatureSpatialGeometryType.Point,
+                    Crs = "EPSG:4326",
+                    Relationship = FeatureSpatialRelationship.Intersects
+                },
+            }));
+
+        Assert.Contains("spatial filters", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task HonuaSourceFacade_QueriesWfsClientAndSuppressesUnsupportedEdits()
     {
         string? capturedQuery = null;


### PR DESCRIPTION
## Summary
- add provider-neutral explicit geometry spatial filters to `FeatureQueryRequest`/`SourceQuery`
- map explicit spatial filters into gRPC and GeoServices queries, including CRS and spatial relationship handling
- reject unsupported explicit geometry filters in OGC API Features and WFS shared queries instead of silently ignoring them
- document provider behavior and add adapter/facade tests

Refs #52.

## Validation
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore` (0 warnings)
- `dotnet test Honua.Sdk.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore` (0 warnings)
- `dotnet pack src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj --configuration Release --no-build --no-restore`
- `HONUA_API_COMPAT_BASE_REF=trunk scripts/validate-api-compat.sh`
