### PR TITLE
Add shared source descriptor discovery

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -108,6 +108,13 @@ query/edit interfaces, normalizes protocol aliases such as
 `geoservices-featureserver` to `geoservices-feature-service`, and keeps native
 clients available through `IHonuaSource.Protocol<TClient>()`.
 
+Source descriptor discovery is provider-aware. `IHonuaSource.GetDescriptorAsync`
+returns enriched `SourceDescriptor` metadata when the backing client supports
+`IHonuaFeatureDescriptorClient`: GeoServices maps FeatureServer layer metadata,
+OGC API Features combines collection metadata with queryables, WFS combines
+capabilities with DescribeFeatureType, and gRPC derives schema from query
+metadata plus an extent-only query until the proto adds a dedicated schema RPC.
+
 Shared query support is intentionally provider-aware. GeoServices FeatureServer
 maps provider-neutral time filters, statistics, group-by, and having clauses to
 native query parameters. GeoServices FeatureServer and gRPC map explicit

--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -17,7 +17,7 @@ protocol-specific method is needed.
   from the descriptor.
 - `IHonuaSource` is the runtime handle with `QueryAsync()`,
   `QueryPagesAsync()`, `QueryAllAsync()`, `QueryObjectIdsAsync()`,
-  `ApplyEditsAsync()`, and `Protocol<TClient>()`.
+  `GetDescriptorAsync()`, `ApplyEditsAsync()`, and `Protocol<TClient>()`.
 
 ```csharp
 var source = new HonuaSource(
@@ -46,6 +46,13 @@ group-by fields, and having
 clauses. Adapters map only the facets their backing protocol supports. Unsupported
 facets fail with `NotSupportedException` instead of being ignored.
 
+`GetDescriptorAsync()` asks a backing provider for source schema and capability
+metadata when the client implements descriptor discovery. GeoServices maps layer
+metadata directly; OGC API Features combines collection metadata with
+`queryables`; WFS combines `GetCapabilities` with `DescribeFeatureType`; gRPC
+uses feature query metadata plus an extent-only query because the current proto
+does not expose a dedicated schema RPC.
+
 ## Protocol IDs
 
 Use `FeatureProtocolIds` for stable protocol identifiers. The facade accepts
@@ -64,10 +71,11 @@ persisted descriptors may contain older provider names.
 ## Capabilities
 
 Use `FeatureCapabilities` for shared capability identifiers. The .NET facade
-currently advertises query, query-object-IDs, stream/page iteration, and edit
-capabilities where the wrapped client supports them. `FeatureProtocolCapabilities`
-contains protocol defaults and helpers for union/intersection when a caller is
-building a multi-source view.
+advertises query, statistics, extent, query-object-IDs, time-filter, spatial
+relationship, stream/page iteration, edit, attachment, relationship, and offline
+capabilities where the wrapped client or discovered metadata supports them.
+`FeatureProtocolCapabilities` contains protocol defaults and helpers for
+union/intersection when a caller is building a multi-source view.
 
 `HonuaSource` intersects declared descriptor capabilities with runtime client
 capabilities. For example, WFS can still be described as queryable while

--- a/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
@@ -20,6 +20,12 @@ public static class FeatureCapabilities
     /// <summary>Object or feature ID query support.</summary>
     public const string QueryObjectIds = "queryObjectIds";
 
+    /// <summary>Temporal query filter support.</summary>
+    public const string TimeFilter = "timeFilter";
+
+    /// <summary>Spatial relationship query support.</summary>
+    public const string SpatialRelationships = "spatialRelationships";
+
     /// <summary>Related-record query support.</summary>
     public const string QueryRelated = "queryRelated";
 
@@ -59,6 +65,9 @@ public static class FeatureCapabilities
     /// <summary>OGC API Processes support.</summary>
     public const string Processes = "processes";
 
+    /// <summary>Offline replica or sync support.</summary>
+    public const string Offline = "offline";
+
     /// <summary>All canonical capability identifiers supported by the shared vocabulary.</summary>
     public static IReadOnlyList<string> All { get; } =
     [
@@ -66,6 +75,8 @@ public static class FeatureCapabilities
         QueryAggregate,
         QueryExtent,
         QueryObjectIds,
+        TimeFilter,
+        SpatialRelationships,
         QueryRelated,
         ApplyEdits,
         Attachments,
@@ -78,7 +89,8 @@ public static class FeatureCapabilities
         Image,
         Geometry,
         Geoprocess,
-        Processes
+        Processes,
+        Offline
     ];
 
     /// <summary>

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
@@ -14,14 +14,21 @@ public static class FeatureProtocolCapabilities
             [FeatureProtocolIds.Grpc] =
             [
                 FeatureCapabilities.Query,
+                FeatureCapabilities.QueryAggregate,
+                FeatureCapabilities.QueryExtent,
                 FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.SpatialRelationships,
                 FeatureCapabilities.ApplyEdits,
                 FeatureCapabilities.Stream
             ],
             [FeatureProtocolIds.GeoServicesFeatureService] =
             [
                 FeatureCapabilities.Query,
+                FeatureCapabilities.QueryAggregate,
+                FeatureCapabilities.QueryExtent,
                 FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.TimeFilter,
+                FeatureCapabilities.SpatialRelationships,
                 FeatureCapabilities.ApplyEdits,
                 FeatureCapabilities.Stream
             ],
@@ -29,6 +36,7 @@ public static class FeatureProtocolCapabilities
             [
                 FeatureCapabilities.Query,
                 FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.TimeFilter,
                 FeatureCapabilities.Stream
             ],
             [FeatureProtocolIds.Wfs] =

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -13,6 +13,7 @@ public sealed class HonuaSource : IHonuaSource
 {
     private readonly IHonuaFeatureQueryClient _queryClient;
     private readonly IHonuaFeatureEditClient? _editClient;
+    private readonly IHonuaFeatureDescriptorClient? _descriptorClient;
     private readonly object? _nativeClient;
 
     /// <summary>
@@ -27,6 +28,24 @@ public sealed class HonuaSource : IHonuaSource
         IHonuaFeatureQueryClient queryClient,
         IHonuaFeatureEditClient? editClient = null,
         object? nativeClient = null)
+        : this(descriptor, queryClient, editClient, nativeClient, descriptorClient: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaSource"/> class.
+    /// </summary>
+    /// <param name="descriptor">Serializable source descriptor.</param>
+    /// <param name="queryClient">Provider-neutral query client.</param>
+    /// <param name="editClient">Optional provider-neutral edit client.</param>
+    /// <param name="nativeClient">Optional native protocol client for <see cref="Protocol(string)"/>.</param>
+    /// <param name="descriptorClient">Optional provider-neutral descriptor discovery client.</param>
+    public HonuaSource(
+        SourceDescriptor descriptor,
+        IHonuaFeatureQueryClient queryClient,
+        IHonuaFeatureEditClient? editClient,
+        object? nativeClient,
+        IHonuaFeatureDescriptorClient? descriptorClient)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         ArgumentNullException.ThrowIfNull(queryClient);
@@ -35,6 +54,10 @@ public sealed class HonuaSource : IHonuaSource
         _queryClient = queryClient;
         _editClient = editClient;
         _nativeClient = nativeClient ?? queryClient;
+        _descriptorClient =
+            descriptorClient ??
+            queryClient as IHonuaFeatureDescriptorClient ??
+            nativeClient as IHonuaFeatureDescriptorClient;
         Capabilities = BuildCapabilities(descriptor, queryClient, editClient);
     }
 
@@ -43,6 +66,17 @@ public sealed class HonuaSource : IHonuaSource
 
     /// <inheritdoc />
     public IReadOnlyList<string> Capabilities { get; }
+
+    /// <inheritdoc />
+    public Task<SourceDescriptor> GetDescriptorAsync(CancellationToken ct = default)
+    {
+        if (_descriptorClient is null || !SupportsDescriptorProtocol(Descriptor, _descriptorClient))
+        {
+            return Task.FromResult(Descriptor);
+        }
+
+        return _descriptorClient.GetDescriptorAsync(Descriptor, ct);
+    }
 
     /// <inheritdoc />
     public Task<FeatureQueryResult> QueryAsync(SourceQuery? query = null, CancellationToken ct = default)
@@ -236,6 +270,10 @@ public sealed class HonuaSource : IHonuaSource
     private static bool SupportsEditProtocol(SourceDescriptor descriptor, IHonuaFeatureEditClient editClient)
         => FeatureProtocolIds.Matches(descriptor.Protocol, editClient.ProviderName) ||
            FeatureProtocolIds.Matches(descriptor.CanonicalProtocol, editClient.ProviderName);
+
+    private static bool SupportsDescriptorProtocol(SourceDescriptor descriptor, IHonuaFeatureDescriptorClient descriptorClient)
+        => FeatureProtocolIds.Matches(descriptor.Protocol, descriptorClient.ProviderName) ||
+           FeatureProtocolIds.Matches(descriptor.CanonicalProtocol, descriptorClient.ProviderName);
 
     private FeatureQueryRequest BuildQueryRequest(SourceQuery? query)
         => (query ?? new SourceQuery()).ToFeatureQueryRequest(Descriptor.ToFeatureSource());

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureDescriptorClient.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureDescriptorClient.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Shared source descriptor discovery contract implemented by protocol-specific Honua clients.
+/// </summary>
+public interface IHonuaFeatureDescriptorClient
+{
+    /// <summary>
+    /// Provider name for diagnostics and provider selection.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Retrieves provider-neutral source schema and capability metadata for the supplied source descriptor.
+    /// </summary>
+    /// <param name="descriptor">Source descriptor containing the provider-specific locator.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The source descriptor enriched with discovered schema and capabilities.</returns>
+    Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaSource.cs
@@ -14,6 +14,14 @@ public interface IHonuaSource
     /// <summary>Canonical capabilities supported by this source handle.</summary>
     IReadOnlyList<string> Capabilities { get; }
 
+    /// <summary>
+    /// Retrieves this source descriptor enriched with provider-neutral schema and discovered capabilities when available.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The current descriptor, or a provider-enriched descriptor when the backing client supports discovery.</returns>
+    Task<SourceDescriptor> GetDescriptorAsync(CancellationToken ct = default)
+        => Task.FromResult(Descriptor);
+
     /// <summary>Executes a feature query and returns one page.</summary>
     /// <param name="query">Source-oriented query request.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
+
 namespace Honua.Sdk.Abstractions.Features;
 
 /// <summary>
@@ -50,8 +52,29 @@ public sealed record SourceSchema
     /// <summary>Primary key or object ID field name.</summary>
     public string? PrimaryKey { get; init; }
 
+    /// <summary>Provider object ID field name, when the source has one.</summary>
+    public string? ObjectIdField { get; init; }
+
+    /// <summary>Provider global ID field name, when the source has one.</summary>
+    public string? GlobalIdField { get; init; }
+
+    /// <summary>Feature geometry type advertised by the source.</summary>
+    public FeatureSpatialGeometryType GeometryType { get; init; } = FeatureSpatialGeometryType.Unspecified;
+
+    /// <summary>Full source extent, when advertised by the provider.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Coordinate reference system identifier for the source geometry, when advertised.</summary>
+    public string? SpatialReference { get; init; }
+
     /// <summary>Temporal validity field name, when applicable.</summary>
     public string? TimeField { get; init; }
+
+    /// <summary>Temporal metadata advertised by the source.</summary>
+    public SourceTimeInfo? TimeInfo { get; init; }
+
+    /// <summary>Edit capabilities advertised by the source.</summary>
+    public FeatureEditCapabilities? EditCapabilities { get; init; }
 }
 
 /// <summary>
@@ -62,6 +85,9 @@ public sealed record SourceField
     /// <summary>Field name.</summary>
     public required string Name { get; init; }
 
+    /// <summary>Human-readable field alias or title.</summary>
+    public string? Alias { get; init; }
+
     /// <summary>Provider or canonical field type.</summary>
     public string? Type { get; init; }
 
@@ -70,6 +96,36 @@ public sealed record SourceField
 
     /// <summary>Maximum length for string fields.</summary>
     public int? Length { get; init; }
+
+    /// <summary>Whether the field can be edited by clients.</summary>
+    public bool? Editable { get; init; }
+
+    /// <summary>Whether the field is required for writes.</summary>
+    public bool? Required { get; init; }
+
+    /// <summary>Provider-native field domain metadata, when advertised.</summary>
+    public JsonElement? Domain { get; init; }
+
+    /// <summary>Provider-native default value, when advertised.</summary>
+    public JsonElement? DefaultValue { get; init; }
+}
+
+/// <summary>
+/// Temporal metadata for a source.
+/// </summary>
+public sealed record SourceTimeInfo
+{
+    /// <summary>Start time field name.</summary>
+    public string? StartTimeField { get; init; }
+
+    /// <summary>End time field name for interval-aware sources.</summary>
+    public string? EndTimeField { get; init; }
+
+    /// <summary>Track ID field name for moving-object or track-aware sources.</summary>
+    public string? TrackIdField { get; init; }
+
+    /// <summary>Provider time reference identifier or JSON summary.</summary>
+    public string? TimeReference { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -14,7 +14,12 @@ namespace Honua.Sdk.GeoServices.FeatureServer;
 /// <summary>
 /// HTTP client implementation for the Honua FeatureServer (GeoServices) read/query API.
 /// </summary>
-public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonuaFeatureServerEditClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaFeatureServerClient :
+    IHonuaFeatureServerClient,
+    IHonuaFeatureServerEditClient,
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureDescriptorClient
 {
     private const int PostFallbackThreshold = 2000;
     private static readonly FeatureEditCapabilities ProviderEditCapabilities = new()
@@ -66,6 +71,27 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
         var body = await GetStringAsync(url, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerLayerInfo)
             ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize layer info.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var locator = descriptor.Locator;
+        if (string.IsNullOrWhiteSpace(locator.ServiceId) || !locator.LayerId.HasValue)
+        {
+            throw new ArgumentException(
+                "GeoServices descriptor discovery requires SourceDescriptor.Locator.ServiceId and LayerId.",
+                nameof(descriptor));
+        }
+
+        var layer = await GetLayerInfoAsync(locator.ServiceId, locator.LayerId.Value, ct).ConfigureAwait(false);
+        return descriptor with
+        {
+            Capabilities = BuildDiscoveredCapabilities(layer),
+            Schema = BuildSourceSchema(layer),
+        };
     }
 
     /// <inheritdoc />
@@ -693,6 +719,173 @@ public sealed class HonuaFeatureServerClient : IHonuaFeatureServerClient, IHonua
 
         return (request.Source.ServiceId, request.Source.LayerId.Value, query);
     }
+
+    private static List<string> BuildDiscoveredCapabilities(FeatureServerLayerInfo layer)
+    {
+        var capabilities = new HashSet<string>(
+            FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.GeoServicesFeatureService),
+            StringComparer.Ordinal);
+        var advertised = SplitCapabilities(layer.Capabilities);
+        var hasAdvertisedCapabilities = advertised.Count > 0;
+        var supportsQuery = !hasAdvertisedCapabilities || advertised.Contains("Query");
+
+        if (!supportsQuery)
+        {
+            capabilities.Remove(FeatureCapabilities.Query);
+            capabilities.Remove(FeatureCapabilities.QueryAggregate);
+            capabilities.Remove(FeatureCapabilities.QueryExtent);
+            capabilities.Remove(FeatureCapabilities.QueryObjectIds);
+            capabilities.Remove(FeatureCapabilities.TimeFilter);
+            capabilities.Remove(FeatureCapabilities.SpatialRelationships);
+            capabilities.Remove(FeatureCapabilities.Stream);
+        }
+
+        if (!layer.SupportsStatistics)
+        {
+            capabilities.Remove(FeatureCapabilities.QueryAggregate);
+        }
+
+        if (!layer.SupportsAdvancedQueries && hasAdvertisedCapabilities && !advertised.Contains("Query"))
+        {
+            capabilities.Remove(FeatureCapabilities.QueryExtent);
+        }
+
+        if (layer.TimeInfo is null)
+        {
+            capabilities.Remove(FeatureCapabilities.TimeFilter);
+        }
+
+        if (!LayerSupportsEdits(advertised, hasAdvertisedCapabilities))
+        {
+            capabilities.Remove(FeatureCapabilities.ApplyEdits);
+        }
+
+        if (layer.HasAttachments)
+        {
+            capabilities.Add(FeatureCapabilities.Attachments);
+        }
+
+        if (advertised.Contains("Sync"))
+        {
+            capabilities.Add(FeatureCapabilities.Offline);
+        }
+
+        return FeatureCapabilities.All.Where(capabilities.Contains).ToList();
+    }
+
+    private static SourceSchema BuildSourceSchema(FeatureServerLayerInfo layer)
+    {
+        var spatialReference = FormatSpatialReference(layer.SpatialReference);
+        return new SourceSchema
+        {
+            Fields = layer.Fields?.Select(ToSourceField).ToList() ?? [],
+            PrimaryKey = layer.ObjectIdField,
+            ObjectIdField = layer.ObjectIdField,
+            GlobalIdField = layer.GlobalIdField,
+            GeometryType = ToSourceGeometryType(layer.GeometryType),
+            Extent = ToFeatureBoundingBox(layer.Extent, spatialReference),
+            SpatialReference = spatialReference,
+            TimeField = layer.TimeInfo?.StartTimeField,
+            TimeInfo = layer.TimeInfo is not null
+                ? new SourceTimeInfo
+                {
+                    StartTimeField = layer.TimeInfo.StartTimeField,
+                    EndTimeField = layer.TimeInfo.EndTimeField,
+                    TrackIdField = layer.TimeInfo.TrackIdField,
+                    TimeReference = JsonElementToRawText(layer.TimeInfo.TimeReference),
+                }
+                : null,
+            EditCapabilities = BuildLayerEditCapabilities(layer),
+        };
+    }
+
+    private static SourceField ToSourceField(FeatureServerField field)
+        => new()
+        {
+            Name = field.Name,
+            Alias = field.Alias,
+            Type = field.Type,
+            Nullable = field.Nullable,
+            Length = field.Length,
+            Editable = field.Editable,
+            Required = !field.Nullable,
+            DefaultValue = CloneJsonElement(field.DefaultValue),
+            Domain = CloneJsonElement(field.Domain),
+        };
+
+    private static FeatureEditCapabilities BuildLayerEditCapabilities(FeatureServerLayerInfo layer)
+    {
+        var advertised = SplitCapabilities(layer.Capabilities);
+        var hasAdvertisedCapabilities = advertised.Count > 0;
+        var supportsAnyEdit = LayerSupportsEdits(advertised, hasAdvertisedCapabilities);
+
+        return new FeatureEditCapabilities
+        {
+            SupportsAdds = supportsAnyEdit && (!hasAdvertisedCapabilities || advertised.Contains("Create") || advertised.Contains("Editing")),
+            SupportsUpdates = supportsAnyEdit && (!hasAdvertisedCapabilities || advertised.Contains("Update") || advertised.Contains("Editing")),
+            SupportsDeletes = supportsAnyEdit && (!hasAdvertisedCapabilities || advertised.Contains("Delete") || advertised.Contains("Editing")),
+            SupportsRollbackOnFailure = supportsAnyEdit,
+            NativeSurface = ProviderEditCapabilities.NativeSurface,
+            UnsupportedReason = supportsAnyEdit ? null : "GeoServices FeatureServer layer does not advertise edit capabilities.",
+        };
+    }
+
+    private static bool LayerSupportsEdits(HashSet<string> advertised, bool hasAdvertisedCapabilities)
+        => !hasAdvertisedCapabilities ||
+           advertised.Contains("Create") ||
+           advertised.Contains("Update") ||
+           advertised.Contains("Delete") ||
+           advertised.Contains("Editing");
+
+    private static HashSet<string> SplitCapabilities(string? capabilities)
+        => string.IsNullOrWhiteSpace(capabilities)
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : capabilities
+                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static FeatureSpatialGeometryType ToSourceGeometryType(string? geometryType)
+        => geometryType switch
+        {
+            "esriGeometryPoint" => FeatureSpatialGeometryType.Point,
+            "esriGeometryEnvelope" => FeatureSpatialGeometryType.Envelope,
+            "esriGeometryMultipoint" => FeatureSpatialGeometryType.MultiPoint,
+            "esriGeometryPolyline" => FeatureSpatialGeometryType.Polyline,
+            "esriGeometryPolygon" => FeatureSpatialGeometryType.Polygon,
+            _ => FeatureSpatialGeometryType.Unspecified,
+        };
+
+    private static FeatureBoundingBox? ToFeatureBoundingBox(FeatureServerExtent? extent, string? fallbackCrs)
+    {
+        if (extent is null)
+        {
+            return null;
+        }
+
+        return new FeatureBoundingBox
+        {
+            MinX = extent.Xmin,
+            MinY = extent.Ymin,
+            MaxX = extent.Xmax,
+            MaxY = extent.Ymax,
+            Crs = FormatSpatialReference(extent.SpatialReference) ?? fallbackCrs,
+        };
+    }
+
+    private static string? FormatSpatialReference(FeatureServerSpatialReference? spatialReference)
+        => spatialReference?.Wkid > 0
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $"EPSG:{spatialReference.Wkid}")
+            : null;
+
+    private static JsonElement? CloneJsonElement(JsonElement? element)
+        => element.HasValue ? element.Value.Clone() : null;
+
+    private static string? JsonElementToRawText(JsonElement? element)
+        => element.HasValue && element.Value.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null
+            ? element.Value.GetRawText()
+            : null;
 
     private static (string ServiceId, int LayerId) GetEditSource(FeatureEditRequest request)
     {

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerField.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerField.cs
@@ -38,4 +38,8 @@ public sealed class FeatureServerField
     /// <summary>The default value for the field.</summary>
     [JsonPropertyName("defaultValue")]
     public JsonElement? DefaultValue { get; init; }
+
+    /// <summary>The provider-native domain metadata for the field.</summary>
+    [JsonPropertyName("domain")]
+    public JsonElement? Domain { get; init; }
 }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerLayerInfo.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerLayerInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Honua.Sdk.GeoServices.FeatureServer.Models;
@@ -54,6 +55,10 @@ public sealed class FeatureServerLayerInfo
     [JsonPropertyName("capabilities")]
     public string? Capabilities { get; init; }
 
+    /// <summary>Whether the layer advertises attachment support.</summary>
+    [JsonPropertyName("hasAttachments")]
+    public bool HasAttachments { get; init; }
+
     /// <summary>Whether the layer supports statistics.</summary>
     [JsonPropertyName("supportsStatistics")]
     public bool SupportsStatistics { get; init; }
@@ -61,4 +66,30 @@ public sealed class FeatureServerLayerInfo
     /// <summary>Whether the layer supports advanced queries.</summary>
     [JsonPropertyName("supportsAdvancedQueries")]
     public bool SupportsAdvancedQueries { get; init; }
+
+    /// <summary>Time metadata advertised by the layer.</summary>
+    [JsonPropertyName("timeInfo")]
+    public FeatureServerTimeInfo? TimeInfo { get; init; }
+}
+
+/// <summary>
+/// Time metadata advertised by a FeatureServer layer.
+/// </summary>
+public sealed class FeatureServerTimeInfo
+{
+    /// <summary>Start time field name.</summary>
+    [JsonPropertyName("startTimeField")]
+    public string? StartTimeField { get; init; }
+
+    /// <summary>End time field name.</summary>
+    [JsonPropertyName("endTimeField")]
+    public string? EndTimeField { get; init; }
+
+    /// <summary>Track ID field name.</summary>
+    [JsonPropertyName("trackIdField")]
+    public string? TrackIdField { get; init; }
+
+    /// <summary>Provider time reference payload.</summary>
+    [JsonPropertyName("timeReference")]
+    public JsonElement? TimeReference { get; init; }
 }

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -17,7 +17,12 @@ namespace Honua.Sdk.Grpc;
 /// <summary>
 /// gRPC client for the Honua FeatureService.
 /// </summary>
-public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient, IDisposable
+public sealed class HonuaGrpcClient :
+    IHonuaGrpcClient,
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureDescriptorClient,
+    IDisposable
 {
     private const string FeatureServiceName = "geospatial.v1.FeatureService";
 
@@ -105,6 +110,47 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
 
     /// <inheritdoc />
     public FeatureEditCapabilities EditCapabilities => GrpcEditCapabilities;
+
+    /// <inheritdoc />
+    public async Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        var locator = descriptor.Locator;
+        if (string.IsNullOrWhiteSpace(locator.ServiceId) || !locator.LayerId.HasValue)
+        {
+            throw new ArgumentException(
+                "gRPC descriptor discovery requires SourceDescriptor.Locator.ServiceId and LayerId.",
+                nameof(descriptor));
+        }
+
+        var schemaResponse = await QueryFeaturesAsync(
+            new Models.QueryFeaturesRequest
+            {
+                ServiceId = locator.ServiceId,
+                LayerId = locator.LayerId.Value,
+                Where = "1=1",
+                ReturnGeometry = false,
+                ResultRecordCount = 0,
+            },
+            ct).ConfigureAwait(false);
+        var extentResponse = await QueryFeaturesAsync(
+            new Models.QueryFeaturesRequest
+            {
+                ServiceId = locator.ServiceId,
+                LayerId = locator.LayerId.Value,
+                Where = "1=1",
+                ReturnGeometry = false,
+                ReturnExtentOnly = true,
+            },
+            ct).ConfigureAwait(false);
+
+        return descriptor with
+        {
+            Capabilities = BuildDiscoveredCapabilities(),
+            Schema = BuildSourceSchema(schemaResponse, extentResponse.Extent),
+        };
+    }
 
     /// <inheritdoc />
     public async Task<Models.QueryFeaturesResponse> QueryFeaturesAsync(
@@ -352,6 +398,53 @@ public sealed class HonuaGrpcClient : IHonuaGrpcClient, IHonuaFeatureQueryClient
     private static bool IsHttpOrHttps(Uri uri)
         => string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
            string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+
+    private static List<string> BuildDiscoveredCapabilities()
+        => FeatureCapabilities.All
+            .Where(FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Grpc).Contains)
+            .ToList();
+
+    private static SourceSchema BuildSourceSchema(Models.QueryFeaturesResponse response, Models.Extent? extent)
+    {
+        var objectIdField = string.IsNullOrWhiteSpace(response.ObjectIdFieldName) ? null : response.ObjectIdFieldName;
+        return new SourceSchema
+        {
+            Fields = response.Fields.Select(ToSourceField).ToList(),
+            PrimaryKey = objectIdField,
+            ObjectIdField = objectIdField,
+            GeometryType = ToSourceGeometryType(response.GeometryType),
+            Extent = extent is not null ? ToFeatureBoundingBox(extent) : null,
+            SpatialReference = FormatSpatialReference(response.SpatialReference),
+            EditCapabilities = GrpcEditCapabilities,
+        };
+    }
+
+    private static SourceField ToSourceField(Models.FieldDefinition field)
+        => new()
+        {
+            Name = field.Name,
+            Type = field.FieldType.ToString(),
+            Nullable = field.Nullable,
+            Length = field.Length > 0 ? field.Length : null,
+            Required = !field.Nullable,
+        };
+
+    private static FeatureSpatialGeometryType ToSourceGeometryType(Models.GeometryType geometryType)
+        => geometryType switch
+        {
+            Models.GeometryType.Point => FeatureSpatialGeometryType.Point,
+            Models.GeometryType.MultiPoint => FeatureSpatialGeometryType.MultiPoint,
+            Models.GeometryType.LineString or Models.GeometryType.MultiLineString => FeatureSpatialGeometryType.Polyline,
+            Models.GeometryType.Polygon or Models.GeometryType.MultiPolygon => FeatureSpatialGeometryType.Polygon,
+            _ => FeatureSpatialGeometryType.Unspecified,
+        };
+
+    private static string? FormatSpatialReference(Models.SpatialReference? spatialReference)
+        => spatialReference?.Wkid > 0
+            ? string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"EPSG:{spatialReference.Wkid}")
+            : spatialReference?.Wkt;
 
     private static Models.QueryFeaturesRequest BuildGrpcQuery(FeatureQueryRequest request)
     {

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -15,7 +15,12 @@ namespace Honua.Sdk.OgcFeatures;
 /// <summary>
 /// HTTP client implementation for the Honua OGC API Features read/query API.
 /// </summary>
-public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcFeaturesEditClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaOgcFeaturesClient :
+    IHonuaOgcFeaturesClient,
+    IHonuaOgcFeaturesEditClient,
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureDescriptorClient
 {
     private const string BasePath = "/ogc/features";
     private const string RollbackUnsupportedReason =
@@ -91,6 +96,27 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
         var body = await GetStringAsync(url, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcQueryables)
             ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize queryables.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (string.IsNullOrWhiteSpace(descriptor.Locator.CollectionId))
+        {
+            throw new ArgumentException(
+                "OGC API Features descriptor discovery requires SourceDescriptor.Locator.CollectionId.",
+                nameof(descriptor));
+        }
+
+        var collection = await GetCollectionAsync(descriptor.Locator.CollectionId, ct).ConfigureAwait(false);
+        var queryables = await TryGetQueryablesAsync(descriptor.Locator.CollectionId, ct).ConfigureAwait(false);
+        return descriptor with
+        {
+            Capabilities = BuildDiscoveredCapabilities(),
+            Schema = BuildSourceSchema(collection, queryables),
+        };
     }
 
     /// <inheritdoc />
@@ -448,6 +474,142 @@ public sealed class HonuaOgcFeaturesClient : IHonuaOgcFeaturesClient, IHonuaOgcF
         OgcFeaturesFormat.Parquet => "parquet",
         _ => "json",
     };
+
+    private async Task<OgcQueryables?> TryGetQueryablesAsync(string collectionId, CancellationToken ct)
+    {
+        try
+        {
+            return await GetQueryablesAsync(collectionId, ct).ConfigureAwait(false);
+        }
+        catch (HonuaOgcFeaturesException ex) when (
+            ex.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NotImplemented)
+        {
+            return null;
+        }
+    }
+
+    private static List<string> BuildDiscoveredCapabilities()
+    {
+        var capabilities = new HashSet<string>(
+            FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.OgcFeatures),
+            StringComparer.Ordinal);
+
+        if (OgcEditCapabilities.SupportsAdds || OgcEditCapabilities.SupportsUpdates || OgcEditCapabilities.SupportsDeletes)
+        {
+            capabilities.Add(FeatureCapabilities.ApplyEdits);
+        }
+
+        return FeatureCapabilities.All.Where(capabilities.Contains).ToList();
+    }
+
+    private static SourceSchema BuildSourceSchema(OgcCollection collection, OgcQueryables? queryables)
+    {
+        var fields = BuildQueryableFields(queryables);
+        var spatialReference =
+            collection.StorageCrs ??
+            collection.Extent?.Spatial?.Crs ??
+            (collection.Crs is { Count: > 0 } ? collection.Crs[0] : null);
+        var primaryKey = fields.FirstOrDefault(
+            field => string.Equals(field.Name, "id", StringComparison.OrdinalIgnoreCase))?.Name;
+
+        return new SourceSchema
+        {
+            Fields = fields,
+            PrimaryKey = primaryKey,
+            GeometryType = FeatureSpatialGeometryType.Unspecified,
+            Extent = ToFeatureBoundingBox(collection.Extent?.Spatial, spatialReference),
+            SpatialReference = spatialReference,
+            EditCapabilities = OgcEditCapabilities,
+        };
+    }
+
+    private static List<SourceField> BuildQueryableFields(OgcQueryables? queryables)
+    {
+        if (queryables?.Properties is not { Count: > 0 } properties)
+        {
+            return [];
+        }
+
+        var required = new HashSet<string>(queryables.Required ?? [], StringComparer.Ordinal);
+        return properties.Select(property => ToSourceField(property.Key, property.Value, required)).ToList();
+    }
+
+    private static SourceField ToSourceField(string name, JsonElement schema, HashSet<string> required)
+        => new()
+        {
+            Name = name,
+            Alias = TryGetStringProperty(schema, "title"),
+            Type = GetJsonSchemaType(schema),
+            Nullable = GetJsonSchemaNullable(name, schema, required),
+            Length = TryGetIntProperty(schema, "maxLength"),
+            Required = required.Contains(name),
+            DefaultValue = TryGetPropertyClone(schema, "default"),
+            Domain = TryGetPropertyClone(schema, "enum"),
+        };
+
+    private static string? GetJsonSchemaType(JsonElement schema)
+    {
+        if (!schema.TryGetProperty("type", out var type))
+        {
+            return null;
+        }
+
+        return type.ValueKind switch
+        {
+            JsonValueKind.String => type.GetString(),
+            JsonValueKind.Array => string.Join(
+                "|",
+                type.EnumerateArray()
+                    .Where(item => item.ValueKind == JsonValueKind.String)
+                    .Select(item => item.GetString())),
+            _ => type.GetRawText(),
+        };
+    }
+
+    private static bool? GetJsonSchemaNullable(string name, JsonElement schema, HashSet<string> required)
+    {
+        if (schema.TryGetProperty("nullable", out var nullable) &&
+            nullable.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            return nullable.GetBoolean();
+        }
+
+        return !required.Contains(name);
+    }
+
+    private static string? TryGetStringProperty(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static int? TryGetIntProperty(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.TryGetInt32(out var value)
+            ? value
+            : null;
+
+    private static JsonElement? TryGetPropertyClone(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) &&
+           property.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null
+            ? property.Clone()
+            : null;
+
+    private static FeatureBoundingBox? ToFeatureBoundingBox(OgcSpatialExtent? spatialExtent, string? fallbackCrs)
+    {
+        var bbox = spatialExtent?.Bbox is { Count: > 0 } bboxes ? bboxes[0] : null;
+        if (bbox is not { Count: >= 4 })
+        {
+            return null;
+        }
+
+        return new FeatureBoundingBox
+        {
+            MinX = bbox[0],
+            MinY = bbox[1],
+            MaxX = bbox[2],
+            MaxY = bbox[3],
+            Crs = spatialExtent?.Crs ?? fallbackCrs,
+        };
+    }
 
     private static (string CollectionId, OgcItemsParams Query) BuildOgcQuery(FeatureQueryRequest request)
     {

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -21,7 +21,11 @@ namespace Honua.Sdk.Wfs;
 /// <summary>
 /// WFS 2.0 read/query client for Honua Server.
 /// </summary>
-public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, IHonuaFeatureEditClient
+public sealed class HonuaWfsClient :
+    IHonuaWfsClient,
+    IHonuaFeatureQueryClient,
+    IHonuaFeatureEditClient,
+    IHonuaFeatureDescriptorClient
 {
     private static readonly ActivitySource ActivitySource = new("Honua.Sdk.Wfs");
     private static readonly GeoJsonFeatureCollectionHandler DefaultGeoJsonHandler = new();
@@ -88,6 +92,30 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
         await EnsureSuccessAsync(response, body).ConfigureAwait(false);
 
         return WfsDescribeFeatureTypeParser.Parse(body);
+    }
+
+    /// <inheritdoc />
+    public async Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        if (string.IsNullOrWhiteSpace(descriptor.Locator.TypeName))
+        {
+            throw new ArgumentException(
+                "WFS descriptor discovery requires SourceDescriptor.Locator.TypeName.",
+                nameof(descriptor));
+        }
+
+        var capabilities = await GetCapabilitiesAsync(ct).ConfigureAwait(false);
+        var featureType = capabilities.FeatureTypes.FirstOrDefault(
+            candidate => string.Equals(candidate.Name, descriptor.Locator.TypeName, StringComparison.Ordinal));
+        var schema = await DescribeFeatureTypeAsync(descriptor.Locator.TypeName, ct).ConfigureAwait(false);
+
+        return descriptor with
+        {
+            Capabilities = BuildDiscoveredCapabilities(),
+            Schema = BuildSourceSchema(featureType, schema),
+        };
     }
 
     /// <inheritdoc />
@@ -441,6 +469,92 @@ public sealed class HonuaWfsClient : IHonuaWfsClient, IHonuaFeatureQueryClient, 
     }
 
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
+
+    private static List<string> BuildDiscoveredCapabilities()
+        => FeatureCapabilities.All
+            .Where(FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Wfs).Contains)
+            .ToList();
+
+    private static SourceSchema BuildSourceSchema(WfsFeatureType? featureType, WfsFeatureTypeSchema schema)
+    {
+        var fields = schema.Properties.Select(ToSourceField).ToList();
+        var geometryType = schema.Properties
+            .Select(property => ToSourceGeometryType(property.Type))
+            .FirstOrDefault(type => type != FeatureSpatialGeometryType.Unspecified);
+        var primaryKey = fields.FirstOrDefault(
+            field => string.Equals(field.Name, "id", StringComparison.OrdinalIgnoreCase))?.Name;
+
+        return new SourceSchema
+        {
+            Fields = fields,
+            PrimaryKey = primaryKey,
+            GeometryType = geometryType,
+            Extent = ToFeatureBoundingBox(featureType),
+            SpatialReference = featureType?.DefaultCrs,
+            EditCapabilities = UnsupportedEditCapabilities,
+        };
+    }
+
+    private static SourceField ToSourceField(WfsSchemaProperty property)
+        => new()
+        {
+            Name = property.Name,
+            Type = property.Type,
+            Nullable = property.Nillable || property.MinOccurs == 0,
+            Required = property.MinOccurs > 0 && !property.Nillable,
+        };
+
+    private static FeatureSpatialGeometryType ToSourceGeometryType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type) ||
+            !type.Contains("gml:", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureSpatialGeometryType.Unspecified;
+        }
+
+        if (type.Contains("Point", StringComparison.OrdinalIgnoreCase))
+        {
+            return type.Contains("Multi", StringComparison.OrdinalIgnoreCase)
+                ? FeatureSpatialGeometryType.MultiPoint
+                : FeatureSpatialGeometryType.Point;
+        }
+
+        if (type.Contains("Line", StringComparison.OrdinalIgnoreCase) ||
+            type.Contains("Curve", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureSpatialGeometryType.Polyline;
+        }
+
+        if (type.Contains("Polygon", StringComparison.OrdinalIgnoreCase) ||
+            type.Contains("Surface", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureSpatialGeometryType.Polygon;
+        }
+
+        if (type.Contains("Envelope", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureSpatialGeometryType.Envelope;
+        }
+
+        return FeatureSpatialGeometryType.Unspecified;
+    }
+
+    private static FeatureBoundingBox? ToFeatureBoundingBox(WfsFeatureType? featureType)
+    {
+        if (featureType?.LowerCorner is not { } lower || featureType.UpperCorner is not { } upper)
+        {
+            return null;
+        }
+
+        return new FeatureBoundingBox
+        {
+            MinX = lower.X,
+            MinY = lower.Y,
+            MaxX = upper.X,
+            MaxY = upper.Y,
+            Crs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        };
+    }
 
     private static GetFeaturesRequest BuildWfsQuery(FeatureQueryRequest request)
     {

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -28,9 +28,63 @@ public sealed class SourceFacadeTests
         var wfs = FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Wfs);
 
         Assert.Contains(FeatureCapabilities.Query, geoservices);
+        Assert.Contains(FeatureCapabilities.QueryAggregate, geoservices);
+        Assert.Contains(FeatureCapabilities.TimeFilter, geoservices);
+        Assert.Contains(FeatureCapabilities.SpatialRelationships, geoservices);
         Assert.Contains(FeatureCapabilities.ApplyEdits, geoservices);
         Assert.Contains(FeatureCapabilities.QueryObjectIds, wfs);
         Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, wfs);
+    }
+
+    [Fact]
+    public async Task HonuaSource_GetDescriptorAsync_UsesProviderDescriptorClient()
+    {
+        var discovered = new SourceDescriptor
+        {
+            Id = "parks",
+            Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+            Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 },
+            Capabilities = [FeatureCapabilities.Query, FeatureCapabilities.QueryExtent],
+            Schema = new SourceSchema
+            {
+                ObjectIdField = "OBJECTID",
+                PrimaryKey = "OBJECTID",
+                GeometryType = FeatureSpatialGeometryType.Point,
+                SpatialReference = "EPSG:4326",
+                Fields =
+                [
+                    new SourceField
+                    {
+                        Name = "NAME",
+                        Alias = "Park name",
+                        Type = "string",
+                        Nullable = true,
+                        Length = 128
+                    }
+                ]
+            }
+        };
+        var queryClient = new FakeQueryClient("geoservices-featureserver", _ => []);
+        var descriptorClient = new FakeDescriptorClient("geoservices-featureserver", discovered);
+        var source = new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = "parks",
+                Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+                Locator = new SourceLocator { ServiceId = "svc", LayerId = 0 }
+            },
+            queryClient,
+            editClient: null,
+            nativeClient: queryClient,
+            descriptorClient);
+
+        var descriptor = await source.GetDescriptorAsync();
+
+        Assert.Equal("OBJECTID", descriptor.Schema?.ObjectIdField);
+        Assert.Equal(FeatureSpatialGeometryType.Point, descriptor.Schema?.GeometryType);
+        Assert.Equal("Park name", descriptor.Schema?.Fields[0].Alias);
+        Assert.Contains(FeatureCapabilities.QueryExtent, descriptor.Capabilities);
+        Assert.Same(queryClient, source.Protocol<FakeQueryClient>());
     }
 
     [Fact]
@@ -453,5 +507,15 @@ public sealed class SourceFacadeTests
             ApplyCalls++;
             return Task.FromResult(new FeatureEditResponse { ProviderName = ProviderName });
         }
+    }
+
+    private sealed class FakeDescriptorClient(
+        string providerName,
+        SourceDescriptor descriptor) : IHonuaFeatureDescriptorClient
+    {
+        public string ProviderName { get; } = providerName;
+
+        public Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor sourceDescriptor, CancellationToken ct = default)
+            => Task.FromResult(descriptor);
     }
 }

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -74,6 +74,89 @@ public class HonuaFeatureServerClientTests
         Assert.Equal(2, result.Fields.Count);
     }
 
+    [Fact]
+    public async Task GetDescriptorAsync_SharedAbstraction_MapsLayerSchemaAndCapabilities()
+    {
+        var json = """
+        {
+            "id": 0,
+            "name": "Parks",
+            "geometryType": "esriGeometryPoint",
+            "objectIdField": "OBJECTID",
+            "globalIdField": "GLOBALID",
+            "capabilities": "Query,Create,Update,Delete,Uploads,Sync",
+            "supportsStatistics": true,
+            "supportsAdvancedQueries": true,
+            "hasAttachments": true,
+            "spatialReference": { "wkid": 4326, "latestWkid": 4326 },
+            "extent": {
+                "xmin": -180,
+                "ymin": -90,
+                "xmax": 180,
+                "ymax": 90,
+                "spatialReference": { "wkid": 4326 }
+            },
+            "timeInfo": {
+                "startTimeField": "start_at",
+                "endTimeField": "end_at",
+                "trackIdField": "track_id",
+                "timeReference": { "timeZone": "UTC" }
+            },
+            "fields": [
+                { "name": "OBJECTID", "type": "esriFieldTypeOID", "alias": "Object ID", "nullable": false, "editable": false },
+                {
+                    "name": "STATUS",
+                    "type": "esriFieldTypeString",
+                    "alias": "Status",
+                    "nullable": false,
+                    "length": 20,
+                    "editable": true,
+                    "defaultValue": "open",
+                    "domain": { "type": "codedValue", "codedValues": [{ "name": "Open", "code": "open" }] }
+                }
+            ]
+        }
+        """;
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            Assert.Contains("/rest/services/parks/FeatureServer/0", req.RequestUri?.ToString());
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var descriptor = await ((IHonuaFeatureDescriptorClient)client).GetDescriptorAsync(new SourceDescriptor
+        {
+            Id = "parks",
+            Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+            Locator = new SourceLocator { ServiceId = "parks", LayerId = 0 }
+        });
+
+        Assert.NotNull(descriptor.Schema);
+        Assert.Equal("OBJECTID", descriptor.Schema.ObjectIdField);
+        Assert.Equal("GLOBALID", descriptor.Schema.GlobalIdField);
+        Assert.Equal(FeatureSpatialGeometryType.Point, descriptor.Schema.GeometryType);
+        Assert.Equal("EPSG:4326", descriptor.Schema.SpatialReference);
+        Assert.Equal("EPSG:4326", descriptor.Schema.Extent?.Crs);
+        Assert.Equal("start_at", descriptor.Schema.TimeInfo?.StartTimeField);
+        Assert.Equal("end_at", descriptor.Schema.TimeInfo?.EndTimeField);
+        Assert.True(descriptor.Schema.EditCapabilities?.SupportsAdds);
+        Assert.True(descriptor.Schema.EditCapabilities?.SupportsUpdates);
+        Assert.True(descriptor.Schema.EditCapabilities?.SupportsDeletes);
+        Assert.Contains(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.Attachments, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.Offline, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
+        var status = Assert.Single(descriptor.Schema.Fields, field => field.Name == "STATUS");
+        Assert.Equal("Status", status.Alias);
+        Assert.Equal("esriFieldTypeString", status.Type);
+        Assert.False(status.Nullable);
+        Assert.Equal(20, status.Length);
+        Assert.True(status.Editable);
+        Assert.True(status.Required);
+        Assert.Equal("open", status.DefaultValue?.GetString());
+        Assert.Equal("codedValue", status.Domain?.GetProperty("type").GetString());
+    }
+
     // ── QueryAsync ──────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -47,6 +47,71 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task GetDescriptorAsync_SharedAbstraction_QueriesSchemaAndExtent()
+    {
+        var capturedRequests = new List<Proto.QueryFeaturesRequest>();
+        var schemaResponse = new Proto.QueryFeaturesResponse
+        {
+            ObjectIdFieldName = "OBJECTID",
+            GeometryType = Proto.GeometryType.Polygon,
+            SpatialReference = new Proto.SpatialReference { Wkid = 3857 }
+        };
+        schemaResponse.Fields.Add(new Proto.FieldDefinition
+        {
+            Name = "NAME",
+            FieldType = Proto.FieldType.String,
+            Length = 255,
+            Nullable = true
+        });
+        var extentResponse = new Proto.QueryFeaturesResponse
+        {
+            Extent = new Proto.Extent
+            {
+                Xmin = -180,
+                Ymin = -90,
+                Xmax = 180,
+                Ymax = 90,
+                SpatialReference = new Proto.SpatialReference { Wkid = 4326 }
+            }
+        };
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>((req, _, _, _) => capturedRequests.Add(req))
+            .Returns<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (req, _, _, _) => CreateAsyncUnaryCall(req.ReturnExtentOnly ? extentResponse : schemaResponse));
+        var client = new HonuaGrpcClient(mockClient.Object);
+
+        var descriptor = await ((IHonuaFeatureDescriptorClient)client).GetDescriptorAsync(new SourceDescriptor
+        {
+            Id = "parcels",
+            Protocol = FeatureProtocolIds.Grpc,
+            Locator = new SourceLocator { ServiceId = "svc", LayerId = 1 }
+        });
+
+        Assert.Equal(2, capturedRequests.Count);
+        Assert.Equal(0, capturedRequests[0].ResultRecordCount);
+        Assert.False(capturedRequests[0].ReturnGeometry);
+        Assert.True(capturedRequests[1].ReturnExtentOnly);
+        Assert.NotNull(descriptor.Schema);
+        Assert.Equal("OBJECTID", descriptor.Schema.ObjectIdField);
+        Assert.Equal(FeatureSpatialGeometryType.Polygon, descriptor.Schema.GeometryType);
+        Assert.Equal("EPSG:3857", descriptor.Schema.SpatialReference);
+        Assert.Equal("EPSG:4326", descriptor.Schema.Extent?.Crs);
+        Assert.Equal("NAME", descriptor.Schema.Fields[0].Name);
+        Assert.Equal("String", descriptor.Schema.Fields[0].Type);
+        Assert.Equal(255, descriptor.Schema.Fields[0].Length);
+        Assert.Contains(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.QueryExtent, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
+    }
+
+    [Fact]
     public async Task QueryFeaturesAsync_AppliesConfiguredDeadline()
     {
         var timeout = TimeSpan.FromSeconds(30);

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -140,6 +140,68 @@ public class HonuaOgcFeaturesClientTests
         Assert.Single(result.Required);
     }
 
+    [Fact]
+    public async Task GetDescriptorAsync_SharedAbstraction_MapsCollectionAndQueryables()
+    {
+        var collectionJson = """
+        {
+            "id": "buildings",
+            "title": "Buildings",
+            "storageCrs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+            "extent": {
+                "spatial": {
+                    "bbox": [[-180, -90, 180, 90]],
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+                }
+            }
+        }
+        """;
+        var queryablesJson = """
+        {
+            "type": "object",
+            "properties": {
+                "id": { "type": "string", "title": "Identifier" },
+                "name": { "type": "string", "title": "Name", "maxLength": 100 },
+                "status": { "type": "string", "enum": ["open", "closed"], "default": "open" }
+            },
+            "required": ["id", "name"]
+        }
+        """;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            var url = req.RequestUri?.ToString();
+            return Task.FromResult(url?.Contains("/queryables", StringComparison.Ordinal) == true
+                ? TestHelpers.CreateRawJsonResponse(queryablesJson)
+                : TestHelpers.CreateRawJsonResponse(collectionJson));
+        });
+
+        var descriptor = await ((IHonuaFeatureDescriptorClient)client).GetDescriptorAsync(new SourceDescriptor
+        {
+            Id = "buildings",
+            Protocol = FeatureProtocolIds.OgcFeatures,
+            Locator = new SourceLocator { CollectionId = "buildings" }
+        });
+
+        Assert.NotNull(descriptor.Schema);
+        Assert.Equal("id", descriptor.Schema.PrimaryKey);
+        Assert.Equal("http://www.opengis.net/def/crs/OGC/1.3/CRS84", descriptor.Schema.SpatialReference);
+        Assert.Equal(-180, descriptor.Schema.Extent?.MinX);
+        Assert.Contains(FeatureCapabilities.QueryObjectIds, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
+        Assert.Contains(FeatureCapabilities.ApplyEdits, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
+        var name = Assert.Single(descriptor.Schema.Fields, field => field.Name == "name");
+        Assert.Equal("Name", name.Alias);
+        Assert.Equal("string", name.Type);
+        Assert.False(name.Nullable);
+        Assert.True(name.Required);
+        Assert.Equal(100, name.Length);
+        var status = Assert.Single(descriptor.Schema.Fields, field => field.Name == "status");
+        Assert.True(status.Nullable);
+        Assert.Equal("open", status.DefaultValue?.GetString());
+        Assert.Equal(JsonValueKind.Array, status.Domain?.ValueKind);
+    }
+
     // ── GetItemsAsync ───────────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/DescribeFeatureTypeTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/DescribeFeatureTypeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Net;
+using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Wfs.Exceptions;
 using Honua.Sdk.Wfs.Tests.Fixtures;
 
@@ -68,6 +69,54 @@ public sealed class DescribeFeatureTypeTests
         Assert.Equal("xsd:string", parcelId.Type);
         Assert.Equal(1, parcelId.MinOccurs);
         Assert.False(parcelId.Nillable);
+    }
+
+    [Fact]
+    public async Task GetDescriptorAsync_SharedAbstraction_MapsCapabilitiesAndSchema()
+    {
+        var capabilities = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:WFS_Capabilities version="2.0.0"
+              xmlns:wfs="http://www.opengis.net/wfs/2.0"
+              xmlns:ows="http://www.opengis.net/ows/1.1">
+              <wfs:FeatureTypeList>
+                <wfs:FeatureType>
+                  <wfs:Name>parcels</wfs:Name>
+                  <wfs:DefaultCRS>urn:ogc:def:crs:EPSG::4326</wfs:DefaultCRS>
+                  <ows:WGS84BoundingBox>
+                    <ows:LowerCorner>-180 -90</ows:LowerCorner>
+                    <ows:UpperCorner>180 90</ows:UpperCorner>
+                  </ows:WGS84BoundingBox>
+                </wfs:FeatureType>
+              </wfs:FeatureTypeList>
+            </wfs:WFS_Capabilities>
+            """;
+        var client = TestHelpers.CreateClient(req =>
+        {
+            var query = req.RequestUri!.Query;
+            return Task.FromResult(query.Contains("REQUEST=GetCapabilities", StringComparison.Ordinal)
+                ? TestHelpers.CreateXmlResponse(capabilities)
+                : TestHelpers.CreateXmlResponse(ValidSchema));
+        });
+
+        var descriptor = await ((IHonuaFeatureDescriptorClient)client).GetDescriptorAsync(new SourceDescriptor
+        {
+            Id = "parcels",
+            Protocol = FeatureProtocolIds.Wfs,
+            Locator = new SourceLocator { TypeName = "parcels" }
+        });
+
+        Assert.NotNull(descriptor.Schema);
+        Assert.Equal(FeatureSpatialGeometryType.Point, descriptor.Schema.GeometryType);
+        Assert.Equal("urn:ogc:def:crs:EPSG::4326", descriptor.Schema.SpatialReference);
+        Assert.Equal("http://www.opengis.net/def/crs/OGC/1.3/CRS84", descriptor.Schema.Extent?.Crs);
+        Assert.Contains(FeatureCapabilities.QueryObjectIds, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, descriptor.Capabilities);
+        var parcelId = Assert.Single(descriptor.Schema.Fields, field => field.Name == "parcel_id");
+        Assert.Equal("xsd:string", parcelId.Type);
+        Assert.False(parcelId.Nullable);
+        Assert.True(parcelId.Required);
+        Assert.Equal("WFS-T Transaction", descriptor.Schema.EditCapabilities?.NativeSurface);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add shared source schema metadata for field aliases, domains, defaults, object/global IDs, geometry type, extent, spatial reference, time info, and edit capabilities
- add `IHonuaFeatureDescriptorClient` plus `IHonuaSource.GetDescriptorAsync()` for provider-neutral source inspection while preserving native metadata access
- implement descriptor discovery for GeoServices, gRPC, OGC API Features, and WFS
- add capability flags for time filters, spatial relationships, and offline/sync, with provider discovery tests and docs

Refs #53.

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore` (0 warnings)
- `dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `dotnet test Honua.Sdk.sln --configuration Release --no-build --no-restore --logger "console;verbosity=minimal"`
- `dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore` (0 warnings)
- `dotnet pack src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj --configuration Release --no-build --no-restore`
- `dotnet pack src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj --configuration Release --no-build --no-restore`
- `HONUA_API_COMPAT_BASE_REF=trunk scripts/validate-api-compat.sh`
