### PR TITLE
Add shared feature attachment contracts

### DIFF
--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -53,6 +53,52 @@ return `SupportsAdds`, `SupportsUpdates`, and `SupportsDeletes` as `false`,
 populate `UnsupportedReason`, and throw `NotSupportedException` from
 `ApplyEditsAsync`.
 
+## Shared Attachment Abstraction
+
+Use `IHonuaFeatureAttachmentClient` when application code needs provider-neutral
+feature attachment operations. The shared contract supports listing attachment
+metadata, downloading attachment streams, adding attachment content, updating
+attachment content or metadata, and deleting attachments.
+
+```csharp
+using Honua.Sdk.Abstractions.Features;
+
+IHonuaFeatureAttachmentClient attachments = attachmentClients
+    .Single(c => c.ProviderName == "geoservices-featureserver");
+
+var listed = await attachments.ListAttachmentsAsync(new FeatureAttachmentListRequest
+{
+    Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+    ObjectId = 42,
+}, ct);
+
+await using var file = File.OpenRead("photo.jpg");
+var addResult = await attachments.AddAttachmentAsync(new FeatureAttachmentAddRequest
+{
+    Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+    ObjectId = 42,
+    Name = "photo.jpg",
+    ContentType = "image/jpeg",
+    Content = file,
+    Keywords = "field",
+}, ct);
+```
+
+Dispose downloaded `FeatureAttachmentContent.Content` streams when finished.
+
+| Provider | Shared attachment support | Native attachment support |
+|----------|---------------------------|---------------------------|
+| gRPC | Registered as unsupported via `IHonuaFeatureAttachmentClient` | Attachment RPCs are not exposed yet |
+| GeoServices FeatureServer | Yes, via `IHonuaFeatureAttachmentClient` | Yes, via FeatureServer attachment endpoints |
+| WFS | Registered as unsupported via `IHonuaFeatureAttachmentClient` | WFS does not expose attachment operations |
+| OGC API Features | Registered as unsupported via `IHonuaFeatureAttachmentClient` | Not defined by this SDK surface |
+| Admin | Not applicable | Admin has control-plane mutations, not data-plane feature attachments |
+
+Select from `IEnumerable<IHonuaFeatureAttachmentClient>` and inspect
+`AttachmentCapabilities` before attempting attachment operations. Unsupported
+providers return all operation flags as `false`, populate `UnsupportedReason`,
+and throw `NotSupportedException` from attachment methods.
+
 ## gRPC Notes
 
 The gRPC shared adapter maps:

--- a/src/Honua.Sdk.Abstractions/Features/FeatureAttachmentModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureAttachmentModels.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Provider attachment capabilities exposed through the shared feature attachment abstraction.
+/// </summary>
+public sealed record FeatureAttachmentCapabilities
+{
+    /// <summary>Whether the provider can list attachments for a feature.</summary>
+    public bool SupportsList { get; init; }
+
+    /// <summary>Whether the provider can download attachment content.</summary>
+    public bool SupportsDownload { get; init; }
+
+    /// <summary>Whether the provider can add attachments.</summary>
+    public bool SupportsAdd { get; init; }
+
+    /// <summary>Whether the provider can update attachment content or metadata.</summary>
+    public bool SupportsUpdate { get; init; }
+
+    /// <summary>Whether the provider can delete attachments.</summary>
+    public bool SupportsDelete { get; init; }
+
+    /// <summary>Native protocol surface used by the provider, when useful for diagnostics.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason attachments are unsupported when no attachment operation is available.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral attachment metadata.
+/// </summary>
+public sealed record FeatureAttachmentInfo
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public long? ParentObjectId { get; init; }
+
+    /// <summary>Provider attachment identifier.</summary>
+    public long? AttachmentId { get; init; }
+
+    /// <summary>Provider global ID, when available.</summary>
+    public string? GlobalId { get; init; }
+
+    /// <summary>Attachment file name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Attachment content type.</summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>Attachment size in bytes.</summary>
+    public long? Size { get; init; }
+
+    /// <summary>Provider keywords or tags associated with the attachment.</summary>
+    public string? Keywords { get; init; }
+
+    /// <summary>Provider URL for direct attachment access, when advertised.</summary>
+    public Uri? Url { get; init; }
+}
+
+/// <summary>
+/// Request to list attachments for one feature.
+/// </summary>
+public sealed record FeatureAttachmentListRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public required long ObjectId { get; init; }
+}
+
+/// <summary>
+/// Request to download one attachment.
+/// </summary>
+public sealed record FeatureAttachmentDownloadRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Provider attachment identifier.</summary>
+    public required long AttachmentId { get; init; }
+}
+
+/// <summary>
+/// Downloaded attachment content. Dispose <see cref="Content"/> when finished.
+/// </summary>
+public sealed record FeatureAttachmentContent
+{
+    /// <summary>Attachment metadata known at download time.</summary>
+    public FeatureAttachmentInfo Info { get; init; } = new();
+
+    /// <summary>Attachment content stream.</summary>
+    public required Stream Content { get; init; }
+}
+
+/// <summary>
+/// Request to add an attachment to one feature.
+/// </summary>
+public sealed record FeatureAttachmentAddRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Attachment file name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Attachment content type.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Attachment content stream.</summary>
+    public required Stream Content { get; init; }
+
+    /// <summary>Provider keywords or tags associated with the attachment.</summary>
+    public string? Keywords { get; init; }
+}
+
+/// <summary>
+/// Request to update an attachment.
+/// </summary>
+public sealed record FeatureAttachmentUpdateRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Provider attachment identifier.</summary>
+    public required long AttachmentId { get; init; }
+
+    /// <summary>Replacement attachment file name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Replacement attachment content type.</summary>
+    public required string ContentType { get; init; }
+
+    /// <summary>Replacement attachment content stream.</summary>
+    public required Stream Content { get; init; }
+
+    /// <summary>Provider keywords or tags associated with the attachment.</summary>
+    public string? Keywords { get; init; }
+}
+
+/// <summary>
+/// Request to delete one attachment.
+/// </summary>
+public sealed record FeatureAttachmentDeleteRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Object ID of the parent feature.</summary>
+    public required long ObjectId { get; init; }
+
+    /// <summary>Provider attachment identifier.</summary>
+    public required long AttachmentId { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral outcome of a single attachment edit operation.
+/// </summary>
+public sealed record FeatureAttachmentResult
+{
+    /// <summary>Provider attachment identifier.</summary>
+    public long? AttachmentId { get; init; }
+
+    /// <summary>Provider global ID, when available.</summary>
+    public string? GlobalId { get; init; }
+
+    /// <summary>Whether the attachment operation succeeded.</summary>
+    public bool Succeeded { get; init; }
+
+    /// <summary>Error details when the operation failed.</summary>
+    public FeatureEditError? Error { get; init; }
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureAttachmentClient.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureAttachmentClient.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Shared feature attachment contract implemented by attachment-capable Honua clients.
+/// </summary>
+public interface IHonuaFeatureAttachmentClient
+{
+    /// <summary>
+    /// Provider name for diagnostics and provider selection.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Provider attachment capabilities exposed by this client.
+    /// </summary>
+    FeatureAttachmentCapabilities AttachmentCapabilities { get; }
+
+    /// <summary>
+    /// Lists attachments for one feature.
+    /// </summary>
+    /// <param name="request">Provider-neutral attachment list request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment metadata.</returns>
+    Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Downloads one attachment.
+    /// </summary>
+    /// <param name="request">Provider-neutral attachment download request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Downloaded attachment content. Dispose the returned content stream when finished.</returns>
+    Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Adds an attachment to one feature.
+    /// </summary>
+    /// <param name="request">Provider-neutral attachment add request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment operation result.</returns>
+    Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates one attachment.
+    /// </summary>
+    /// <param name="request">Provider-neutral attachment update request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment operation result.</returns>
+    Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes one attachment.
+    /// </summary>
+    /// <param name="request">Provider-neutral attachment delete request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Attachment operation result.</returns>
+    Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
@@ -75,6 +75,9 @@ public sealed record SourceSchema
 
     /// <summary>Edit capabilities advertised by the source.</summary>
     public FeatureEditCapabilities? EditCapabilities { get; init; }
+
+    /// <summary>Attachment capabilities advertised by the source.</summary>
+    public FeatureAttachmentCapabilities? AttachmentCapabilities { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureServerEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
+        services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerJsonContext.cs
@@ -17,6 +17,8 @@ namespace Honua.Sdk.GeoServices.FeatureServer;
 [JsonSerializable(typeof(FeatureServerLayerInfo))]
 [JsonSerializable(typeof(FeatureServerQueryResponse))]
 [JsonSerializable(typeof(FeatureServerEditResponse))]
+[JsonSerializable(typeof(FeatureServerAttachmentQueryResponse))]
+[JsonSerializable(typeof(FeatureServerAttachmentEditResponse))]
 [JsonSerializable(typeof(FeatureServerFeature[]))]
 [JsonSerializable(typeof(FeatureServerStatisticDefinition[]))]
 [JsonSerializable(typeof(FeatureServerValidateSqlResponse))]

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 
@@ -19,7 +22,8 @@ public sealed class HonuaFeatureServerClient :
     IHonuaFeatureServerEditClient,
     IHonuaFeatureQueryClient,
     IHonuaFeatureEditClient,
-    IHonuaFeatureDescriptorClient
+    IHonuaFeatureDescriptorClient,
+    IHonuaFeatureAttachmentClient
 {
     private const int PostFallbackThreshold = 2000;
     private static readonly FeatureEditCapabilities ProviderEditCapabilities = new()
@@ -29,6 +33,15 @@ public sealed class HonuaFeatureServerClient :
         SupportsDeletes = true,
         SupportsRollbackOnFailure = true,
         NativeSurface = "GeoServices FeatureServer applyEdits"
+    };
+    private static readonly FeatureAttachmentCapabilities ProviderAttachmentCapabilities = new()
+    {
+        SupportsList = true,
+        SupportsDownload = true,
+        SupportsAdd = true,
+        SupportsUpdate = true,
+        SupportsDelete = true,
+        NativeSurface = "GeoServices FeatureServer attachments"
     };
 
     private readonly HttpClient _http;
@@ -47,6 +60,9 @@ public sealed class HonuaFeatureServerClient :
 
     /// <inheritdoc />
     public FeatureEditCapabilities EditCapabilities => ProviderEditCapabilities;
+
+    /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities => ProviderAttachmentCapabilities;
 
     private static string ServicePath(string serviceId) =>
         $"/rest/services/{Uri.EscapeDataString(serviceId)}/FeatureServer";
@@ -249,6 +265,131 @@ public sealed class HonuaFeatureServerClient :
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetAttachmentSource(request.Source);
+        var path = $"{ServicePath(serviceId)}/{layerId}/{request.ObjectId}/attachments?f=json";
+        var body = await GetStringAsync(path, ct).ConfigureAwait(false);
+        var response = JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerAttachmentQueryResponse)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize attachment response.", body);
+
+        return response.AttachmentInfos
+            .Select(info => ToFeatureAttachmentInfo(info, request.Source, request.ObjectId))
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Response ownership is transferred to FeatureAttachmentContent.Content.")]
+    public async Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetAttachmentSource(request.Source);
+        var path = $"{ServicePath(serviceId)}/{layerId}/{request.ObjectId}/attachments/{request.AttachmentId}";
+        var response = await _http.GetAsync(CreateRequestUri(path), HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            response.Dispose();
+            EnsureSuccess(response, body);
+        }
+
+        var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        var contentLength = response.Content.Headers.ContentLength;
+        var contentDispositionName = response.Content.Headers.ContentDisposition?.FileNameStar ??
+            response.Content.Headers.ContentDisposition?.FileName;
+
+        return new FeatureAttachmentContent
+        {
+            Info = new FeatureAttachmentInfo
+            {
+                Source = request.Source,
+                ParentObjectId = request.ObjectId,
+                AttachmentId = request.AttachmentId,
+                Name = TrimHeaderFileName(contentDispositionName),
+                ContentType = contentType,
+                Size = contentLength,
+            },
+            Content = new ResponseOwningStream(stream, response),
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetAttachmentSource(request.Source);
+        var path = $"{ServicePath(serviceId)}/{layerId}/{request.ObjectId}/addAttachment";
+        var response = await PostAttachmentAsync(
+            path,
+            request.Content,
+            request.Name,
+            request.ContentType,
+            request.Keywords,
+            ct).ConfigureAwait(false);
+
+        return ToFeatureAttachmentResult(response.AddAttachmentResult)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "FeatureServer did not return addAttachmentResult.");
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetAttachmentSource(request.Source);
+        var path = $"{ServicePath(serviceId)}/{layerId}/{request.ObjectId}/updateAttachment";
+        var response = await PostAttachmentAsync(
+            path,
+            request.Content,
+            request.Name,
+            request.ContentType,
+            request.Keywords,
+            ct,
+            ("attachmentId", request.AttachmentId.ToString(CultureInfo.InvariantCulture))).ConfigureAwait(false);
+
+        return ToFeatureAttachmentResult(response.UpdateAttachmentResult)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "FeatureServer did not return updateAttachmentResult.");
+    }
+
+    /// <inheritdoc />
+    public async Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var (serviceId, layerId) = GetAttachmentSource(request.Source);
+        var path = $"{ServicePath(serviceId)}/{layerId}/{request.ObjectId}/deleteAttachments";
+        var body = await PostFormAsync(
+            path,
+            [
+                ("f", "json"),
+                ("attachmentIds", request.AttachmentId.ToString(CultureInfo.InvariantCulture))
+            ],
+            ct).ConfigureAwait(false);
+        var response = JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerAttachmentEditResponse)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize delete attachment response.", body);
+
+        var result = response.DeleteAttachmentResults is { Count: > 0 } results
+            ? results[0]
+            : null;
+
+        return ToFeatureAttachmentResult(result)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "FeatureServer did not return deleteAttachmentResults.");
+    }
+
+    /// <inheritdoc />
     public async Task<long> QueryCountAsync(
         string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken ct = default)
     {
@@ -409,6 +550,48 @@ public sealed class HonuaFeatureServerClient :
         var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         EnsureSuccess(response, body);
         return body;
+    }
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MultipartFormDataContent owns and disposes child HttpContent instances.")]
+    private async Task<FeatureServerAttachmentEditResponse> PostAttachmentAsync(
+        string path,
+        Stream content,
+        string name,
+        string contentType,
+        string? keywords,
+        CancellationToken ct,
+        params (string Key, string Value)[] extraParameters)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        using var form = new MultipartFormDataContent();
+        form.Add(new StringContent("json"), "f");
+
+        if (!string.IsNullOrWhiteSpace(keywords))
+        {
+            form.Add(new StringContent(keywords), "keywords");
+        }
+
+        foreach (var parameter in extraParameters)
+        {
+            form.Add(new StringContent(parameter.Value), parameter.Key);
+        }
+
+        using var uploadStream = new NonDisposingStream(content);
+        using var attachment = new StreamContent(uploadStream);
+        attachment.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+        form.Add(attachment, "attachment", name);
+
+        using var response = await _http.PostAsync(CreateRequestUri(path), form, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerAttachmentEditResponse)
+            ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize attachment edit response.", body);
     }
 
     private static void EnsureSuccess(HttpResponseMessage response, string body)
@@ -796,6 +979,7 @@ public sealed class HonuaFeatureServerClient :
                 }
                 : null,
             EditCapabilities = BuildLayerEditCapabilities(layer),
+            AttachmentCapabilities = BuildLayerAttachmentCapabilities(layer),
         };
     }
 
@@ -827,6 +1011,22 @@ public sealed class HonuaFeatureServerClient :
             SupportsRollbackOnFailure = supportsAnyEdit,
             NativeSurface = ProviderEditCapabilities.NativeSurface,
             UnsupportedReason = supportsAnyEdit ? null : "GeoServices FeatureServer layer does not advertise edit capabilities.",
+        };
+    }
+
+    private static FeatureAttachmentCapabilities BuildLayerAttachmentCapabilities(FeatureServerLayerInfo layer)
+    {
+        return new FeatureAttachmentCapabilities
+        {
+            SupportsList = layer.HasAttachments,
+            SupportsDownload = layer.HasAttachments,
+            SupportsAdd = layer.HasAttachments,
+            SupportsUpdate = layer.HasAttachments,
+            SupportsDelete = layer.HasAttachments,
+            NativeSurface = ProviderAttachmentCapabilities.NativeSurface,
+            UnsupportedReason = layer.HasAttachments
+                ? null
+                : "GeoServices FeatureServer layer does not advertise attachment support.",
         };
     }
 
@@ -900,6 +1100,21 @@ public sealed class HonuaFeatureServerClient :
         }
 
         return (request.Source.ServiceId, request.Source.LayerId.Value);
+    }
+
+    private static (string ServiceId, int LayerId) GetAttachmentSource(FeatureSource source)
+    {
+        if (string.IsNullOrWhiteSpace(source.ServiceId))
+        {
+            throw new ArgumentException("A service ID is required for FeatureServer attachments.", nameof(source));
+        }
+
+        if (!source.LayerId.HasValue)
+        {
+            throw new ArgumentException("A layer ID is required for FeatureServer attachments.", nameof(source));
+        }
+
+        return (source.ServiceId, source.LayerId.Value);
     }
 
     private async Task<string?> ResolveObjectIdFieldAsync(
@@ -1331,6 +1546,43 @@ public sealed class HonuaFeatureServerClient :
                 : null,
         };
     }
+
+    private static FeatureAttachmentInfo ToFeatureAttachmentInfo(
+        FeatureServerAttachmentInfo info,
+        FeatureSource source,
+        long fallbackParentObjectId)
+    {
+        return new FeatureAttachmentInfo
+        {
+            Source = source,
+            ParentObjectId = info.ParentObjectId ?? fallbackParentObjectId,
+            AttachmentId = info.Id,
+            GlobalId = info.GlobalId,
+            Name = info.Name,
+            ContentType = info.ContentType,
+            Size = info.Size,
+            Keywords = info.Keywords,
+            Url = info.Url,
+        };
+    }
+
+    private static FeatureAttachmentResult? ToFeatureAttachmentResult(FeatureServerAttachmentEditResult? result)
+    {
+        return result is null
+            ? null
+            : new FeatureAttachmentResult
+            {
+                AttachmentId = result.ObjectId,
+                GlobalId = result.GlobalId,
+                Succeeded = result.Success,
+                Error = result.Error is not null ? ToFeatureEditError(result.Error) : null,
+            };
+    }
+
+    private static string? TrimHeaderFileName(string? fileName)
+        => string.IsNullOrWhiteSpace(fileName)
+            ? null
+            : fileName.Trim('"');
 
     private FeatureEditResponse ToFeatureEditResponse(FeatureServerEditResponse response)
     {

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerAttachmentModels.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Models/FeatureServerAttachmentModels.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.GeoServices.FeatureServer.Models;
+
+/// <summary>
+/// FeatureServer attachment metadata response.
+/// </summary>
+public sealed class FeatureServerAttachmentQueryResponse
+{
+    /// <summary>Attachments associated with the requested feature.</summary>
+    [JsonPropertyName("attachmentInfos")]
+    public IReadOnlyList<FeatureServerAttachmentInfo> AttachmentInfos { get; init; } = [];
+}
+
+/// <summary>
+/// FeatureServer attachment metadata.
+/// </summary>
+public sealed class FeatureServerAttachmentInfo
+{
+    /// <summary>Provider attachment identifier.</summary>
+    [JsonPropertyName("id")]
+    public long? Id { get; init; }
+
+    /// <summary>Parent feature object ID, when returned by the server.</summary>
+    [JsonPropertyName("parentObjectId")]
+    public long? ParentObjectId { get; init; }
+
+    /// <summary>Provider global ID, when available.</summary>
+    [JsonPropertyName("globalId")]
+    public string? GlobalId { get; init; }
+
+    /// <summary>Attachment file name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>Attachment content type.</summary>
+    [JsonPropertyName("contentType")]
+    public string? ContentType { get; init; }
+
+    /// <summary>Attachment size in bytes.</summary>
+    [JsonPropertyName("size")]
+    public long? Size { get; init; }
+
+    /// <summary>Provider keywords or tags.</summary>
+    [JsonPropertyName("keywords")]
+    public string? Keywords { get; init; }
+
+    /// <summary>Provider URL for direct attachment access.</summary>
+    [JsonPropertyName("url")]
+    public Uri? Url { get; init; }
+}
+
+/// <summary>
+/// FeatureServer attachment edit response.
+/// </summary>
+public sealed class FeatureServerAttachmentEditResponse
+{
+    /// <summary>Add attachment result.</summary>
+    [JsonPropertyName("addAttachmentResult")]
+    public FeatureServerAttachmentEditResult? AddAttachmentResult { get; init; }
+
+    /// <summary>Update attachment result.</summary>
+    [JsonPropertyName("updateAttachmentResult")]
+    public FeatureServerAttachmentEditResult? UpdateAttachmentResult { get; init; }
+
+    /// <summary>Delete attachment results.</summary>
+    [JsonPropertyName("deleteAttachmentResults")]
+    public IReadOnlyList<FeatureServerAttachmentEditResult>? DeleteAttachmentResults { get; init; }
+}
+
+/// <summary>
+/// The outcome of a single FeatureServer attachment edit operation.
+/// </summary>
+public sealed class FeatureServerAttachmentEditResult
+{
+    /// <summary>Provider attachment identifier.</summary>
+    [JsonPropertyName("objectId")]
+    public long? ObjectId { get; init; }
+
+    /// <summary>Provider global ID, when available.</summary>
+    [JsonPropertyName("globalId")]
+    public string? GlobalId { get; init; }
+
+    /// <summary>Whether the operation succeeded.</summary>
+    [JsonPropertyName("success")]
+    public bool Success { get; init; }
+
+    /// <summary>Error details when the operation failed.</summary>
+    [JsonPropertyName("error")]
+    public FeatureServerEditError? Error { get; init; }
+}

--- a/src/Honua.Sdk.GeoServices/NonDisposingStream.cs
+++ b/src/Honua.Sdk.GeoServices/NonDisposingStream.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.GeoServices;
+
+/// <summary>
+/// Stream wrapper that leaves the underlying stream open when disposed.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Usage",
+    "CA2213:Disposable fields should be disposed",
+    Justification = "The wrapped stream is caller-owned and must remain open after upload.")]
+internal sealed class NonDisposingStream : Stream
+{
+    private readonly Stream _inner;
+
+    internal NonDisposingStream(Stream inner)
+    {
+        _inner = inner;
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => _inner.CanWrite;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public override void Flush() => _inner.Flush();
+    public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.ReadAsync(buffer, cancellationToken);
+
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+    public override void SetLength(long value) => _inner.SetLength(value);
+    public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+    public override void Write(ReadOnlySpan<byte> buffer) => _inner.Write(buffer);
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.WriteAsync(buffer, cancellationToken);
+}

--- a/src/Honua.Sdk.GeoServices/ResponseOwningStream.cs
+++ b/src/Honua.Sdk.GeoServices/ResponseOwningStream.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.GeoServices;
+
+/// <summary>
+/// Stream wrapper that disposes the underlying HTTP response when the stream is disposed.
+/// </summary>
+internal sealed class ResponseOwningStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly HttpResponseMessage _response;
+
+    internal ResponseOwningStream(Stream inner, HttpResponseMessage response)
+    {
+        _inner = inner;
+        _response = response;
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => false;
+    public override long Length => _inner.Length;
+
+    public override long Position
+    {
+        get => _inner.Position;
+        set => _inner.Position = value;
+    }
+
+    public override void Flush() => _inner.Flush();
+    public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+    public override void SetLength(long value) => _inner.SetLength(value);
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        => _inner.ReadAsync(buffer, cancellationToken);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _inner.Dispose();
+            _response.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _inner.DisposeAsync().ConfigureAwait(false);
+        _response.Dispose();
+        await base.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IHonuaGrpcClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
         services.AddSingleton<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
         services.AddSingleton<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
+        services.AddSingleton<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaGrpcClient>());
         return services;
     }
 }

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -22,9 +22,11 @@ public sealed class HonuaGrpcClient :
     IHonuaFeatureQueryClient,
     IHonuaFeatureEditClient,
     IHonuaFeatureDescriptorClient,
+    IHonuaFeatureAttachmentClient,
     IDisposable
 {
     private const string FeatureServiceName = "geospatial.v1.FeatureService";
+    private const string UnsupportedAttachmentReason = "gRPC FeatureService does not expose attachment RPCs yet.";
 
     private static readonly JsonSerializerOptions FeatureJsonOptions = new()
     {
@@ -37,6 +39,11 @@ public sealed class HonuaGrpcClient :
         SupportsDeletes = true,
         SupportsRollbackOnFailure = true,
         NativeSurface = "grpc FeatureService.ApplyEdits"
+    };
+    private static readonly FeatureAttachmentCapabilities GrpcAttachmentCapabilities = new()
+    {
+        NativeSurface = "grpc FeatureService attachments",
+        UnsupportedReason = UnsupportedAttachmentReason
     };
 
     private readonly Proto.FeatureService.FeatureServiceClient _client;
@@ -110,6 +117,9 @@ public sealed class HonuaGrpcClient :
 
     /// <inheritdoc />
     public FeatureEditCapabilities EditCapabilities => GrpcEditCapabilities;
+
+    /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities => GrpcAttachmentCapabilities;
 
     /// <inheritdoc />
     public async Task<SourceDescriptor> GetDescriptorAsync(SourceDescriptor descriptor, CancellationToken ct = default)
@@ -225,6 +235,36 @@ public sealed class HonuaGrpcClient :
         var response = await ApplyEditsAsync(BuildGrpcEditRequest(request), ct).ConfigureAwait(false);
         return ToFeatureEditResponse(response);
     }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<IReadOnlyList<FeatureAttachmentInfo>>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentContent>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
 
     /// <inheritdoc />
     public async IAsyncEnumerable<Models.FeaturePage> QueryFeaturesStreamAsync(
@@ -416,7 +456,15 @@ public sealed class HonuaGrpcClient :
             Extent = extent is not null ? ToFeatureBoundingBox(extent) : null,
             SpatialReference = FormatSpatialReference(response.SpatialReference),
             EditCapabilities = GrpcEditCapabilities,
+            AttachmentCapabilities = GrpcAttachmentCapabilities,
         };
+    }
+
+    private static Task<TResult> ThrowUnsupportedAttachmentAsync<TResult>(object request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        throw new NotSupportedException(UnsupportedAttachmentReason);
     }
 
     private static SourceField ToSourceField(Models.FieldDefinition field)

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaOgcFeaturesEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
+        services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -20,11 +20,14 @@ public sealed class HonuaOgcFeaturesClient :
     IHonuaOgcFeaturesEditClient,
     IHonuaFeatureQueryClient,
     IHonuaFeatureEditClient,
-    IHonuaFeatureDescriptorClient
+    IHonuaFeatureDescriptorClient,
+    IHonuaFeatureAttachmentClient
 {
     private const string BasePath = "/ogc/features";
     private const string RollbackUnsupportedReason =
         "OGC API Features create, update, and delete endpoints do not support rollback-on-failure edit batches.";
+    private const string UnsupportedAttachmentReason =
+        "OGC API Features does not define provider-neutral attachment operations in this SDK.";
 
     private static readonly FeatureEditCapabilities OgcEditCapabilities = new()
     {
@@ -32,6 +35,11 @@ public sealed class HonuaOgcFeaturesClient :
         SupportsUpdates = true,
         SupportsDeletes = true,
         NativeSurface = "OGC API Features create/update/delete"
+    };
+    private static readonly FeatureAttachmentCapabilities OgcAttachmentCapabilities = new()
+    {
+        NativeSurface = "OGC API Features attachments",
+        UnsupportedReason = UnsupportedAttachmentReason
     };
 
     private readonly HttpClient _http;
@@ -50,6 +58,9 @@ public sealed class HonuaOgcFeaturesClient :
 
     /// <inheritdoc />
     public FeatureEditCapabilities EditCapabilities => OgcEditCapabilities;
+
+    /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities => OgcAttachmentCapabilities;
 
     /// <inheritdoc />
     public async Task<OgcLandingPage> GetLandingPageAsync(CancellationToken ct = default)
@@ -185,6 +196,36 @@ public sealed class HonuaOgcFeaturesClient :
             DeleteResults = deleteResults
         };
     }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<IReadOnlyList<FeatureAttachmentInfo>>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentContent>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
 
     /// <inheritdoc />
     public async Task<OgcFeature> GetItemAsync(string collectionId, string featureId, CancellationToken ct = default)
@@ -520,7 +561,15 @@ public sealed class HonuaOgcFeaturesClient :
             Extent = ToFeatureBoundingBox(collection.Extent?.Spatial, spatialReference),
             SpatialReference = spatialReference,
             EditCapabilities = OgcEditCapabilities,
+            AttachmentCapabilities = OgcAttachmentCapabilities,
         };
+    }
+
+    private static Task<TResult> ThrowUnsupportedAttachmentAsync<TResult>(object request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        throw new NotSupportedException(UnsupportedAttachmentReason);
     }
 
     private static List<SourceField> BuildQueryableFields(OgcQueryables? queryables)

--- a/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaWfsClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
+        services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -25,15 +25,22 @@ public sealed class HonuaWfsClient :
     IHonuaWfsClient,
     IHonuaFeatureQueryClient,
     IHonuaFeatureEditClient,
-    IHonuaFeatureDescriptorClient
+    IHonuaFeatureDescriptorClient,
+    IHonuaFeatureAttachmentClient
 {
     private static readonly ActivitySource ActivitySource = new("Honua.Sdk.Wfs");
     private static readonly GeoJsonFeatureCollectionHandler DefaultGeoJsonHandler = new();
     private const string UnsupportedEditReason = "Honua.Sdk.Wfs does not currently implement WFS-T transactions.";
+    private const string UnsupportedAttachmentReason = "WFS does not expose attachment operations.";
     private static readonly FeatureEditCapabilities UnsupportedEditCapabilities = new()
     {
         NativeSurface = "WFS-T Transaction",
         UnsupportedReason = UnsupportedEditReason
+    };
+    private static readonly FeatureAttachmentCapabilities UnsupportedAttachmentCapabilities = new()
+    {
+        NativeSurface = "WFS attachments",
+        UnsupportedReason = UnsupportedAttachmentReason
     };
 
     private static readonly JsonSerializerOptions FeatureJsonOptions = new()
@@ -60,6 +67,9 @@ public sealed class HonuaWfsClient :
 
     /// <inheritdoc />
     public FeatureEditCapabilities EditCapabilities => UnsupportedEditCapabilities;
+
+    /// <inheritdoc />
+    public FeatureAttachmentCapabilities AttachmentCapabilities => UnsupportedAttachmentCapabilities;
 
     /// <inheritdoc />
     public async Task<WfsCapabilities> GetCapabilitiesAsync(CancellationToken ct = default)
@@ -193,6 +203,36 @@ public sealed class HonuaWfsClient :
         ct.ThrowIfCancellationRequested();
         throw new NotSupportedException(UnsupportedEditReason);
     }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<FeatureAttachmentInfo>> ListAttachmentsAsync(
+        FeatureAttachmentListRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<IReadOnlyList<FeatureAttachmentInfo>>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentContent> DownloadAttachmentAsync(
+        FeatureAttachmentDownloadRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentContent>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> AddAttachmentAsync(
+        FeatureAttachmentAddRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> UpdateAttachmentAsync(
+        FeatureAttachmentUpdateRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
+
+    /// <inheritdoc />
+    public Task<FeatureAttachmentResult> DeleteAttachmentAsync(
+        FeatureAttachmentDeleteRequest request,
+        CancellationToken ct = default)
+        => ThrowUnsupportedAttachmentAsync<FeatureAttachmentResult>(request, ct);
 
     /// <inheritdoc />
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Response ownership is transferred to ResponseOwningStream when the handler owns the response stream.")]
@@ -492,7 +532,15 @@ public sealed class HonuaWfsClient :
             Extent = ToFeatureBoundingBox(featureType),
             SpatialReference = featureType?.DefaultCrs,
             EditCapabilities = UnsupportedEditCapabilities,
+            AttachmentCapabilities = UnsupportedAttachmentCapabilities,
         };
+    }
+
+    private static Task<TResult> ThrowUnsupportedAttachmentAsync<TResult>(object request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        throw new NotSupportedException(UnsupportedAttachmentReason);
     }
 
     private static SourceField ToSourceField(WfsSchemaProperty property)

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices.Extensions;
@@ -141,6 +143,11 @@ public class HonuaFeatureServerClientTests
         Assert.True(descriptor.Schema.EditCapabilities?.SupportsAdds);
         Assert.True(descriptor.Schema.EditCapabilities?.SupportsUpdates);
         Assert.True(descriptor.Schema.EditCapabilities?.SupportsDeletes);
+        Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsList);
+        Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsDownload);
+        Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsAdd);
+        Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsUpdate);
+        Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsDelete);
         Assert.Contains(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
         Assert.Contains(FeatureCapabilities.Attachments, descriptor.Capabilities);
         Assert.Contains(FeatureCapabilities.Offline, descriptor.Capabilities);
@@ -634,6 +641,160 @@ public class HonuaFeatureServerClientTests
     }
 
     [Fact]
+    public async Task AttachmentOperationsAsync_SharedAbstraction_UsesFeatureServerAttachmentEndpoints()
+    {
+        var client = TestHelpers.CreateFeatureServerClient(async req =>
+        {
+            var path = req.RequestUri?.AbsolutePath;
+            if (req.Method == HttpMethod.Get &&
+                path == "/rest/services/parks/FeatureServer/0/42/attachments")
+            {
+                Assert.Equal("?f=json", req.RequestUri?.Query);
+                return TestHelpers.CreateRawJsonResponse("""
+                {
+                    "attachmentInfos": [
+                        {
+                            "id": 7,
+                            "parentObjectId": 42,
+                            "globalId": "attachment-global-id",
+                            "name": "photo.txt",
+                            "contentType": "text/plain",
+                            "size": 5,
+                            "keywords": "field",
+                            "url": "http://localhost/files/7"
+                        }
+                    ]
+                }
+                """);
+            }
+
+            if (req.Method == HttpMethod.Get &&
+                path == "/rest/services/parks/FeatureServer/0/42/attachments/7")
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes("photo"))
+                };
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+                response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+                {
+                    FileName = "\"photo.txt\""
+                };
+                return response;
+            }
+
+            if (req.Method == HttpMethod.Post &&
+                path == "/rest/services/parks/FeatureServer/0/42/addAttachment")
+            {
+                var body = await req.Content!.ReadAsStringAsync();
+                Assert.Contains("name=f", body);
+                Assert.Contains("name=keywords", body);
+                Assert.Contains("field", body);
+                Assert.Contains("name=attachment", body);
+                Assert.Contains("filename=photo.txt", body);
+                Assert.Contains("text/plain", body);
+                return TestHelpers.CreateRawJsonResponse("""
+                { "addAttachmentResult": { "objectId": 8, "globalId": "added-global-id", "success": true } }
+                """);
+            }
+
+            if (req.Method == HttpMethod.Post &&
+                path == "/rest/services/parks/FeatureServer/0/42/updateAttachment")
+            {
+                var body = await req.Content!.ReadAsStringAsync();
+                Assert.Contains("name=attachmentId", body);
+                Assert.Contains("7", body);
+                return TestHelpers.CreateRawJsonResponse("""
+                { "updateAttachmentResult": { "objectId": 7, "globalId": "updated-global-id", "success": true } }
+                """);
+            }
+
+            if (req.Method == HttpMethod.Post &&
+                path == "/rest/services/parks/FeatureServer/0/42/deleteAttachments")
+            {
+                var body = await req.Content!.ReadAsStringAsync();
+                Assert.Contains("f=json", body);
+                Assert.Contains("attachmentIds=7", body);
+                return TestHelpers.CreateRawJsonResponse("""
+                { "deleteAttachmentResults": [{ "objectId": 7, "success": true }] }
+                """);
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {req.Method} {req.RequestUri}");
+        });
+
+        var source = new FeatureSource { ServiceId = "parks", LayerId = 0 };
+        var attachments = (IHonuaFeatureAttachmentClient)client;
+
+        var listed = await attachments.ListAttachmentsAsync(new FeatureAttachmentListRequest
+        {
+            Source = source,
+            ObjectId = 42
+        });
+
+        var info = Assert.Single(listed);
+        Assert.Equal(7, info.AttachmentId);
+        Assert.Equal(42, info.ParentObjectId);
+        Assert.Equal("attachment-global-id", info.GlobalId);
+        Assert.Equal("photo.txt", info.Name);
+        Assert.Equal("text/plain", info.ContentType);
+        Assert.Equal(5, info.Size);
+        Assert.Equal("field", info.Keywords);
+        Assert.Equal(new Uri("http://localhost/files/7"), info.Url);
+
+        var downloaded = await attachments.DownloadAttachmentAsync(new FeatureAttachmentDownloadRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7
+        });
+        using var reader = new StreamReader(downloaded.Content, Encoding.UTF8);
+        Assert.Equal("photo", await reader.ReadToEndAsync());
+        Assert.Equal("photo.txt", downloaded.Info.Name);
+        Assert.Equal("text/plain", downloaded.Info.ContentType);
+
+        using var addContent = new MemoryStream(Encoding.UTF8.GetBytes("photo"));
+        var addResult = await attachments.AddAttachmentAsync(new FeatureAttachmentAddRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            Name = "photo.txt",
+            ContentType = "text/plain",
+            Content = addContent,
+            Keywords = "field"
+        });
+        Assert.True(addResult.Succeeded);
+        Assert.Equal(8, addResult.AttachmentId);
+        Assert.Equal("added-global-id", addResult.GlobalId);
+        Assert.True(addContent.CanRead);
+
+        using var updateContent = new MemoryStream(Encoding.UTF8.GetBytes("photo2"));
+        var updateResult = await attachments.UpdateAttachmentAsync(new FeatureAttachmentUpdateRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7,
+            Name = "photo.txt",
+            ContentType = "text/plain",
+            Content = updateContent,
+            Keywords = "field"
+        });
+        Assert.True(updateResult.Succeeded);
+        Assert.Equal(7, updateResult.AttachmentId);
+        Assert.Equal("updated-global-id", updateResult.GlobalId);
+        Assert.True(updateContent.CanRead);
+
+        var deleteResult = await attachments.DeleteAttachmentAsync(new FeatureAttachmentDeleteRequest
+        {
+            Source = source,
+            ObjectId = 42,
+            AttachmentId = 7
+        });
+        Assert.True(deleteResult.Succeeded);
+        Assert.Equal(7, deleteResult.AttachmentId);
+    }
+
+    [Fact]
     public async Task GetEditCapabilitiesAsync_ParsesLayerCapabilities()
     {
         var client = TestHelpers.CreateFeatureServerClient(_ =>
@@ -663,12 +824,19 @@ public class HonuaFeatureServerClientTests
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
         var featureServerEditClient = Assert.Single(provider.GetServices<IHonuaFeatureServerEditClient>());
+        var attachmentClient = Assert.Single(provider.GetServices<IHonuaFeatureAttachmentClient>());
 
         Assert.Equal("geoservices-featureserver", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
         Assert.True(editClient.EditCapabilities.SupportsUpdates);
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
         Assert.IsType<HonuaFeatureServerClient>(featureServerEditClient);
+        Assert.Equal("geoservices-featureserver", attachmentClient.ProviderName);
+        Assert.True(attachmentClient.AttachmentCapabilities.SupportsList);
+        Assert.True(attachmentClient.AttachmentCapabilities.SupportsDownload);
+        Assert.True(attachmentClient.AttachmentCapabilities.SupportsAdd);
+        Assert.True(attachmentClient.AttachmentCapabilities.SupportsUpdate);
+        Assert.True(attachmentClient.AttachmentCapabilities.SupportsDelete);
     }
 
     // ── GetFeatureAsync ────────────────────────────────────────────

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -500,11 +500,15 @@ public class HonuaGrpcClientTests
 
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+        var attachmentClient = Assert.Single(provider.GetServices<IHonuaFeatureAttachmentClient>());
 
         Assert.Equal("grpc", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
         Assert.True(editClient.EditCapabilities.SupportsUpdates);
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
+        Assert.Equal("grpc", attachmentClient.ProviderName);
+        Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);
+        Assert.Contains("attachment RPCs", attachmentClient.AttachmentCapabilities.UnsupportedReason);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -49,6 +49,7 @@ public sealed class ClientOptionsTests
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
         var nativeEditClient = Assert.Single(provider.GetServices<IHonuaOgcFeaturesEditClient>());
+        var attachmentClient = Assert.Single(provider.GetServices<IHonuaFeatureAttachmentClient>());
 
         Assert.Equal("ogc-features", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
@@ -56,6 +57,9 @@ public sealed class ClientOptionsTests
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
         Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
         Assert.IsType<HonuaOgcFeaturesClient>(nativeEditClient);
+        Assert.Equal("ogc-features", attachmentClient.ProviderName);
+        Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);
+        Assert.Contains("attachment operations", attachmentClient.AttachmentCapabilities.UnsupportedReason);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
@@ -48,12 +48,16 @@ public sealed class ClientOptionsTests
 
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
+        var attachmentClient = Assert.Single(provider.GetServices<IHonuaFeatureAttachmentClient>());
 
         Assert.Equal("wfs", editClient.ProviderName);
         Assert.False(editClient.EditCapabilities.SupportsAdds);
         Assert.False(editClient.EditCapabilities.SupportsUpdates);
         Assert.False(editClient.EditCapabilities.SupportsDeletes);
         Assert.Contains("WFS-T", editClient.EditCapabilities.UnsupportedReason);
+        Assert.Equal("wfs", attachmentClient.ProviderName);
+        Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);
+        Assert.Contains("attachment operations", attachmentClient.AttachmentCapabilities.UnsupportedReason);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add provider-neutral `IHonuaFeatureAttachmentClient` contracts and attachment capability metadata on `SourceSchema`.
- Implement GeoServices FeatureServer list/download/add/update/delete attachment operations through the shared abstraction.
- Register attachment clients across GeoServices, gRPC, WFS, and OGC; non-attachment providers expose explicit unsupported capability metadata.
- Document shared attachment semantics and add unit coverage for endpoint mapping, descriptor capabilities, DI registration, and stream ownership.

Closes #54.

## Validation
- `dotnet build`
- `dotnet test --no-build`
- `dotnet format --verify-no-changes`
- `git diff --check`
