### PR TITLE
wasm: expand browser SDK smoke sample

### DIFF
--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -19,11 +19,12 @@ rendering stay in host applications or downstream adapter packages.
 | `Honua.Sdk.Spec` | Candidate | REST validation/plan/cancel paths are browser candidates. Apply streaming uses SSE-style responses and still needs runtime validation under Blazor WebAssembly before being called supported. |
 | `Honua.Sdk.Wfs` | Candidate | REST/XML/GeoJSON client over browser `HttpClient`; requires server CORS and browser-owned auth. |
 | `Honua.Sdk.GeoServices` | Candidate | REST/JSON FeatureServer client over browser `HttpClient`; requires server CORS and browser-owned auth. |
+| Routing client in `Honua.Sdk.GeoServices` | Candidate | REST/JSON NAServer client over browser `HttpClient`; requires server CORS and browser-owned auth. Host apps own current-location acquisition, route display, and map interaction. |
 | `Honua.Sdk.Scenes` | Candidate | REST/JSON scene metadata client over browser `HttpClient`; requires server CORS and browser-owned auth. Display, Cesium, WebGL/WebGPU, and renderer caches remain outside the SDK. |
 | `Honua.Sdk.Field` | Candidate | Pure form, validation, calculated field, duplicate detection, and record workflow contracts. Browser hosts own rendering, storage, device capture, local media handling, and any map display. |
 | `Honua.Sdk.OgcFeatures` | Candidate | REST/JSON OGC API Features client over browser `HttpClient`; requires server CORS and browser-owned auth. |
 | `Honua.Sdk.Grpc` | Not supported for browser runtime | Native gRPC/HTTP2 is not a supported browser path. Treat current browser builds as compile-only. Add gRPC-Web support only after `honua-server` exposes a compatible endpoint and the SDK has a browser-specific transport plan. |
-| Routing, realtime feeds, plugins | Not implemented | Future packages should split pure contracts from runtime adapters and update this matrix before browser consumption. |
+| Realtime feeds and plugins | Not implemented | Future packages should split pure contracts from runtime adapters and update this matrix before browser consumption. |
 | Display/maps | Out of SDK core | MapLibre/deck.gl, Cesium, Mapsui, renderer caches, controls, and AR/VR anchors belong in viewer/mobile/admin apps or display adapter packages. SDK packages should hand back portable data/contracts. |
 
 ## Explicit Browser Exclusions
@@ -49,10 +50,36 @@ packages and registers the REST clients with retry disabled. That gate proves
 the packages can be consumed by a browser app without native compile-time
 dependencies.
 
-Runtime validation still belongs to the consuming app or a follow-up SDK sample:
+The smoke app also contains a compile-checked browser feature-map sample. It
+uses `IHonuaOgcFeaturesClient` to query a GeoJSON feature collection, uses
+`IHonuaGeocodingClient` to forward-geocode an address, and hands both to an
+injected `IBrowserGeoJsonDisplayAdapter`. The adapter is intentionally a no-op
+in this repository: MapLibre/deck.gl, Cesium, Mapsui, canvas/WebGL lifecycle,
+and picking controls remain in viewer packages or host apps.
+
+Live runtime validation still belongs to the consuming app or a follow-up SDK
+sample wired to a test Honua deployment:
 
 - browser `HttpClient` requests against a real or fake Honua server;
 - cross-origin CORS behavior where the deployment is not same-origin;
 - delegated bearer-token or BFF authentication;
 - `Honua.Sdk.Spec` apply-stream behavior;
 - offline storage adapters such as IndexedDB.
+
+Minimum browser host configuration for live REST validation:
+
+- use same-origin routes or configure CORS for the SDK REST origins;
+- allow `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS` as required by
+  the selected SDK clients;
+- allow `Authorization` and content headers used by the host auth flow;
+- never place privileged admin API keys or server-only connection secrets in
+  static browser configuration.
+
+## Browser gRPC Plan
+
+Browser consumers should not register `Honua.Sdk.Grpc` as a runtime transport.
+Feature reads and edits should route through OGC API Features or GeoServices
+REST clients until `honua-server` exposes a gRPC-Web endpoint and the SDK has a
+browser-specific transport package. That future package should be separate from
+the native gRPC package so browser apps do not accidentally assume raw HTTP/2
+channel support.

--- a/tests/Honua.Sdk.BrowserSmoke/BrowserFeatureMapSample.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/BrowserFeatureMapSample.cs
@@ -1,0 +1,94 @@
+using Honua.Sdk.Admin.Geocoding;
+using Honua.Sdk.OgcFeatures;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.BrowserSmoke;
+
+internal sealed class BrowserFeatureMapSample(
+    IHonuaOgcFeaturesClient features,
+    IHonuaGeocodingClient geocoding,
+    IBrowserGeoJsonDisplayAdapter display,
+    BrowserFeatureMapSampleOptions options)
+{
+    private readonly IHonuaOgcFeaturesClient _features = features;
+    private readonly IHonuaGeocodingClient _geocoding = geocoding;
+    private readonly IBrowserGeoJsonDisplayAdapter _display = display;
+    private readonly BrowserFeatureMapSampleOptions _options = options;
+
+    public async Task<BrowserGeoJsonDisplayPayload> RunAsync(CancellationToken ct = default)
+    {
+        var featureCollection = await _features.GetItemsAsync(
+            _options.CollectionId,
+            new OgcItemsParams
+            {
+                Limit = _options.FeatureLimit,
+                Filter = _options.Filter,
+                FilterLang = string.IsNullOrWhiteSpace(_options.Filter) ? null : "cql2-text",
+                Format = OgcFeaturesFormat.GeoJson,
+            },
+            ct).ConfigureAwait(false);
+
+        var geocodes = await _geocoding.ForwardGeocodeAsync(
+            _options.Address,
+            new ForwardGeocodeOptions
+            {
+                MaxResults = _options.GeocodeLimit,
+                SpatialReferenceWkid = 4326,
+            },
+            ct).ConfigureAwait(false);
+
+        var payload = new BrowserGeoJsonDisplayPayload(
+            _options.DisplayLayerId,
+            featureCollection,
+            geocodes.Select(ToMarker).ToArray());
+
+        await _display.SetGeoJsonAsync(payload, ct).ConfigureAwait(false);
+        return payload;
+    }
+
+    private static BrowserGeocodeMarker ToMarker(GeocodeResult result)
+        => new(result.Address, result.Latitude, result.Longitude, result.Score);
+}
+
+internal sealed record BrowserFeatureMapSampleOptions
+{
+    public string CollectionId { get; init; } = "parks";
+
+    public string Address { get; init; } = "Honolulu, HI";
+
+    public int FeatureLimit { get; init; } = 25;
+
+    public int GeocodeLimit { get; init; } = 3;
+
+    public string? Filter { get; init; } = "status = 'open'";
+
+    public string DisplayLayerId { get; init; } = "honua-browser-sample";
+}
+
+internal sealed record BrowserGeoJsonDisplayPayload(
+    string LayerId,
+    OgcFeatureCollection FeatureCollection,
+    IReadOnlyList<BrowserGeocodeMarker> GeocodeMarkers);
+
+internal sealed record BrowserGeocodeMarker(
+    string Address,
+    double Latitude,
+    double Longitude,
+    double Score);
+
+internal interface IBrowserGeoJsonDisplayAdapter
+{
+    ValueTask SetGeoJsonAsync(BrowserGeoJsonDisplayPayload payload, CancellationToken ct = default);
+}
+
+internal sealed class NoopBrowserGeoJsonDisplayAdapter : IBrowserGeoJsonDisplayAdapter
+{
+    public BrowserGeoJsonDisplayPayload? LastPayload { get; private set; }
+
+    public ValueTask SetGeoJsonAsync(BrowserGeoJsonDisplayPayload payload, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        LastPayload = payload;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Honua.Sdk.BrowserSmoke/Program.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/Program.cs
@@ -1,5 +1,6 @@
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Admin;
+using Honua.Sdk.Admin.Geocoding;
 using Honua.Sdk.Admin.Extensions;
 using Honua.Sdk.BrowserSmoke;
 using Honua.Sdk.Field.Forms;
@@ -11,6 +12,8 @@ using Honua.Sdk.Offline;
 using Honua.Sdk.Offline.Abstractions;
 using Honua.Sdk.OgcFeatures;
 using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.Scenes;
+using Honua.Sdk.Scenes.Extensions;
 using Honua.Sdk.Spec;
 using Honua.Sdk.Spec.Extensions;
 using Honua.Sdk.Wfs;
@@ -23,11 +26,14 @@ builder.RootComponents.Add<App>("#app");
 
 var server = new Uri("https://honua.example.test/");
 ConfigureRestClients(builder.Services, server);
+RegisterBrowserFeatureMapSample(builder.Services);
 RegisterFieldContracts(builder.Services);
 RegisterGeometryContracts(builder.Services);
 RegisterOfflineContracts(builder.Services);
 
-await builder.Build().RunAsync().ConfigureAwait(false);
+var host = builder.Build();
+_ = host.Services.GetRequiredService<BrowserFeatureMapSample>();
+await host.RunAsync().ConfigureAwait(false);
 
 static void ConfigureRestClients(IServiceCollection services, Uri server)
 {
@@ -51,9 +57,17 @@ static void ConfigureRestClients(IServiceCollection services, Uri server)
     {
         ConfigureGeoServicesBrowserCandidate(options, server);
     });
+    services.AddHonuaRouting(options =>
+    {
+        ConfigureGeoServicesBrowserCandidate(options, server);
+    });
     services.AddHonuaOgcFeatures(options =>
     {
         ConfigureOgcFeaturesBrowserCandidate(options, server);
+    });
+    services.AddHonuaScenes(options =>
+    {
+        ConfigureSceneBrowserCandidate(options, server);
     });
 }
 
@@ -92,6 +106,13 @@ static void ConfigureOgcFeaturesBrowserCandidate(HonuaOgcFeaturesClientOptions o
     options.EnableRetry = false;
 }
 
+static void ConfigureSceneBrowserCandidate(HonuaSceneClientOptions options, Uri server)
+{
+    options.BaseAddress = server;
+    options.BearerTokenProvider = NoBrowserTokenAsync;
+    options.EnableRetry = false;
+}
+
 static Task<string?> NoBrowserTokenAsync(CancellationToken cancellationToken)
 {
     cancellationToken.ThrowIfCancellationRequested();
@@ -102,6 +123,17 @@ static void RegisterGeometryContracts(IServiceCollection services)
 {
     services.AddSingleton(HonuaSpatialReference.Wgs84);
     services.AddSingleton<HonuaCoordinateTransformer>();
+}
+
+static void RegisterBrowserFeatureMapSample(IServiceCollection services)
+{
+    services.AddSingleton(new BrowserFeatureMapSampleOptions());
+    services.AddScoped<IBrowserGeoJsonDisplayAdapter>(_ => new NoopBrowserGeoJsonDisplayAdapter());
+    services.AddScoped(sp => new BrowserFeatureMapSample(
+        sp.GetRequiredService<IHonuaOgcFeaturesClient>(),
+        sp.GetRequiredService<IHonuaGeocodingClient>(),
+        sp.GetRequiredService<IBrowserGeoJsonDisplayAdapter>(),
+        sp.GetRequiredService<BrowserFeatureMapSampleOptions>()));
 }
 
 static void RegisterFieldContracts(IServiceCollection services)


### PR DESCRIPTION
## Summary
- expands the Blazor WebAssembly smoke app to register routing and scene REST clients alongside the existing browser-candidate packages
- adds a compile-checked browser feature-map sample workflow that queries OGC GeoJSON, forward-geocodes an address, and hands both to an injected display adapter seam
- updates the browser/WASM support doc with the routing candidate status, live REST/CORS host requirements, and the browser gRPC plan

## Testing
- `dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet restore Honua.Sdk.sln`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `git diff --check`

Related to #62.
