### PR TITLE
sdk: add routing client contracts

### DIFF
--- a/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
+++ b/contracts/fixtures/mobile-sdk-contract-harmonization.v1.json
@@ -6,7 +6,7 @@
   "compatibility": {
     "mobileBaseline": {
       "repository": "honua-io/honua-mobile",
-      "ref": "main after honua-mobile#52",
+      "ref": "main after honua-mobile#67",
       "packageVersion": "unreleased-source"
     },
     "sdkBaseline": {
@@ -15,27 +15,27 @@
       "packages": [
         {
           "packageId": "Honua.Sdk.Abstractions",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline.Abstractions",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Offline",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.Grpc",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.GeoServices",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         },
         {
           "packageId": "Honua.Sdk.OgcFeatures",
-          "version": "0.1.2-alpha.1"
+          "version": "0.1.4-alpha.1"
         }
       ]
     }
@@ -94,6 +94,31 @@
       "mobileDisposition": "adapter-required",
       "migrationIssue": "honua-mobile#54",
       "notes": "Offline queue rows keep mobile retry metadata, but uploaded payloads should map to FeatureEditRequest."
+    },
+    {
+      "id": "feature-attachments",
+      "displayName": "Feature attachment metadata and edit requests",
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Features.IHonuaFeatureAttachmentClient",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentCapabilities",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentInfo",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentListRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentDownloadRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentContent",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentAddRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentUpdateRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentDeleteRequest",
+        "Honua.Sdk.Abstractions.Features.FeatureAttachmentResult"
+      ],
+      "mobileTypes": [
+        "Honua.Mobile.Sdk.Features.HonuaMobileSdkFeatureClient",
+        "Honua.Mobile.Offline.Sync.HonuaMobileSdkFeatureClient"
+      ],
+      "mobileDisposition": "adapter-only",
+      "migrationIssue": "honua-mobile#54",
+      "notes": "Attachment request/result shapes are SDK-owned. Mobile should delegate through the SDK feature attachment client and keep only platform/runtime adapter behavior."
     },
     {
       "id": "geometry",
@@ -198,9 +223,25 @@
     {
       "id": "routing",
       "displayName": "Routing and network analysis requests",
-      "owner": "shared-split",
-      "authoritativePackage": "pending Honua.Sdk.Routing contracts",
-      "authoritativeTypes": [],
+      "owner": "honua-sdk-dotnet",
+      "authoritativePackage": "Honua.Sdk.Abstractions",
+      "authoritativeTypes": [
+        "Honua.Sdk.Abstractions.Routing.IHonuaRoutingClient",
+        "Honua.Sdk.Abstractions.Routing.RoutingCapabilities",
+        "Honua.Sdk.Abstractions.Routing.RouteServiceMetadataRequest",
+        "Honua.Sdk.Abstractions.Routing.RouteServiceMetadata",
+        "Honua.Sdk.Abstractions.Routing.RouteTravelMode",
+        "Honua.Sdk.Abstractions.Routing.RoutingCoordinate",
+        "Honua.Sdk.Abstractions.Routing.RoutingLocation",
+        "Honua.Sdk.Abstractions.Routing.RouteTimeWindow",
+        "Honua.Sdk.Abstractions.Routing.RouteDirectionsRequest",
+        "Honua.Sdk.Abstractions.Routing.RouteOptimizationRequest",
+        "Honua.Sdk.Abstractions.Routing.ServiceAreaRequest",
+        "Honua.Sdk.Abstractions.Routing.ClosestFacilityRequest",
+        "Honua.Sdk.Abstractions.Routing.RouteResult",
+        "Honua.Sdk.Abstractions.Routing.ServiceAreaResult",
+        "Honua.Sdk.Abstractions.Routing.ClosestFacilityResult"
+      ],
       "mobileTypes": [
         "Honua.Mobile.Sdk.Routing.RouteDirectionsRequest",
         "Honua.Mobile.Sdk.Routing.RouteOptimizationRequest",
@@ -210,12 +251,12 @@
         "Honua.Mobile.Sdk.Routing.HonuaRoutingClient",
         "Honua.Mobile.Sdk.Routing.IRoutingLocationProvider"
       ],
-      "mobileDisposition": "mobile-authoritative-until-sdk-routing",
+      "mobileDisposition": "adapter-required",
       "migrationIssue": "honua-sdk-dotnet#60",
       "serverDependencyIssues": [
         "honua-server#366"
       ],
-      "notes": "Routing contracts can move to SDK; device location providers and platform permission flows stay mobile-owned."
+      "notes": "Routing contracts are SDK-owned. Device location providers, platform permission flows, route display, and map interaction stay mobile-owned."
     },
     {
       "id": "geopackage-sync",

--- a/docs/mobile-contract-harmonization.md
+++ b/docs/mobile-contract-harmonization.md
@@ -11,7 +11,7 @@ read the same ownership map without referencing each other's assemblies.
 
 | Mobile baseline | Shared SDK baseline | Status |
 |-----------------|---------------------|--------|
-| `honua-mobile` source packages from `main` after `honua-mobile#52` | `Honua.Sdk.*` `0.1.2-alpha.1` | Fixture-level compatibility for shared feature, source, edit, and offline contracts |
+| `honua-mobile` source packages from `main` after `honua-mobile#67` | `Honua.Sdk.*` `0.1.4-alpha.1` | Fixture-level compatibility for shared feature, source, edit, attachment, routing, and offline contracts |
 
 `honua-mobile` does not currently publish versioned NuGet packages. Until it
 does, compatibility is stated as source-baseline compatibility against the
@@ -23,11 +23,12 @@ published `Honua.Sdk.*` package versions in the fixture.
 |--------------|-------|--------------------|
 | Feature query requests/results | `Honua.Sdk.Abstractions` | Mobile DTOs become transport shims or adapters. |
 | Feature edit envelopes/results | `Honua.Sdk.Abstractions` | Mobile edit DTOs and queued offline payloads map to SDK edit contracts. |
+| Feature attachment requests/results | `Honua.Sdk.Abstractions` | Mobile delegates through SDK attachment clients and keeps only runtime adapter behavior. |
 | Geometry and spatial references | Split pending SDK geometry contracts | Keep platform coordinates at mobile edges; use NetTopologySuite and ProjNet rather than custom geometry engines where possible. |
 | Offline sync state, journals, conflicts | `Honua.Sdk.Offline.Abstractions` plus mobile runtime adapters | Mobile owns native queues, GeoPackage persistence, scheduling, and background execution. |
 | Form-related feature schemas | `Honua.Sdk.Abstractions` now; pending field package for workflow contracts | Mobile owns form rendering, validation UX, capture workflow, and device media handling. |
 | Scene metadata and offline scene packages | Pending SDK scene contracts after server dependencies | Mobile and embed own renderers, caches, downloads, and display lifecycle. |
-| Routing and network analysis | Pending SDK routing contracts after server dependency | Mobile owns device location providers and platform permission flows. |
+| Routing and network analysis | `Honua.Sdk.Abstractions` contracts plus `Honua.Sdk.GeoServices` NAServer client | Mobile owns device location providers, platform permission flows, route display, and map interaction. |
 | GeoPackage sync and native storage | `honua-mobile` | SDK describes portable manifests and journals only. |
 | Display/embed maps | `honua-mobile` / `Honua.Embed` | SDK returns portable contracts only; MapLibre, deck.gl, Cesium, Mapsui, WebGL/WebGPU, and map controls stay outside SDK core. |
 | Non-UI plugin contracts | Pending SDK plugin contracts after server dependency | Hosts own runtime loading, UI registration, sandboxing, and signing. |
@@ -40,6 +41,12 @@ published `Honua.Sdk.*` package versions in the fixture.
   `FeatureQueryResult`, `FeatureSource`, `SourceDescriptor`, and `SourceQuery`.
 - New provider-neutral feature edit code targets `FeatureEditRequest`,
   `FeatureEditResponse`, and related edit result models.
+- New provider-neutral feature attachment code targets
+  `IHonuaFeatureAttachmentClient` and the `FeatureAttachment*` request/result
+  contracts.
+- New provider-neutral routing code targets
+  `Honua.Sdk.Abstractions.Routing.IHonuaRoutingClient` and the
+  `Route*`/`ServiceArea*`/`ClosestFacility*` contracts.
 - New portable offline code targets `Honua.Sdk.Offline.Abstractions` for
   manifests, source descriptors, change journal entries, checkpoints, retry
   checkpoints, and conflict envelopes.
@@ -62,6 +69,7 @@ published `Honua.Sdk.*` package versions in the fixture.
   SDK offline contracts while keeping runtime storage in mobile.
 - `honua-sdk-dotnet#55` defines geometry ownership and should lean on
   NetTopologySuite and ProjNet rather than custom geometry/projection code.
-- `honua-sdk-dotnet#60`, `#70`, `#71`, and `#72` graduate routing, scene, field,
-  and plugin contracts into SDK packages after linked server dependencies are
-  ready.
+- `honua-sdk-dotnet#70`, `#71`, and `#72` graduate scene, field, and plugin
+  contracts into SDK packages after linked server dependencies are ready.
+- `honua-mobile#54` should replace local routing DTOs with the published SDK
+  routing contracts once the next SDK package is released.

--- a/docs/sdk-capability-backlog.md
+++ b/docs/sdk-capability-backlog.md
@@ -418,6 +418,11 @@ Acceptance criteria:
 Outcome: route solving is available as a service client without tying the SDK to
 any map control.
 
+Implementation status: `Honua.Sdk.Abstractions.Routing` owns provider-neutral
+routing contracts. `Honua.Sdk.GeoServices.Routing.HonuaRoutingClient` provides
+the GeoServices NAServer implementation and keeps live navigation, voice
+guidance, current-location acquisition, and route display in downstream apps.
+
 Acceptance criteria:
 
 - Add route solve APIs for point-to-point and multi-stop routing.

--- a/src/Honua.Sdk.Abstractions/Routing/IHonuaRoutingClient.cs
+++ b/src/Honua.Sdk.Abstractions/Routing/IHonuaRoutingClient.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Routing;
+
+/// <summary>
+/// Provider-neutral routing and network-analysis client contract.
+/// </summary>
+public interface IHonuaRoutingClient
+{
+    /// <summary>Stable provider name for diagnostics and adapter selection.</summary>
+    string ProviderName { get; }
+
+    /// <summary>Provider capabilities for routing operations.</summary>
+    RoutingCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// Gets routing service metadata such as travel modes and supported directions languages.
+    /// </summary>
+    /// <param name="request">Metadata discovery request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Routing service metadata.</returns>
+    Task<RouteServiceMetadata> GetServiceMetadataAsync(RouteServiceMetadataRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets directions from an origin to a destination with optional waypoints.
+    /// </summary>
+    /// <param name="request">Route solve request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Route result including parsed summaries and directions when advertised by the provider.</returns>
+    Task<RouteResult> GetDirectionsAsync(RouteDirectionsRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Optimizes the order of route stops using provider best-sequence routing.
+    /// </summary>
+    /// <param name="request">Route optimization request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Route result including parsed summaries and directions when advertised by the provider.</returns>
+    Task<RouteResult> OptimizeRouteAsync(RouteOptimizationRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a service area / isochrone polygon around a center location.
+    /// </summary>
+    /// <param name="request">Service-area request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Service-area result with raw provider response.</returns>
+    Task<ServiceAreaResult> GetServiceAreaAsync(ServiceAreaRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds the closest facilities for one or more incident locations.
+    /// </summary>
+    /// <param name="request">Closest-facility request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Closest-facility result including parsed summaries and directions when advertised by the provider.</returns>
+    Task<ClosestFacilityResult> FindClosestFacilityAsync(ClosestFacilityRequest request, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Routing/RoutingModels.cs
+++ b/src/Honua.Sdk.Abstractions/Routing/RoutingModels.cs
@@ -1,0 +1,440 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Routing;
+
+/// <summary>
+/// WGS84 coordinate used by routing operations. Longitude maps to X and latitude maps to Y.
+/// </summary>
+public readonly record struct RoutingCoordinate(double Longitude, double Latitude)
+{
+    /// <summary>
+    /// Creates a coordinate from latitude/longitude ordered values, which is common for GPS APIs.
+    /// </summary>
+    /// <param name="latitude">Latitude in decimal degrees.</param>
+    /// <param name="longitude">Longitude in decimal degrees.</param>
+    /// <returns>A coordinate in longitude/latitude order.</returns>
+    public static RoutingCoordinate FromLatitudeLongitude(double latitude, double longitude) => new(longitude, latitude);
+}
+
+/// <summary>
+/// Optional arrival time window associated with a routing stop.
+/// </summary>
+public sealed record RouteTimeWindow
+{
+    /// <summary>Inclusive start of the time window.</summary>
+    public DateTimeOffset? Start { get; init; }
+
+    /// <summary>Inclusive end of the time window.</summary>
+    public DateTimeOffset? End { get; init; }
+}
+
+/// <summary>
+/// Point input for route stops, facilities, incidents, barriers, and service-area centers.
+/// </summary>
+public sealed class RoutingLocation
+{
+    /// <summary>WGS84 point coordinate.</summary>
+    public required RoutingCoordinate Coordinate { get; init; }
+
+    /// <summary>Optional display name sent as the route stop/facility name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Optional stable caller identifier.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Optional arrival window for stops when the provider supports time-window routing.</summary>
+    public RouteTimeWindow? TimeWindow { get; init; }
+
+    /// <summary>Additional provider-neutral attributes included with the network-analysis feature.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+
+    /// <summary>
+    /// Creates a location from longitude/latitude ordered values.
+    /// </summary>
+    /// <param name="longitude">Longitude in decimal degrees.</param>
+    /// <param name="latitude">Latitude in decimal degrees.</param>
+    /// <param name="name">Optional stop name.</param>
+    /// <returns>A routing location.</returns>
+    public static RoutingLocation FromLongitudeLatitude(double longitude, double latitude, string? name = null) => new()
+    {
+        Coordinate = new RoutingCoordinate(longitude, latitude),
+        Name = name,
+    };
+
+    /// <summary>
+    /// Creates a location from latitude/longitude ordered values, which is common for GPS APIs.
+    /// </summary>
+    /// <param name="latitude">Latitude in decimal degrees.</param>
+    /// <param name="longitude">Longitude in decimal degrees.</param>
+    /// <param name="name">Optional stop name.</param>
+    /// <returns>A routing location.</returns>
+    public static RoutingLocation FromLatitudeLongitude(double latitude, double longitude, string? name = null) => new()
+    {
+        Coordinate = RoutingCoordinate.FromLatitudeLongitude(latitude, longitude),
+        Name = name,
+    };
+}
+
+/// <summary>
+/// Routing capabilities advertised by a provider implementation.
+/// </summary>
+public sealed record RoutingCapabilities
+{
+    /// <summary>Whether point-to-point and multi-stop directions are supported.</summary>
+    public bool SupportsDirections { get; init; }
+
+    /// <summary>Whether best-sequence route optimization is supported.</summary>
+    public bool SupportsRouteOptimization { get; init; }
+
+    /// <summary>Whether service-area or isochrone solving is supported.</summary>
+    public bool SupportsServiceAreas { get; init; }
+
+    /// <summary>Whether closest-facility solving is supported.</summary>
+    public bool SupportsClosestFacility { get; init; }
+
+    /// <summary>Whether provider metadata can advertise travel modes.</summary>
+    public bool SupportsTravelModes { get; init; }
+
+    /// <summary>Whether point barriers can be sent with solve requests.</summary>
+    public bool SupportsPointBarriers { get; init; }
+
+    /// <summary>Whether localized directions language can be requested.</summary>
+    public bool SupportsDirectionsLanguage { get; init; }
+
+    /// <summary>Native provider surface backing the implementation.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason the capability set is unavailable, when applicable.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Request used to discover routing service metadata such as travel modes and directions languages.
+/// </summary>
+public sealed record RouteServiceMetadataRequest
+{
+    /// <summary>Override for the routing service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Override for the route layer name.</summary>
+    public string? RouteLayerName { get; init; }
+}
+
+/// <summary>
+/// Travel mode advertised by a routing provider.
+/// </summary>
+public sealed record RouteTravelMode
+{
+    /// <summary>Travel mode display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Provider-specific travel mode type.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>Provider-specific description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Raw provider travel mode payload.</summary>
+    public JsonElement Raw { get; init; }
+}
+
+/// <summary>
+/// Routing service metadata discovered from a provider.
+/// </summary>
+public sealed record RouteServiceMetadata
+{
+    /// <summary>Provider service id used for discovery.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Route layer used for discovery.</summary>
+    public required string RouteLayerName { get; init; }
+
+    /// <summary>Supported travel modes, when advertised.</summary>
+    public IReadOnlyList<RouteTravelMode> TravelModes { get; init; } = [];
+
+    /// <summary>Default travel mode name, id, or JSON summary, when advertised.</summary>
+    public string? DefaultTravelMode { get; init; }
+
+    /// <summary>Supported directions languages, when advertised.</summary>
+    public IReadOnlyList<string> SupportedDirectionsLanguages { get; init; } = [];
+
+    /// <summary>Raw provider metadata response.</summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Options shared by route solve requests.
+/// </summary>
+public sealed class RouteSolveOptions
+{
+    /// <summary>Override for the routing service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Override for the route layer name.</summary>
+    public string? RouteLayerName { get; init; }
+
+    /// <summary>REST response format. Defaults to JSON.</summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>Requests turn-by-turn directions in the response.</summary>
+    public bool ReturnDirections { get; init; } = true;
+
+    /// <summary>Requests route geometry in the response.</summary>
+    public bool ReturnRoutes { get; init; } = true;
+
+    /// <summary>Requests traffic-aware routing when the server/network supports it.</summary>
+    public bool UseTraffic { get; init; }
+
+    /// <summary>Requests toll-road restrictions when the server/network supports them.</summary>
+    public bool AvoidTolls { get; init; }
+
+    /// <summary>Requests highway restrictions when the server/network supports them.</summary>
+    public bool AvoidHighways { get; init; }
+
+    /// <summary>Optional server travel mode name or JSON travel-mode payload.</summary>
+    public string? TravelMode { get; init; }
+
+    /// <summary>Optional route start time.</summary>
+    public DateTimeOffset? StartTime { get; init; }
+
+    /// <summary>Optional language code for turn-by-turn directions.</summary>
+    public string? DirectionsLanguage { get; init; }
+
+    /// <summary>Direction length units sent to GeoServices-compatible NAServer endpoints.</summary>
+    public string DirectionsLengthUnits { get; init; } = "esriMeters";
+
+    /// <summary>Route line shape type sent to GeoServices-compatible NAServer endpoints.</summary>
+    public string OutputLines { get; init; } = "esriNAOutputLineTrueShape";
+
+    /// <summary>Optional point barriers used by providers that support barrier feature sets.</summary>
+    public IReadOnlyList<RoutingLocation>? PointBarriers { get; init; }
+
+    /// <summary>Additional raw provider parameters for server-specific routing extensions.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Directions request for point-to-point and multi-stop routing.
+/// </summary>
+public sealed class RouteDirectionsRequest
+{
+    /// <summary>Origin stop.</summary>
+    public required RoutingLocation Origin { get; init; }
+
+    /// <summary>Destination stop.</summary>
+    public required RoutingLocation Destination { get; init; }
+
+    /// <summary>Optional intermediate stops.</summary>
+    public IReadOnlyList<RoutingLocation>? Waypoints { get; init; }
+
+    /// <summary>Routing options.</summary>
+    public RouteSolveOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for optimized multi-stop route requests.
+/// </summary>
+public sealed class RouteOptimizationOptions
+{
+    /// <summary>Override for the routing service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Override for the route layer name.</summary>
+    public string? RouteLayerName { get; init; }
+
+    /// <summary>REST response format. Defaults to JSON.</summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>Requests turn-by-turn directions in the response.</summary>
+    public bool ReturnDirections { get; init; } = true;
+
+    /// <summary>Requests route geometry in the response.</summary>
+    public bool ReturnRoutes { get; init; } = true;
+
+    /// <summary>Requests traffic-aware routing when the server/network supports it.</summary>
+    public bool UseTraffic { get; init; }
+
+    /// <summary>Requests toll-road restrictions when the server/network supports them.</summary>
+    public bool AvoidTolls { get; init; }
+
+    /// <summary>Requests highway restrictions when the server/network supports them.</summary>
+    public bool AvoidHighways { get; init; }
+
+    /// <summary>Optional server travel mode name or JSON travel-mode payload.</summary>
+    public string? TravelMode { get; init; }
+
+    /// <summary>Optional route start time.</summary>
+    public DateTimeOffset? StartTime { get; init; }
+
+    /// <summary>Whether the first stop must remain first when optimizing sequence.</summary>
+    public bool PreserveFirstStop { get; init; } = true;
+
+    /// <summary>Whether the last stop must remain last when optimizing sequence.</summary>
+    public bool PreserveLastStop { get; init; } = true;
+
+    /// <summary>Optional language code for turn-by-turn directions.</summary>
+    public string? DirectionsLanguage { get; init; }
+
+    /// <summary>Direction length units sent to GeoServices-compatible NAServer endpoints.</summary>
+    public string DirectionsLengthUnits { get; init; } = "esriMeters";
+
+    /// <summary>Route line shape type sent to GeoServices-compatible NAServer endpoints.</summary>
+    public string OutputLines { get; init; } = "esriNAOutputLineTrueShape";
+
+    /// <summary>Optional point barriers used by providers that support barrier feature sets.</summary>
+    public IReadOnlyList<RoutingLocation>? PointBarriers { get; init; }
+
+    /// <summary>Additional raw provider parameters for server-specific routing extensions.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Optimizes a sequence of stops using best-sequence routing.
+/// </summary>
+public sealed class RouteOptimizationRequest
+{
+    /// <summary>Stops to sequence and solve.</summary>
+    public required IReadOnlyList<RoutingLocation> Stops { get; init; }
+
+    /// <summary>Optimization options.</summary>
+    public RouteOptimizationOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for service-area / isochrone requests.
+/// </summary>
+public sealed class ServiceAreaOptions
+{
+    /// <summary>Override for the routing service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Override for the service-area layer name.</summary>
+    public string? ServiceAreaLayerName { get; init; }
+
+    /// <summary>REST response format. Defaults to JSON.</summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>Provider travel direction parameter.</summary>
+    public string TravelDirection { get; init; } = "esriNATravelDirectionFromFacility";
+
+    /// <summary>Provider output polygon detail parameter.</summary>
+    public string OutputPolygons { get; init; } = "esriNAOutputPolygonSimplified";
+
+    /// <summary>Whether similar polygon ranges should be merged.</summary>
+    public bool MergeSimilarPolygonRanges { get; init; } = true;
+
+    /// <summary>Optional server travel mode name or JSON travel-mode payload.</summary>
+    public string? TravelMode { get; init; }
+
+    /// <summary>Optional route start time.</summary>
+    public DateTimeOffset? StartTime { get; init; }
+
+    /// <summary>Optional point barriers used by providers that support barrier feature sets.</summary>
+    public IReadOnlyList<RoutingLocation>? PointBarriers { get; init; }
+
+    /// <summary>Additional raw provider parameters for server-specific routing extensions.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Service-area / isochrone request centered on one location.
+/// </summary>
+public sealed class ServiceAreaRequest
+{
+    /// <summary>Center location.</summary>
+    public required RoutingLocation Center { get; init; }
+
+    /// <summary>Travel time break.</summary>
+    public required TimeSpan TravelTime { get; init; }
+
+    /// <summary>Service-area options.</summary>
+    public ServiceAreaOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Options for closest-facility network-analysis requests.
+/// </summary>
+public sealed class ClosestFacilityOptions
+{
+    /// <summary>Override for the routing service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Override for the closest-facility layer name.</summary>
+    public string? ClosestFacilityLayerName { get; init; }
+
+    /// <summary>REST response format. Defaults to JSON.</summary>
+    public string ResponseFormat { get; init; } = "json";
+
+    /// <summary>Maximum number of facilities returned for each incident.</summary>
+    public int? TargetFacilityCount { get; init; }
+
+    /// <summary>Provider travel direction parameter.</summary>
+    public string TravelDirection { get; init; } = "esriNATravelDirectionToFacility";
+
+    /// <summary>Requests turn-by-turn directions in the response.</summary>
+    public bool ReturnDirections { get; init; } = true;
+
+    /// <summary>Requests route geometry in the response.</summary>
+    public bool ReturnRoutes { get; init; } = true;
+
+    /// <summary>Optional server travel mode name or JSON travel-mode payload.</summary>
+    public string? TravelMode { get; init; }
+
+    /// <summary>Optional route start time.</summary>
+    public DateTimeOffset? StartTime { get; init; }
+
+    /// <summary>Optional language code for turn-by-turn directions.</summary>
+    public string? DirectionsLanguage { get; init; }
+
+    /// <summary>Optional point barriers used by providers that support barrier feature sets.</summary>
+    public IReadOnlyList<RoutingLocation>? PointBarriers { get; init; }
+
+    /// <summary>Additional raw provider parameters for server-specific routing extensions.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Finds the nearest facilities for one or more incident locations.
+/// </summary>
+public sealed class ClosestFacilityRequest
+{
+    /// <summary>Incident locations.</summary>
+    public required IReadOnlyList<RoutingLocation> Incidents { get; init; }
+
+    /// <summary>Candidate facility locations.</summary>
+    public required IReadOnlyList<RoutingLocation> Facilities { get; init; }
+
+    /// <summary>Closest-facility options.</summary>
+    public ClosestFacilityOptions Options { get; init; } = new();
+}
+
+/// <summary>
+/// Summary information parsed from a routing response when present.
+/// </summary>
+public sealed record RouteSummary(string? Name, double? TotalDistance, TimeSpan? TotalTime);
+
+/// <summary>
+/// Turn-by-turn instruction parsed from a routing response when present.
+/// </summary>
+public sealed record RouteDirectionStep(string? Text, double? Distance, TimeSpan? Time, string? ManeuverType);
+
+/// <summary>
+/// Result returned from directions and optimized-route requests.
+/// </summary>
+public sealed record RouteResult(JsonElement RawResponse, IReadOnlyList<RouteSummary> Routes, IReadOnlyList<RouteDirectionStep> Directions);
+
+/// <summary>
+/// Result returned from service-area requests.
+/// </summary>
+public sealed record ServiceAreaResult(JsonElement RawResponse);
+
+/// <summary>
+/// Result returned from closest-facility requests.
+/// </summary>
+public sealed record ClosestFacilityResult(
+    JsonElement RawResponse,
+    IReadOnlyList<RouteSummary> Routes,
+    IReadOnlyList<RouteDirectionStep> Directions);

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.GeoServices.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
@@ -43,6 +45,35 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
+        ConfigureResilience(httpBuilder, configure);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Honua GeoServices NAServer routing client with the DI container.
+    /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    /// <param name="configure">Configuration delegate for client options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaRouting(
+        this IServiceCollection services,
+        Action<HonuaGeoServicesClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.Configure(configure);
+        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = services.AddHttpClient<HonuaRoutingClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
+            HonuaGeoServicesClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaGeoServicesClientOptions.ValidateTimeout(options.Timeout);
+            client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
+        })
+        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+        services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
         ConfigureResilience(httpBuilder, configure);
         return services;
     }

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -61,6 +61,26 @@ public sealed class HonuaGeoServicesClientOptions
 
     private int _maxRetryAttempts = 3;
 
+    /// <summary>
+    /// Default GeoServices NAServer service id used by routing clients.
+    /// </summary>
+    public string RoutingServiceId { get; set; } = "Routing";
+
+    /// <summary>
+    /// Default NAServer route layer name used for directions and route optimization.
+    /// </summary>
+    public string RoutingRouteLayerName { get; set; } = "Route";
+
+    /// <summary>
+    /// Default NAServer service-area layer name used for isochrone requests.
+    /// </summary>
+    public string RoutingServiceAreaLayerName { get; set; } = "ServiceArea";
+
+    /// <summary>
+    /// Default NAServer closest-facility layer name used for nearest-facility requests.
+    /// </summary>
+    public string RoutingClosestFacilityLayerName { get; set; } = "ClosestFacility";
+
     internal static void ValidateBaseAddress(Uri? baseAddress)
     {
         if (baseAddress is null)

--- a/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
+++ b/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
@@ -1,0 +1,1137 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Globalization;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Routing;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.GeoServices.Routing;
+
+/// <summary>
+/// GeoServices NAServer implementation of routing and network-analysis operations.
+/// </summary>
+public sealed class HonuaRoutingClient : IHonuaRoutingClient
+{
+    private static readonly RoutingCapabilities ProviderCapabilities = new()
+    {
+        SupportsDirections = true,
+        SupportsRouteOptimization = true,
+        SupportsServiceAreas = true,
+        SupportsClosestFacility = true,
+        SupportsTravelModes = true,
+        SupportsPointBarriers = true,
+        SupportsDirectionsLanguage = true,
+        NativeSurface = "GeoServices NAServer"
+    };
+
+    private readonly HttpClient _http;
+    private readonly HonuaGeoServicesClientOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaRoutingClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    /// <param name="options">GeoServices options used for default service and layer names.</param>
+    [ActivatorUtilitiesConstructor]
+    public HonuaRoutingClient(HttpClient httpClient, IOptions<HonuaGeoServicesClientOptions> options)
+        : this(httpClient, GetOptionsValue(options))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaRoutingClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    /// <param name="options">GeoServices options used for default service and layer names.</param>
+    public HonuaRoutingClient(HttpClient httpClient, HonuaGeoServicesClientOptions options)
+    {
+        _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <inheritdoc />
+    public string ProviderName => "geoservices-naserver";
+
+    /// <inheritdoc />
+    public RoutingCapabilities Capabilities => ProviderCapabilities;
+
+    /// <inheritdoc />
+    public async Task<RouteServiceMetadata> GetServiceMetadataAsync(
+        RouteServiceMetadataRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var serviceId = ResolveServiceId(request.ServiceId);
+        var layerName = ResolveLayerName(request.RouteLayerName, _options.RoutingRouteLayerName);
+        var path = BuildNasLayerPath(serviceId, layerName);
+        var body = await GetStringAsync($"{path}?f=json", ct).ConfigureAwait(false);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        return new RouteServiceMetadata
+        {
+            ServiceId = serviceId,
+            RouteLayerName = layerName,
+            TravelModes = ParseTravelModes(root),
+            DefaultTravelMode = ParseDefaultTravelMode(root),
+            SupportedDirectionsLanguages = ParseDirectionsLanguages(root),
+            RawResponse = root.Clone(),
+        };
+    }
+
+    /// <summary>
+    /// Creates a fluent directions builder.
+    /// </summary>
+    /// <returns>A route directions builder.</returns>
+    public RouteDirectionsBuilder Route() => new(this);
+
+    /// <summary>
+    /// Gets directions from an origin to a destination with optional waypoints.
+    /// </summary>
+    /// <param name="origin">Origin stop.</param>
+    /// <param name="destination">Destination stop.</param>
+    /// <param name="waypoints">Optional intermediate stops.</param>
+    /// <param name="options">Routing options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Route result.</returns>
+    public Task<RouteResult> GetDirectionsAsync(
+        RoutingLocation origin,
+        RoutingLocation destination,
+        IReadOnlyList<RoutingLocation>? waypoints = null,
+        RouteSolveOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(origin);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        return GetDirectionsAsync(
+            new RouteDirectionsRequest
+            {
+                Origin = origin,
+                Destination = destination,
+                Waypoints = waypoints,
+                Options = options ?? new RouteSolveOptions(),
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<RouteResult> GetDirectionsAsync(RouteDirectionsRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Origin);
+        ArgumentNullException.ThrowIfNull(request.Destination);
+
+        var stops = new List<RoutingLocation> { request.Origin };
+        if (request.Waypoints is { Count: > 0 })
+        {
+            stops.AddRange(request.Waypoints);
+        }
+
+        stops.Add(request.Destination);
+        ValidateLocations(stops, minCount: 2, nameof(request));
+
+        var options = request.Options ?? new RouteSolveOptions();
+        var form = CreateRouteSolveForm(options);
+        form.Add(("stops", SerializeFeatureSet(stops)));
+        form.Add(("findBestSequence", "false"));
+        AddPointBarriers(form, options.PointBarriers);
+
+        var body = await PostFormAsync(
+            BuildNasOperationPath(options.ServiceId, options.RouteLayerName, "solve", _options.RoutingRouteLayerName),
+            form,
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseRoute(body);
+    }
+
+    /// <summary>
+    /// Gets the service area reachable from <paramref name="center"/> within <paramref name="travelTime"/>.
+    /// </summary>
+    /// <param name="center">Center location.</param>
+    /// <param name="travelTime">Travel time break.</param>
+    /// <param name="options">Service-area options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Service-area result.</returns>
+    public Task<ServiceAreaResult> GetServiceAreaAsync(
+        RoutingLocation center,
+        TimeSpan travelTime,
+        ServiceAreaOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(center);
+
+        return GetServiceAreaAsync(
+            new ServiceAreaRequest
+            {
+                Center = center,
+                TravelTime = travelTime,
+                Options = options ?? new ServiceAreaOptions(),
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<ServiceAreaResult> GetServiceAreaAsync(ServiceAreaRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Center);
+
+        if (request.TravelTime <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Travel time must be greater than zero.");
+        }
+
+        ValidateLocations([request.Center], minCount: 1, nameof(request));
+
+        var options = request.Options ?? new ServiceAreaOptions();
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", options.ResponseFormat),
+            ("facilities", SerializeFeatureSet([request.Center])),
+            ("defaultBreaks", request.TravelTime.TotalMinutes.ToString("0.###", CultureInfo.InvariantCulture)),
+            ("travelDirection", options.TravelDirection),
+            ("outputPolygons", options.OutputPolygons),
+            ("mergeSimilarPolygonRanges", options.MergeSimilarPolygonRanges ? "true" : "false"),
+            ("travelMode", options.TravelMode),
+            ("startTime", FormatStartTime(options.StartTime)),
+        };
+        AddPointBarriers(form, options.PointBarriers);
+        AddAdditionalParameters(form, options.AdditionalParameters);
+
+        var body = await PostFormAsync(
+            BuildNasOperationPath(
+                options.ServiceId,
+                options.ServiceAreaLayerName,
+                "solveServiceArea",
+                _options.RoutingServiceAreaLayerName),
+            form,
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseServiceArea(body);
+    }
+
+    /// <summary>
+    /// Finds the closest facilities for one or more incident locations.
+    /// </summary>
+    /// <param name="incidents">Incident locations.</param>
+    /// <param name="facilities">Candidate facility locations.</param>
+    /// <param name="options">Closest-facility options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Closest-facility result.</returns>
+    public Task<ClosestFacilityResult> FindClosestFacilityAsync(
+        IReadOnlyList<RoutingLocation> incidents,
+        IReadOnlyList<RoutingLocation> facilities,
+        ClosestFacilityOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return FindClosestFacilityAsync(
+            new ClosestFacilityRequest
+            {
+                Incidents = incidents,
+                Facilities = facilities,
+                Options = options ?? new ClosestFacilityOptions(),
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<ClosestFacilityResult> FindClosestFacilityAsync(ClosestFacilityRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Incidents);
+        ArgumentNullException.ThrowIfNull(request.Facilities);
+
+        ValidateLocations(request.Incidents, minCount: 1, nameof(request.Incidents));
+        ValidateLocations(request.Facilities, minCount: 1, nameof(request.Facilities));
+
+        var options = request.Options ?? new ClosestFacilityOptions();
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", options.ResponseFormat),
+            ("incidents", SerializeFeatureSet(request.Incidents)),
+            ("facilities", SerializeFeatureSet(request.Facilities)),
+            ("defaultTargetFacilityCount", options.TargetFacilityCount?.ToString(CultureInfo.InvariantCulture)),
+            ("travelDirection", options.TravelDirection),
+            ("returnDirections", options.ReturnDirections ? "true" : "false"),
+            ("returnRoutes", options.ReturnRoutes ? "true" : "false"),
+            ("travelMode", options.TravelMode),
+            ("startTime", FormatStartTime(options.StartTime)),
+            ("directionsLanguage", options.DirectionsLanguage),
+        };
+        AddPointBarriers(form, options.PointBarriers);
+        AddAdditionalParameters(form, options.AdditionalParameters);
+
+        var body = await PostFormAsync(
+            BuildNasOperationPath(
+                options.ServiceId,
+                options.ClosestFacilityLayerName,
+                "solveClosestFacility",
+                _options.RoutingClosestFacilityLayerName),
+            form,
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseClosestFacility(body);
+    }
+
+    /// <summary>
+    /// Optimizes the order of route stops using NAServer best-sequence routing.
+    /// </summary>
+    /// <param name="stops">Stops to sequence and solve.</param>
+    /// <param name="options">Optimization options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Route result.</returns>
+    public Task<RouteResult> OptimizeRouteAsync(
+        IReadOnlyList<RoutingLocation> stops,
+        RouteOptimizationOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return OptimizeRouteAsync(
+            new RouteOptimizationRequest
+            {
+                Stops = stops,
+                Options = options ?? new RouteOptimizationOptions(),
+            },
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<RouteResult> OptimizeRouteAsync(RouteOptimizationRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Stops);
+        ValidateLocations(request.Stops, minCount: 2, nameof(request.Stops));
+
+        var options = request.Options ?? new RouteOptimizationOptions();
+        var form = CreateRouteOptimizationForm(options);
+        form.Add(("stops", SerializeFeatureSet(request.Stops)));
+        AddPointBarriers(form, options.PointBarriers);
+
+        var body = await PostFormAsync(
+            BuildNasOperationPath(options.ServiceId, options.RouteLayerName, "solve", _options.RoutingRouteLayerName),
+            form,
+            ct).ConfigureAwait(false);
+
+        return RoutingResultParser.ParseRoute(body);
+    }
+
+    private async Task<string> GetStringAsync(string url, CancellationToken ct)
+    {
+        using var response = await _http.GetAsync(CreateRequestUri(url), ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return body;
+    }
+
+    private async Task<string> PostFormAsync(
+        string path,
+        List<(string Key, string? Value)> parameters,
+        CancellationToken ct)
+    {
+        using var content = new FormUrlEncodedContent(
+            parameters
+                .Where(parameter => !string.IsNullOrWhiteSpace(parameter.Value))
+                .Select(parameter => new KeyValuePair<string, string>(parameter.Key, parameter.Value!)));
+
+        using var response = await _http.PostAsync(CreateRequestUri(path), content, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return body;
+    }
+
+    private static HonuaGeoServicesClientOptions GetOptionsValue(IOptions<HonuaGeoServicesClientOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return options.Value;
+    }
+
+    private static List<(string Key, string? Value)> CreateRouteSolveForm(RouteSolveOptions options)
+    {
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", options.ResponseFormat),
+            ("returnDirections", options.ReturnDirections ? "true" : "false"),
+            ("returnRoutes", options.ReturnRoutes ? "true" : "false"),
+            ("useTraffic", options.UseTraffic ? "true" : null),
+            ("avoidTolls", options.AvoidTolls ? "true" : null),
+            ("avoidHighways", options.AvoidHighways ? "true" : null),
+            ("travelMode", options.TravelMode),
+            ("startTime", FormatStartTime(options.StartTime)),
+            ("directionsLanguage", options.DirectionsLanguage),
+            ("directionsLengthUnits", options.DirectionsLengthUnits),
+            ("outputLines", options.OutputLines),
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+        return form;
+    }
+
+    private static List<(string Key, string? Value)> CreateRouteOptimizationForm(RouteOptimizationOptions options)
+    {
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", options.ResponseFormat),
+            ("returnDirections", options.ReturnDirections ? "true" : "false"),
+            ("returnRoutes", options.ReturnRoutes ? "true" : "false"),
+            ("findBestSequence", "true"),
+            ("preserveFirstStop", options.PreserveFirstStop ? "true" : "false"),
+            ("preserveLastStop", options.PreserveLastStop ? "true" : "false"),
+            ("useTraffic", options.UseTraffic ? "true" : null),
+            ("avoidTolls", options.AvoidTolls ? "true" : null),
+            ("avoidHighways", options.AvoidHighways ? "true" : null),
+            ("travelMode", options.TravelMode),
+            ("startTime", FormatStartTime(options.StartTime)),
+            ("directionsLanguage", options.DirectionsLanguage),
+            ("directionsLengthUnits", options.DirectionsLengthUnits),
+            ("outputLines", options.OutputLines),
+        };
+        AddAdditionalParameters(form, options.AdditionalParameters);
+        return form;
+    }
+
+    private string BuildNasOperationPath(
+        string? serviceId,
+        string? layerName,
+        string operation,
+        string defaultLayerName)
+    {
+        var resolvedServiceId = ResolveServiceId(serviceId);
+        var resolvedLayerName = ResolveLayerName(layerName, defaultLayerName);
+        return $"{BuildNasLayerPath(resolvedServiceId, resolvedLayerName)}/{operation}";
+    }
+
+    private static string BuildNasLayerPath(string serviceId, string layerName)
+        => $"/rest/services/{Uri.EscapeDataString(serviceId)}/NAServer/{Uri.EscapeDataString(layerName)}";
+
+    private string ResolveServiceId(string? serviceId)
+    {
+        var resolved = string.IsNullOrWhiteSpace(serviceId) ? _options.RoutingServiceId : serviceId;
+        return string.IsNullOrWhiteSpace(resolved)
+            ? throw new InvalidOperationException("Honua GeoServices routing service id must be configured.")
+            : resolved;
+    }
+
+    private static string ResolveLayerName(string? layerName, string defaultLayerName)
+    {
+        var resolved = string.IsNullOrWhiteSpace(layerName) ? defaultLayerName : layerName;
+        return string.IsNullOrWhiteSpace(resolved)
+            ? throw new InvalidOperationException("Honua GeoServices routing layer name must be configured.")
+            : resolved;
+    }
+
+    private static void AddPointBarriers(
+        List<(string Key, string? Value)> form,
+        IReadOnlyList<RoutingLocation>? pointBarriers)
+    {
+        if (pointBarriers is not { Count: > 0 })
+        {
+            return;
+        }
+
+        ValidateLocations(pointBarriers, minCount: 1, nameof(pointBarriers));
+        form.Add(("barriers", SerializeFeatureSet(pointBarriers)));
+    }
+
+    private static string SerializeFeatureSet(IReadOnlyList<RoutingLocation> locations)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("features");
+            writer.WriteStartArray();
+            foreach (var location in locations)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("geometry");
+                WritePointGeometry(writer, location.Coordinate);
+
+                if (HasAttributes(location))
+                {
+                    writer.WritePropertyName("attributes");
+                    WriteAttributes(writer, location);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WritePropertyName("spatialReference");
+            WriteSpatialReference(writer);
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static void WritePointGeometry(Utf8JsonWriter writer, RoutingCoordinate coordinate)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("x", coordinate.Longitude);
+        writer.WriteNumber("y", coordinate.Latitude);
+        writer.WritePropertyName("spatialReference");
+        WriteSpatialReference(writer);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteSpatialReference(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("wkid", 4326);
+        writer.WriteEndObject();
+    }
+
+    private static bool HasAttributes(RoutingLocation location)
+        => !string.IsNullOrWhiteSpace(location.Id) ||
+           !string.IsNullOrWhiteSpace(location.Name) ||
+           location.TimeWindow is not null ||
+           location.Attributes is { Count: > 0 };
+
+    private static void WriteAttributes(Utf8JsonWriter writer, RoutingLocation location)
+    {
+        writer.WriteStartObject();
+        if (!string.IsNullOrWhiteSpace(location.Id))
+        {
+            writer.WriteString("Id", location.Id);
+        }
+
+        if (!string.IsNullOrWhiteSpace(location.Name))
+        {
+            writer.WriteString("Name", location.Name);
+        }
+
+        if (location.TimeWindow?.Start is { } start)
+        {
+            writer.WriteString("TimeWindowStart", FormatStartTime(start));
+        }
+
+        if (location.TimeWindow?.End is { } end)
+        {
+            writer.WriteString("TimeWindowEnd", FormatStartTime(end));
+        }
+
+        if (location.Attributes is not null)
+        {
+            foreach (var attribute in location.Attributes)
+            {
+                writer.WritePropertyName(attribute.Key);
+                attribute.Value.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void ValidateLocations(IReadOnlyList<RoutingLocation> locations, int minCount, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(locations);
+
+        if (locations.Count < minCount)
+        {
+            throw new ArgumentException($"At least {minCount} routing location(s) are required.", parameterName);
+        }
+
+        foreach (var location in locations)
+        {
+            ArgumentNullException.ThrowIfNull(location);
+            if (!double.IsFinite(location.Coordinate.Longitude) || !double.IsFinite(location.Coordinate.Latitude))
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing coordinates must be finite numbers.");
+            }
+
+            if (location.Coordinate.Latitude is < -90 or > 90)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing latitude must be between -90 and 90.");
+            }
+
+            if (location.Coordinate.Longitude is < -180 or > 180)
+            {
+                throw new ArgumentOutOfRangeException(parameterName, "Routing longitude must be between -180 and 180.");
+            }
+        }
+    }
+
+    private static void AddAdditionalParameters(
+        List<(string Key, string? Value)> form,
+        IReadOnlyDictionary<string, string?>? additionalParameters)
+    {
+        if (additionalParameters is null)
+        {
+            return;
+        }
+
+        foreach (var parameter in additionalParameters)
+        {
+            form.Add((parameter.Key, parameter.Value));
+        }
+    }
+
+    private static string? FormatStartTime(DateTimeOffset? startTime)
+        => startTime?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+
+    private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
+
+    private static void EnsureSuccess(HttpResponseMessage response, string body)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            if (!string.IsNullOrWhiteSpace(body) && TryExtractGeoServicesError(body, response.StatusCode) is { } error)
+            {
+                throw error;
+            }
+
+            return;
+        }
+
+        var errorMessage = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "GeoServices routing request failed";
+        throw new HonuaFeatureServerException(response.StatusCode, errorMessage, body);
+    }
+
+    private static HonuaFeatureServerException? TryExtractGeoServicesError(string body, HttpStatusCode fallbackStatus)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("error", out var errorElement) ||
+                errorElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var message = "GeoServices routing returned an error.";
+            int? geoServicesCode = null;
+            IReadOnlyList<string>? details = null;
+            var httpCode = fallbackStatus;
+            if (errorElement.TryGetProperty("message", out var msgProp) &&
+                msgProp.ValueKind == JsonValueKind.String)
+            {
+                message = msgProp.GetString() ?? message;
+            }
+
+            if (errorElement.TryGetProperty("code", out var codeProp) &&
+                codeProp.TryGetInt32(out var errorCode))
+            {
+                geoServicesCode = errorCode;
+                httpCode = (HttpStatusCode)errorCode;
+            }
+
+            if (errorElement.TryGetProperty("details", out var detailsProp) &&
+                detailsProp.ValueKind == JsonValueKind.Array)
+            {
+                var detailList = new List<string>();
+                foreach (var item in detailsProp.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        detailList.Add(item.GetString()!);
+                    }
+                }
+
+                details = detailList;
+            }
+
+            return new HonuaFeatureServerException(httpCode, message, body, geoServicesCode, details);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryExtractErrorMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
+                errorElement.ValueKind == JsonValueKind.Object &&
+                errorElement.TryGetProperty("message", out var msg) &&
+                msg.ValueKind == JsonValueKind.String)
+            {
+                return msg.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("message", out var topMsg) &&
+                topMsg.ValueKind == JsonValueKind.String)
+            {
+                return topMsg.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static List<RouteTravelMode> ParseTravelModes(JsonElement root)
+    {
+        if (!TryGetProperty(root, "supportedTravelModes", out var travelModes))
+        {
+            return [];
+        }
+
+        if (travelModes.ValueKind == JsonValueKind.String &&
+            TryParseJson(travelModes.GetString(), out var parsedModes))
+        {
+            using (parsedModes)
+            {
+                return ParseTravelModes(parsedModes.RootElement);
+            }
+        }
+
+        if (travelModes.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var modes = new List<RouteTravelMode>();
+        foreach (var mode in travelModes.EnumerateArray())
+        {
+            modes.Add(new RouteTravelMode
+            {
+                Name = ReadString(mode, "name", "Name", "id", "Id"),
+                Type = ReadString(mode, "type", "Type"),
+                Description = ReadString(mode, "description", "Description"),
+                Raw = mode.Clone(),
+            });
+        }
+
+        return modes;
+    }
+
+    private static string? ParseDefaultTravelMode(JsonElement root)
+    {
+        if (!TryGetProperty(root, "defaultTravelMode", out var value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString();
+        }
+
+        if (value.ValueKind == JsonValueKind.Object)
+        {
+            return ReadString(value, "name", "Name", "id", "Id") ?? value.GetRawText();
+        }
+
+        return value.GetRawText();
+    }
+
+    private static List<string> ParseDirectionsLanguages(JsonElement root)
+    {
+        foreach (var propertyName in new[] { "supportedDirectionsLanguages", "directionsLanguages" })
+        {
+            if (!TryGetProperty(root, propertyName, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Array)
+            {
+                return value.EnumerateArray()
+                    .Where(item => item.ValueKind == JsonValueKind.String)
+                    .Select(item => item.GetString())
+                    .OfType<string>()
+                    .ToList();
+            }
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString()?
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .ToList() ?? [];
+            }
+        }
+
+        return [];
+    }
+
+    private static bool TryParseJson(string? json, out JsonDocument document)
+    {
+        document = default!;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        try
+        {
+            document = JsonDocument.Parse(json);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string? ReadString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (TryGetProperty(element, name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}
+
+/// <summary>
+/// Fluent builder for common directions requests.
+/// </summary>
+public sealed class RouteDirectionsBuilder
+{
+    private readonly HonuaRoutingClient _client;
+    private readonly List<RoutingLocation> _waypoints = [];
+    private RoutingLocation? _origin;
+    private RoutingLocation? _destination;
+    private RouteSolveOptions _options = new();
+
+    internal RouteDirectionsBuilder(HonuaRoutingClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>Sets the route origin.</summary>
+    /// <param name="origin">Origin stop.</param>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder From(RoutingLocation origin)
+    {
+        _origin = origin ?? throw new ArgumentNullException(nameof(origin));
+        return this;
+    }
+
+    /// <summary>Sets the route destination.</summary>
+    /// <param name="destination">Destination stop.</param>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder To(RoutingLocation destination)
+    {
+        _destination = destination ?? throw new ArgumentNullException(nameof(destination));
+        return this;
+    }
+
+    /// <summary>Adds an intermediate stop.</summary>
+    /// <param name="waypoint">Intermediate stop.</param>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder Via(RoutingLocation waypoint)
+    {
+        _waypoints.Add(waypoint ?? throw new ArgumentNullException(nameof(waypoint)));
+        return this;
+    }
+
+    /// <summary>Requests traffic-aware routing.</summary>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder WithTraffic()
+    {
+        _options = CopyOptions(useTraffic: true);
+        return this;
+    }
+
+    /// <summary>Requests toll-road avoidance when supported.</summary>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder AvoidTolls()
+    {
+        _options = CopyOptions(avoidTolls: true);
+        return this;
+    }
+
+    /// <summary>Requests highway avoidance when supported.</summary>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder AvoidHighways()
+    {
+        _options = CopyOptions(avoidHighways: true);
+        return this;
+    }
+
+    /// <summary>Sets the provider travel mode.</summary>
+    /// <param name="travelMode">Travel mode name or JSON payload.</param>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder WithTravelMode(string travelMode)
+    {
+        if (string.IsNullOrWhiteSpace(travelMode))
+        {
+            throw new ArgumentException("Travel mode cannot be empty.", nameof(travelMode));
+        }
+
+        _options = CopyOptions(travelMode: travelMode);
+        return this;
+    }
+
+    /// <summary>Replaces the route solve options.</summary>
+    /// <param name="options">Route solve options.</param>
+    /// <returns>The current builder.</returns>
+    public RouteDirectionsBuilder WithOptions(RouteSolveOptions options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        return this;
+    }
+
+    /// <summary>Executes the built route solve request.</summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Route result.</returns>
+    public Task<RouteResult> ExecuteAsync(CancellationToken ct = default)
+    {
+        if (_origin is null)
+        {
+            throw new InvalidOperationException("Route origin has not been set.");
+        }
+
+        if (_destination is null)
+        {
+            throw new InvalidOperationException("Route destination has not been set.");
+        }
+
+        return _client.GetDirectionsAsync(_origin, _destination, _waypoints, _options, ct);
+    }
+
+    private RouteSolveOptions CopyOptions(
+        bool? useTraffic = null,
+        bool? avoidTolls = null,
+        bool? avoidHighways = null,
+        string? travelMode = null)
+        => new()
+        {
+            ServiceId = _options.ServiceId,
+            RouteLayerName = _options.RouteLayerName,
+            ResponseFormat = _options.ResponseFormat,
+            ReturnDirections = _options.ReturnDirections,
+            ReturnRoutes = _options.ReturnRoutes,
+            UseTraffic = useTraffic ?? _options.UseTraffic,
+            AvoidTolls = avoidTolls ?? _options.AvoidTolls,
+            AvoidHighways = avoidHighways ?? _options.AvoidHighways,
+            TravelMode = travelMode ?? _options.TravelMode,
+            StartTime = _options.StartTime,
+            DirectionsLanguage = _options.DirectionsLanguage,
+            DirectionsLengthUnits = _options.DirectionsLengthUnits,
+            OutputLines = _options.OutputLines,
+            PointBarriers = _options.PointBarriers,
+            AdditionalParameters = _options.AdditionalParameters,
+        };
+}
+
+internal static class RoutingResultParser
+{
+    public static RouteResult ParseRoute(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var directions = ParseDirections(document.RootElement);
+        var routes = ParseRouteSummaries(document.RootElement);
+        if (routes.Count == 0)
+        {
+            routes = ParseDirectionSummaries(document.RootElement);
+        }
+
+        return new RouteResult(document.RootElement.Clone(), routes, directions);
+    }
+
+    public static ServiceAreaResult ParseServiceArea(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        return new ServiceAreaResult(document.RootElement.Clone());
+    }
+
+    public static ClosestFacilityResult ParseClosestFacility(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var routes = ParseRouteSummaries(document.RootElement);
+        if (routes.Count == 0)
+        {
+            routes = ParseDirectionSummaries(document.RootElement);
+        }
+
+        return new ClosestFacilityResult(document.RootElement.Clone(), routes, ParseDirections(document.RootElement));
+    }
+
+    private static List<RouteDirectionStep> ParseDirections(JsonElement root)
+    {
+        var steps = new List<RouteDirectionStep>();
+        if (!TryGetProperty(root, "directions", out var directions))
+        {
+            return steps;
+        }
+
+        foreach (var directionSet in EnumerateObjectOrArray(directions))
+        {
+            if (!TryGetProperty(directionSet, "features", out var features))
+            {
+                continue;
+            }
+
+            foreach (var feature in EnumerateObjectOrArray(features))
+            {
+                if (!TryGetProperty(feature, "attributes", out var attributes))
+                {
+                    continue;
+                }
+
+                steps.Add(new RouteDirectionStep(
+                    ReadString(attributes, "text", "Text", "maneuverText", "driveInstruction"),
+                    ReadDouble(attributes, "length", "Length", "distance", "Distance"),
+                    ReadMinutes(attributes, "time", "Time", "minutes", "Minutes"),
+                    ReadString(attributes, "maneuverType", "ManeuverType", "type")));
+            }
+        }
+
+        return steps;
+    }
+
+    private static List<RouteSummary> ParseRouteSummaries(JsonElement root)
+    {
+        var summaries = new List<RouteSummary>();
+        if (!TryGetProperty(root, "routes", out var routes) || !TryGetProperty(routes, "features", out var features))
+        {
+            return summaries;
+        }
+
+        foreach (var feature in EnumerateObjectOrArray(features))
+        {
+            if (!TryGetProperty(feature, "attributes", out var attributes))
+            {
+                continue;
+            }
+
+            summaries.Add(new RouteSummary(
+                ReadString(attributes, "Name", "name", "RouteName"),
+                ReadDouble(attributes, "Total_Length", "totalLength", "TotalDistance", "totalDistance"),
+                ReadMinutes(attributes, "Total_Time", "totalTime", "Total_TravelTime", "travelTime")));
+        }
+
+        return summaries;
+    }
+
+    private static List<RouteSummary> ParseDirectionSummaries(JsonElement root)
+    {
+        var summaries = new List<RouteSummary>();
+        if (!TryGetProperty(root, "directions", out var directions))
+        {
+            return summaries;
+        }
+
+        foreach (var directionSet in EnumerateObjectOrArray(directions))
+        {
+            if (!TryGetProperty(directionSet, "summary", out var summary))
+            {
+                continue;
+            }
+
+            summaries.Add(new RouteSummary(
+                ReadString(summary, "routeName", "RouteName", "Name"),
+                ReadDouble(summary, "totalLength", "Total_Length", "totalDistance"),
+                ReadMinutes(summary, "totalTime", "Total_Time", "travelTime")));
+        }
+
+        return summaries;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateObjectOrArray(JsonElement element)
+    {
+        if (element.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in element.EnumerateArray())
+            {
+                yield return item;
+            }
+        }
+        else if (element.ValueKind == JsonValueKind.Object)
+        {
+            yield return element;
+        }
+    }
+
+    private static string? ReadString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (TryGetProperty(element, name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static double? ReadDouble(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!TryGetProperty(element, name, out var value))
+            {
+                continue;
+            }
+
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDouble(out var number))
+            {
+                return number;
+            }
+
+            if (value.ValueKind == JsonValueKind.String &&
+                double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out number))
+            {
+                return number;
+            }
+        }
+
+        return null;
+    }
+
+    private static TimeSpan? ReadMinutes(JsonElement element, params string[] names)
+    {
+        var value = ReadDouble(element, names);
+        return value is null ? null : TimeSpan.FromMinutes(value.Value);
+    }
+
+    private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
+    {
+        if (element.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = property.Value;
+                    return true;
+                }
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/MobileContractHarmonizationFixtureTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/MobileContractHarmonizationFixtureTests.cs
@@ -20,6 +20,7 @@ public sealed class MobileContractHarmonizationFixtureTests
     [
         "feature-query",
         "feature-edit",
+        "feature-attachments",
         "geometry",
         "offline-sync-state",
         "form-feature-schema",
@@ -94,7 +95,7 @@ public sealed class MobileContractHarmonizationFixtureTests
             .ToArray();
 
         Assert.Equal(ExpectedSdkPackageIds, packages.Select(package => package.PackageId));
-        Assert.All(packages, package => Assert.Equal("0.1.2-alpha.1", package.Version));
+        Assert.All(packages, package => Assert.Equal("0.1.4-alpha.1", package.Version));
     }
 
     private static bool IsSdkOwnedFamily(JsonElement family)

--- a/tests/Honua.Sdk.GeoServices.Tests/Routing/HonuaRoutingClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/Routing/HonuaRoutingClientTests.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Routing;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.Routing;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.Tests.Routing;
+
+public sealed class HonuaRoutingClientTests
+{
+    [Fact]
+    public async Task GetDirectionsAsync_SendsNasServerSolvePayloadAndParsesDirections()
+    {
+        Dictionary<string, string>? form = null;
+        HttpMethod? method = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, ct) =>
+        {
+            method = request.Method;
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("""
+            {
+              "routes": {
+                "features": [
+                  { "attributes": { "Name": "Route 1", "Total_Length": 10.5, "Total_Time": 25 } }
+                ]
+              },
+              "directions": [
+                {
+                  "features": [
+                    { "attributes": { "text": "Head east", "length": 0.1, "time": 1.2, "maneuverType": "esriDMTDepart" } }
+                  ]
+                }
+              ]
+            }
+            """);
+        });
+
+        var result = await client.GetDirectionsAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Start"),
+            RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810, "Finish"),
+            [RoutingLocation.FromLongitudeLatitude(-157.84, 21.29, "Waypoint")]);
+
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal("http://localhost:5000/rest/services/Routing/NAServer/Route/solve", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("true", form["returnDirections"]);
+        Assert.Equal("false", form["findBestSequence"]);
+
+        using var stops = JsonDocument.Parse(form["stops"]);
+        var features = stops.RootElement.GetProperty("features").EnumerateArray().ToArray();
+        Assert.Equal(3, features.Length);
+        Assert.Equal("Start", features[0].GetProperty("attributes").GetProperty("Name").GetString());
+        Assert.Equal(-157.8583, features[0].GetProperty("geometry").GetProperty("x").GetDouble(), precision: 4);
+
+        Assert.Single(result.Routes);
+        Assert.Equal("Route 1", result.Routes[0].Name);
+        Assert.Single(result.Directions);
+        Assert.Equal("Head east", result.Directions[0].Text);
+        Assert.Equal(TimeSpan.FromMinutes(1.2), result.Directions[0].Time);
+    }
+
+    [Fact]
+    public async Task OptimizeRouteAsync_SendsBestSequenceParameters()
+    {
+        Dictionary<string, string>? form = null;
+        var client = CreateClient(async (request, ct) =>
+        {
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+
+        await client.OptimizeRouteAsync(
+            [
+                RoutingLocation.FromLongitudeLatitude(-157.86, 21.30, "A"),
+                RoutingLocation.FromLongitudeLatitude(-157.84, 21.31, "B"),
+                RoutingLocation.FromLongitudeLatitude(-157.82, 21.32, "C"),
+            ],
+            new RouteOptimizationOptions
+            {
+                PreserveFirstStop = true,
+                PreserveLastStop = false,
+            });
+
+        Assert.NotNull(form);
+        Assert.Equal("true", form["findBestSequence"]);
+        Assert.Equal("true", form["preserveFirstStop"]);
+        Assert.Equal("false", form["preserveLastStop"]);
+    }
+
+    [Fact]
+    public async Task GetServiceAreaAsync_SendsTravelTimeBreak()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, ct) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+
+        await client.GetServiceAreaAsync(
+            RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Depot"),
+            TimeSpan.FromMinutes(30));
+
+        Assert.Equal("http://localhost:5000/rest/services/Routing/NAServer/ServiceArea/solveServiceArea", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("30", form["defaultBreaks"]);
+        Assert.Equal("esriNATravelDirectionFromFacility", form["travelDirection"]);
+        using var facilities = JsonDocument.Parse(form["facilities"]);
+        Assert.Equal("Depot", facilities.RootElement.GetProperty("features")[0].GetProperty("attributes").GetProperty("Name").GetString());
+    }
+
+    [Fact]
+    public async Task FindClosestFacilityAsync_SendsIncidentAndFacilityFeatureSets()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, ct) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+
+        await client.FindClosestFacilityAsync(
+            [RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident")],
+            [
+                RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A"),
+                RoutingLocation.FromLongitudeLatitude(-157.82, 21.31, "Facility B"),
+            ],
+            new ClosestFacilityOptions { TargetFacilityCount = 1 });
+
+        Assert.Equal("http://localhost:5000/rest/services/Routing/NAServer/ClosestFacility/solveClosestFacility", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("1", form["defaultTargetFacilityCount"]);
+        using var incidents = JsonDocument.Parse(form["incidents"]);
+        using var facilities = JsonDocument.Parse(form["facilities"]);
+        Assert.Single(incidents.RootElement.GetProperty("features").EnumerateArray());
+        Assert.Equal(2, facilities.RootElement.GetProperty("features").EnumerateArray().Count());
+    }
+
+    [Fact]
+    public async Task FindClosestFacilityAsync_UsesDirectionSummaryWhenRoutesAreOmitted()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("""
+        {
+          "directions": [
+            {
+              "summary": { "routeName": "Incident - Facility A", "totalLength": 2.5, "totalTime": 8 }
+            }
+          ]
+        }
+        """)));
+
+        var result = await client.FindClosestFacilityAsync(
+            [RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident")],
+            [RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A")],
+            new ClosestFacilityOptions { ReturnRoutes = false });
+
+        Assert.Single(result.Routes);
+        Assert.Equal("Incident - Facility A", result.Routes[0].Name);
+        Assert.Equal(2.5, result.Routes[0].TotalDistance);
+        Assert.Equal(TimeSpan.FromMinutes(8), result.Routes[0].TotalTime);
+    }
+
+    [Fact]
+    public async Task RouteBuilder_AppliesTrafficRestrictionsBarriersAndLanguage()
+    {
+        Dictionary<string, string>? form = null;
+        var client = CreateClient(async (request, ct) =>
+        {
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+
+        await client.Route()
+            .From(RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069))
+            .Via(RoutingLocation.FromLongitudeLatitude(-157.84, 21.29))
+            .To(RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810))
+            .WithOptions(new RouteSolveOptions
+            {
+                DirectionsLanguage = "es",
+                PointBarriers = [RoutingLocation.FromLongitudeLatitude(-157.83, 21.30, "Closure")],
+            })
+            .WithTraffic()
+            .AvoidTolls()
+            .ExecuteAsync();
+
+        Assert.NotNull(form);
+        Assert.Equal("true", form["useTraffic"]);
+        Assert.Equal("true", form["avoidTolls"]);
+        Assert.Equal("es", form["directionsLanguage"]);
+        using var stops = JsonDocument.Parse(form["stops"]);
+        using var barriers = JsonDocument.Parse(form["barriers"]);
+        Assert.Equal(3, stops.RootElement.GetProperty("features").EnumerateArray().Count());
+        Assert.Equal("Closure", barriers.RootElement.GetProperty("features")[0].GetProperty("attributes").GetProperty("Name").GetString());
+    }
+
+    [Fact]
+    public async Task GetServiceMetadataAsync_ParsesTravelModesAndLanguages()
+    {
+        Uri? uri = null;
+        var client = CreateClient((request, _) =>
+        {
+            uri = request.RequestUri;
+            return Task.FromResult(JsonResponse("""
+            {
+              "defaultTravelMode": { "name": "Driving Time" },
+              "supportedTravelModes": [
+                { "name": "Driving Time", "type": "AUTOMOBILE", "description": "Fastest driving route" }
+              ],
+              "supportedDirectionsLanguages": ["en", "es"]
+            }
+            """));
+        });
+
+        var metadata = await client.GetServiceMetadataAsync(new RouteServiceMetadataRequest());
+
+        Assert.Equal("http://localhost:5000/rest/services/Routing/NAServer/Route?f=json", uri?.ToString());
+        Assert.Equal("Routing", metadata.ServiceId);
+        Assert.Equal("Route", metadata.RouteLayerName);
+        var mode = Assert.Single(metadata.TravelModes);
+        Assert.Equal("Driving Time", mode.Name);
+        Assert.Equal("AUTOMOBILE", mode.Type);
+        Assert.Equal("Driving Time", metadata.DefaultTravelMode);
+        Assert.Equal(["en", "es"], metadata.SupportedDirectionsLanguages);
+    }
+
+    [Fact]
+    public async Task RoutingLocation_SerializesTimeWindowsAndJsonAttributes()
+    {
+        Dictionary<string, string>? form = null;
+        using var priority = JsonDocument.Parse("\"high\"");
+        var location = new RoutingLocation
+        {
+            Coordinate = new RoutingCoordinate(-157.8583, 21.3069),
+            Name = "Timed stop",
+            TimeWindow = new RouteTimeWindow
+            {
+                Start = new DateTimeOffset(2026, 4, 30, 20, 0, 0, TimeSpan.Zero),
+                End = new DateTimeOffset(2026, 4, 30, 21, 0, 0, TimeSpan.Zero),
+            },
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["Priority"] = priority.RootElement.Clone(),
+            },
+        };
+        var client = CreateClient(async (request, ct) =>
+        {
+            form = await ReadFormAsync(request, ct);
+            return JsonResponse("{}");
+        });
+
+        await client.GetDirectionsAsync(location, RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810));
+
+        Assert.NotNull(form);
+        using var stops = JsonDocument.Parse(form["stops"]);
+        var attributes = stops.RootElement.GetProperty("features")[0].GetProperty("attributes");
+        Assert.Equal("Timed stop", attributes.GetProperty("Name").GetString());
+        Assert.Equal("2026-04-30T20:00:00.0000000+00:00", attributes.GetProperty("TimeWindowStart").GetString());
+        Assert.Equal("high", attributes.GetProperty("Priority").GetString());
+    }
+
+    [Fact]
+    public void AddHonuaRouting_RegistersRoutingClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaRouting(options =>
+        {
+            options.BaseAddress = new Uri("http://localhost:5000");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var routingClient = Assert.Single(provider.GetServices<IHonuaRoutingClient>());
+
+        Assert.Equal("geoservices-naserver", routingClient.ProviderName);
+        Assert.True(routingClient.Capabilities.SupportsDirections);
+        Assert.True(routingClient.Capabilities.SupportsRouteOptimization);
+        Assert.True(routingClient.Capabilities.SupportsServiceAreas);
+        Assert.True(routingClient.Capabilities.SupportsClosestFacility);
+    }
+
+    private static HonuaRoutingClient CreateClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler,
+        HonuaGeoServicesClientOptions? options = null)
+    {
+        var mockHandler = new MockHttpHandler(request => handler(request, CancellationToken.None));
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        options ??= new HonuaGeoServicesClientOptions
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+            RoutingServiceId = "Routing",
+        };
+
+        return new HonuaRoutingClient(httpClient, options);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static async Task<Dictionary<string, string>> ReadFormAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        var body = await request.Content!.ReadAsStringAsync(ct);
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string Decode(string value) => Uri.UnescapeDataString(value.Replace("+", " ", StringComparison.Ordinal));
+}


### PR DESCRIPTION
## Summary
- adds provider-neutral `Honua.Sdk.Abstractions.Routing` contracts for route solving, optimization, service areas, closest facility, service metadata, travel modes, languages, barriers, and time windows
- adds a GeoServices NAServer routing client plus DI registration and configurable NAServer service/layer defaults
- updates the mobile harmonization fixture/docs so attachments and routing are SDK-owned and mobile keeps runtime/display/location adapters

## Server dependency
- linked dependency remains https://github.com/honua-io/honua-server/issues/366 for server-side routing parity

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `dotnet format --verify-no-changes --no-restore`
- `git diff --check`

Closes #60