### PR TITLE
feat: add production auth provider hooks

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,18 +1,23 @@
 # Authentication
 
-Honua SDK clients accept static credentials for simple deployments and provider
-delegates for production token refresh, key rotation, and revocation.
+Honua SDK clients accept static credentials for simple deployments, provider
+delegates for key rotation, and request-aware token providers for production
+OAuth/OIDC refresh flows.
 
 ## Supported Clients
 
 These option types support `ApiKey`, `BearerToken`, `ApiKeyProvider`, and
-`BearerTokenProvider`:
+`BearerTokenProvider`. They also support `AccessTokenProvider`,
+`AuthenticationScopes`, `AuthenticationAudience`,
+`AuthenticationDiagnostics`, and `PrimaryHttpMessageHandlerFactory`:
 
 - `HonuaAdminClientOptions` for Admin and Geocoding
 - `HonuaGrpcClientOptions` for gRPC
 - `HonuaWfsClientOptions` for WFS
 - `HonuaGeoServicesClientOptions` for GeoServices FeatureServer
 - `HonuaOgcFeaturesClientOptions` for OGC API Features
+- `HonuaSceneClientOptions` for scene metadata and offline scene packages
+- `HonuaSpecClientOptions` for spec workspace plan/apply APIs
 
 Provider delegates are invoked before each SDK request or RPC. When a provider
 is configured, its value takes precedence over the static property. Returning
@@ -30,6 +35,83 @@ builder.Services.AddHonuaGrpc(o =>
 {
     o.Address = "https://honua.example.com";
     o.ApiKeyProvider = ct => apiKeyStore.GetCurrentApiKeyAsync(ct);
+});
+```
+
+## Production Token Providers
+
+Prefer `AccessTokenProvider` for production OAuth/OIDC integration. It receives
+a `HonuaAuthenticationRequest` with transport, service name, method, request
+URI when available, configured scopes, and configured audience. This lets one
+provider choose different tokens for Admin, OGC Features, FeatureServer, WFS,
+Scenes, Spec, or gRPC calls without parsing global SDK state.
+
+`AccessTokenProvider` takes precedence over `BearerTokenProvider` and
+`BearerToken`. API key sources remain independent and can be sent alongside an
+access token when a deployment requires both.
+
+```csharp
+var tokenProvider = new HonuaOAuthClientCredentialsTokenProvider(
+    httpClient,
+    new HonuaOAuthClientCredentialsTokenProviderOptions
+    {
+        TokenEndpoint = new Uri("https://identity.example.com/oauth/token"),
+        ClientId = "honua-worker",
+        ClientSecret = clientSecret,
+        Scopes = ["honua.features.read"],
+        Audience = "https://honua.example.com"
+    });
+
+builder.Services.AddHonuaOgcFeatures(o =>
+{
+    o.BaseAddress = new Uri("https://honua.example.com");
+    o.AccessTokenProvider = tokenProvider;
+    o.AuthenticationScopes = ["honua.features.read"];
+    o.AuthenticationAudience = "https://honua.example.com";
+});
+```
+
+The SDK includes two built-in provider hooks:
+
+- `HonuaOAuthClientCredentialsTokenProvider` for service-to-service flows.
+- `HonuaOAuthAuthorizationCodeTokenProvider` for authorization-code and refresh-token flows.
+
+Both providers call a standard token endpoint, cache the current access token
+in memory, and refresh before expiry using `RefreshSkew`. They do not persist
+tokens or log token endpoint payloads.
+
+## Scopes, Audience, And Diagnostics
+
+Set `AuthenticationScopes` and `AuthenticationAudience` on client options when
+the identity provider requires per-service values. HTTP requests can override
+the default context with `HonuaAuthenticationRequestOptions.Scopes`,
+`HonuaAuthenticationRequestOptions.Audience`, and
+`HonuaAuthenticationRequestOptions.Operation` before the auth handler runs.
+
+`AuthenticationDiagnostics` receives sanitized events only. The SDK reports
+whether an API key or authorization header was present, the authorization
+scheme, transport, service, method, URI, scopes, and audience. It never passes
+raw API key, bearer token, client secret, refresh token, or access token values
+to diagnostics. `HonuaAuthenticationSupport.RedactSecret` is available for
+caller-owned diagnostic code that needs a fixed redaction marker.
+
+## Certificates And mTLS
+
+Use `PrimaryHttpMessageHandlerFactory` when a deployment requires client
+certificates, custom trust roots, proxies, or other enterprise transport
+settings. REST clients pass the factory to `HttpClientFactory`; the gRPC client
+passes it to `GrpcChannelOptions.HttpHandler`.
+
+```csharp
+builder.Services.AddHonuaFeatureServer(o =>
+{
+    o.BaseAddress = new Uri("https://honua.example.com");
+    o.PrimaryHttpMessageHandlerFactory = () =>
+    {
+        var handler = new HttpClientHandler();
+        handler.ClientCertificates.Add(clientCertificate);
+        return handler;
+    };
 });
 ```
 

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationModels.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationModels.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Authentication;
+
+/// <summary>
+/// Transport kind for SDK authentication decisions.
+/// </summary>
+public enum HonuaAuthenticationTransport
+{
+    /// <summary>
+    /// Authentication for an HTTP request.
+    /// </summary>
+    Http,
+
+    /// <summary>
+    /// Authentication for a gRPC call.
+    /// </summary>
+    Grpc
+}
+
+/// <summary>
+/// Request context passed to production token providers.
+/// </summary>
+public sealed class HonuaAuthenticationRequest
+{
+    /// <summary>
+    /// SDK transport sending the credential.
+    /// </summary>
+    public HonuaAuthenticationTransport Transport { get; init; }
+
+    /// <summary>
+    /// Logical Honua service name, such as admin, wfs, geoservices, ogc-features, scenes, spec, or grpc.
+    /// </summary>
+    public string ServiceName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional operation name for request-aware token decisions.
+    /// </summary>
+    public string? Operation { get; init; }
+
+    /// <summary>
+    /// HTTP method or gRPC method name associated with the request.
+    /// </summary>
+    public string? Method { get; init; }
+
+    /// <summary>
+    /// Request URI when the transport exposes one.
+    /// </summary>
+    public Uri? RequestUri { get; init; }
+
+    /// <summary>
+    /// Requested OAuth/OIDC scopes for this SDK request.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Requested OAuth/OIDC audience or resource value for this SDK request.
+    /// </summary>
+    public string? Audience { get; init; }
+}
+
+/// <summary>
+/// Access token returned by a request-aware token provider.
+/// </summary>
+public sealed class HonuaAccessToken
+{
+    /// <summary>
+    /// Raw access token value. The SDK never emits this value through diagnostics.
+    /// </summary>
+    public string Token { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Authorization scheme for the token. Defaults to Bearer.
+    /// </summary>
+    public string TokenType { get; init; } = "Bearer";
+
+    /// <summary>
+    /// Optional UTC expiration instant for cache and refresh decisions.
+    /// </summary>
+    public DateTimeOffset? ExpiresAtUtc { get; init; }
+
+    /// <summary>
+    /// Scopes granted by the identity provider, when returned.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Audience or resource granted by the identity provider, when returned.
+    /// </summary>
+    public string? Audience { get; init; }
+
+    /// <summary>
+    /// Determines whether the token is usable after applying a refresh skew.
+    /// </summary>
+    /// <param name="utcNow">Current UTC time.</param>
+    /// <param name="refreshSkew">Refresh skew to subtract from the expiration.</param>
+    /// <returns><c>true</c> when the token is non-empty and not close to expiration.</returns>
+    public bool IsUsable(DateTimeOffset utcNow, TimeSpan refreshSkew)
+        => !string.IsNullOrWhiteSpace(Token) &&
+           (!ExpiresAtUtc.HasValue || ExpiresAtUtc.Value - refreshSkew > utcNow);
+}
+
+/// <summary>
+/// Provides a request-aware access token.
+/// </summary>
+public interface IHonuaAccessTokenProvider
+{
+    /// <summary>
+    /// Gets the current access token for the supplied SDK request context.
+    /// </summary>
+    /// <param name="request">Authentication request context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An access token, or null to omit the authorization credential.</returns>
+    ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+        HonuaAuthenticationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Shared authentication options implemented by Honua SDK client options.
+/// </summary>
+public interface IHonuaAuthenticationOptions
+{
+    /// <summary>
+    /// Static API key value.
+    /// </summary>
+    string? ApiKey { get; }
+
+    /// <summary>
+    /// Request-time API key provider.
+    /// </summary>
+    Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; }
+
+    /// <summary>
+    /// Static bearer token value.
+    /// </summary>
+    string? BearerToken { get; }
+
+    /// <summary>
+    /// Request-time bearer token provider.
+    /// </summary>
+    Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; }
+
+    /// <summary>
+    /// Request-aware access token provider. When configured, this takes precedence over bearer token delegates.
+    /// </summary>
+    IHonuaAccessTokenProvider? AccessTokenProvider { get; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by this client.
+    /// </summary>
+    IReadOnlyList<string> AuthenticationScopes { get; }
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by this client.
+    /// </summary>
+    string? AuthenticationAudience { get; }
+
+    /// <summary>
+    /// Optional diagnostics callback. SDK diagnostics never include raw credential values.
+    /// </summary>
+    HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; }
+}
+
+/// <summary>
+/// Diagnostic event emitted by SDK authentication plumbing.
+/// </summary>
+public sealed class HonuaAuthenticationDiagnostic
+{
+    /// <summary>
+    /// Event name.
+    /// </summary>
+    public string EventName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Transport associated with the event.
+    /// </summary>
+    public HonuaAuthenticationTransport Transport { get; init; }
+
+    /// <summary>
+    /// Logical Honua service associated with the event.
+    /// </summary>
+    public string ServiceName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional operation name.
+    /// </summary>
+    public string? Operation { get; init; }
+
+    /// <summary>
+    /// HTTP method or gRPC method name.
+    /// </summary>
+    public string? Method { get; init; }
+
+    /// <summary>
+    /// Request URI associated with the event.
+    /// </summary>
+    public Uri? RequestUri { get; init; }
+
+    /// <summary>
+    /// Requested scopes associated with the event.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Requested audience associated with the event.
+    /// </summary>
+    public string? Audience { get; init; }
+
+    /// <summary>
+    /// Sanitized diagnostic attributes. Values must not contain raw credentials.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Attributes { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Handles sanitized SDK authentication diagnostics.
+/// </summary>
+/// <param name="diagnostic">Sanitized authentication diagnostic.</param>
+/// <param name="cancellationToken">Cancellation token.</param>
+/// <returns>A value task that completes when the diagnostic is handled.</returns>
+public delegate ValueTask HonuaAuthenticationDiagnosticHandler(
+    HonuaAuthenticationDiagnostic diagnostic,
+    CancellationToken cancellationToken);
+
+/// <summary>
+/// HTTP request option keys used to override auth context for a single SDK request.
+/// </summary>
+public static class HonuaAuthenticationRequestOptions
+{
+    /// <summary>
+    /// Request-scoped OAuth/OIDC scope override.
+    /// </summary>
+    public static readonly HttpRequestOptionsKey<IReadOnlyList<string>> Scopes =
+        new("Honua.Authentication.Scopes");
+
+    /// <summary>
+    /// Request-scoped OAuth/OIDC audience override.
+    /// </summary>
+    public static readonly HttpRequestOptionsKey<string> Audience =
+        new("Honua.Authentication.Audience");
+
+    /// <summary>
+    /// Request-scoped operation name for diagnostics and token provider decisions.
+    /// </summary>
+    public static readonly HttpRequestOptionsKey<string> Operation =
+        new("Honua.Authentication.Operation");
+}

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net.Http.Headers;
+
+namespace Honua.Sdk.Abstractions.Authentication;
+
+/// <summary>
+/// Shared helpers for applying SDK authentication without exposing raw secrets to diagnostics.
+/// </summary>
+public static class HonuaAuthenticationSupport
+{
+    /// <summary>
+    /// Diagnostic event emitted when credentials are applied or omitted for a request.
+    /// </summary>
+    public const string CredentialAppliedEvent = "honua.auth.credential_applied";
+
+    /// <summary>
+    /// Diagnostic event emitted before the SDK rejects credentials over remote plain HTTP.
+    /// </summary>
+    public const string InsecureTransportRejectedEvent = "honua.auth.insecure_transport_rejected";
+
+    /// <summary>
+    /// Determines whether any credential source is configured.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <returns><c>true</c> when at least one credential source is configured.</returns>
+    public static bool HasCredentialSource(IHonuaAuthenticationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return !string.IsNullOrWhiteSpace(options.ApiKey) ||
+               !string.IsNullOrWhiteSpace(options.BearerToken) ||
+               options.ApiKeyProvider is not null ||
+               options.BearerTokenProvider is not null ||
+               options.AccessTokenProvider is not null;
+    }
+
+    /// <summary>
+    /// Creates a request context for an HTTP request.
+    /// </summary>
+    /// <param name="request">HTTP request.</param>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="serviceName">Logical Honua service name.</param>
+    /// <returns>Request-aware authentication context.</returns>
+    public static HonuaAuthenticationRequest CreateHttpRequest(
+        HttpRequestMessage request,
+        IHonuaAuthenticationOptions options,
+        string serviceName)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(options);
+
+        request.Options.TryGetValue(HonuaAuthenticationRequestOptions.Scopes, out var requestScopes);
+        request.Options.TryGetValue(HonuaAuthenticationRequestOptions.Audience, out var requestAudience);
+        request.Options.TryGetValue(HonuaAuthenticationRequestOptions.Operation, out var requestOperation);
+
+        return new HonuaAuthenticationRequest
+        {
+            Transport = HonuaAuthenticationTransport.Http,
+            ServiceName = serviceName,
+            Operation = requestOperation,
+            Method = request.Method.Method,
+            RequestUri = request.RequestUri,
+            Scopes = NormalizeScopes(requestScopes ?? options.AuthenticationScopes),
+            Audience = string.IsNullOrWhiteSpace(requestAudience) ? options.AuthenticationAudience : requestAudience
+        };
+    }
+
+    /// <summary>
+    /// Creates a request context for a gRPC request.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="serviceName">Logical Honua service name.</param>
+    /// <param name="methodName">gRPC method name.</param>
+    /// <returns>Request-aware authentication context.</returns>
+    public static HonuaAuthenticationRequest CreateGrpcRequest(
+        IHonuaAuthenticationOptions options,
+        string serviceName,
+        string? methodName)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return new HonuaAuthenticationRequest
+        {
+            Transport = HonuaAuthenticationTransport.Grpc,
+            ServiceName = serviceName,
+            Operation = methodName,
+            Method = methodName,
+            Scopes = NormalizeScopes(options.AuthenticationScopes),
+            Audience = options.AuthenticationAudience
+        };
+    }
+
+    /// <summary>
+    /// Applies API key and authorization credentials to an HTTP request.
+    /// </summary>
+    /// <param name="request">HTTP request.</param>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="serviceName">Logical Honua service name.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes after credentials are applied.</returns>
+    public static async Task ApplyHttpCredentialsAsync(
+        HttpRequestMessage request,
+        IHonuaAuthenticationOptions options,
+        string serviceName,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var context = CreateHttpRequest(request, options, serviceName);
+
+        var apiKey = await ResolveApiKeyAsync(options, cancellationToken).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
+        }
+
+        var accessToken = await ResolveAccessTokenAsync(options, context, cancellationToken).ConfigureAwait(false);
+        if (accessToken is not null && !string.IsNullOrWhiteSpace(accessToken.Token))
+        {
+            var tokenType = string.IsNullOrWhiteSpace(accessToken.TokenType) ? "Bearer" : accessToken.TokenType;
+            request.Headers.Authorization = new AuthenticationHeaderValue(tokenType, accessToken.Token);
+        }
+
+        await EmitCredentialAppliedDiagnosticAsync(
+            options,
+            context,
+            hasApiKey: !string.IsNullOrWhiteSpace(apiKey),
+            authorizationScheme: accessToken?.TokenType,
+            hasAuthorization: accessToken is not null && !string.IsNullOrWhiteSpace(accessToken.Token),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolves an API key from configured static or provider-based credentials.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>API key value, or null when omitted.</returns>
+    public static Task<string?> ResolveApiKeyAsync(
+        IHonuaAuthenticationOptions options,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return options.ApiKeyProvider is { } provider
+            ? provider(cancellationToken)
+            : Task.FromResult(options.ApiKey);
+    }
+
+    /// <summary>
+    /// Resolves an access token from request-aware or legacy bearer-token providers.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="request">Authentication request context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>An access token, or null when omitted.</returns>
+    public static async ValueTask<HonuaAccessToken?> ResolveAccessTokenAsync(
+        IHonuaAuthenticationOptions options,
+        HonuaAuthenticationRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (options.AccessTokenProvider is { } accessTokenProvider)
+        {
+            return await accessTokenProvider.GetAccessTokenAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        var bearerToken = options.BearerTokenProvider is { } bearerTokenProvider
+            ? await bearerTokenProvider(cancellationToken).ConfigureAwait(false)
+            : options.BearerToken;
+
+        return string.IsNullOrWhiteSpace(bearerToken)
+            ? null
+            : new HonuaAccessToken { Token = bearerToken };
+    }
+
+    /// <summary>
+    /// Emits a sanitized diagnostic for an insecure transport rejection.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="context">Authentication request context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A value task that completes when the diagnostic is handled.</returns>
+    public static ValueTask EmitInsecureTransportRejectedDiagnosticAsync(
+        IHonuaAuthenticationOptions options,
+        HonuaAuthenticationRequest context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return EmitDiagnosticAsync(
+            options,
+            context,
+            InsecureTransportRejectedEvent,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["reason"] = "remote-http"
+            },
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Redacts a raw secret value for emergency caller-owned diagnostics.
+    /// </summary>
+    /// <param name="value">Potential secret value.</param>
+    /// <returns>An empty string for empty values; otherwise a fixed redaction marker.</returns>
+    public static string RedactSecret(string? value)
+        => string.IsNullOrEmpty(value) ? string.Empty : "[redacted]";
+
+    /// <summary>
+    /// Normalizes a scope sequence by trimming empty values.
+    /// </summary>
+    /// <param name="scopes">Scope sequence.</param>
+    /// <returns>Normalized scopes.</returns>
+    public static IReadOnlyList<string> NormalizeScopes(IEnumerable<string>? scopes)
+        => scopes?
+            .Where(scope => !string.IsNullOrWhiteSpace(scope))
+            .Select(scope => scope.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>();
+
+    /// <summary>
+    /// Emits a sanitized credential-applied diagnostic.
+    /// </summary>
+    /// <param name="options">Authentication options.</param>
+    /// <param name="context">Authentication request context.</param>
+    /// <param name="hasApiKey">Whether an API key was applied.</param>
+    /// <param name="authorizationScheme">Authorization scheme when applied.</param>
+    /// <param name="hasAuthorization">Whether authorization was applied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A value task that completes when the diagnostic is handled.</returns>
+    public static ValueTask EmitCredentialAppliedDiagnosticAsync(
+        IHonuaAuthenticationOptions options,
+        HonuaAuthenticationRequest context,
+        bool hasApiKey,
+        string? authorizationScheme,
+        bool hasAuthorization,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return EmitDiagnosticAsync(
+            options,
+            context,
+            CredentialAppliedEvent,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["apiKey"] = hasApiKey ? "present" : "omitted",
+                ["authorization"] = hasAuthorization ? "present" : "omitted",
+                ["authorizationScheme"] = hasAuthorization && !string.IsNullOrWhiteSpace(authorizationScheme)
+                    ? authorizationScheme
+                    : "none"
+            },
+            cancellationToken);
+    }
+
+    private static ValueTask EmitDiagnosticAsync(
+        IHonuaAuthenticationOptions options,
+        HonuaAuthenticationRequest context,
+        string eventName,
+        IReadOnlyDictionary<string, string> attributes,
+        CancellationToken cancellationToken)
+    {
+        if (options.AuthenticationDiagnostics is not { } diagnostics)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return diagnostics(
+            new HonuaAuthenticationDiagnostic
+            {
+                EventName = eventName,
+                Transport = context.Transport,
+                ServiceName = context.ServiceName,
+                Operation = context.Operation,
+                Method = context.Method,
+                RequestUri = SanitizeUriForDiagnostics(context.RequestUri),
+                Scopes = context.Scopes,
+                Audience = context.Audience,
+                Attributes = attributes
+            },
+            cancellationToken);
+    }
+
+    private static Uri? SanitizeUriForDiagnostics(Uri? requestUri)
+    {
+        if (requestUri is null || string.IsNullOrEmpty(requestUri.Query))
+        {
+            return requestUri;
+        }
+
+        var builder = new UriBuilder(requestUri)
+        {
+            Query = string.Empty
+        };
+        return builder.Uri;
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaOAuthTokenProviders.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaOAuthTokenProviders.cs
@@ -1,0 +1,535 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Authentication;
+
+/// <summary>
+/// Options for the built-in OAuth/OIDC client-credentials token provider.
+/// </summary>
+public sealed class HonuaOAuthClientCredentialsTokenProviderOptions
+{
+    /// <summary>
+    /// OAuth/OIDC token endpoint.
+    /// </summary>
+    public Uri? TokenEndpoint { get; init; }
+
+    /// <summary>
+    /// OAuth/OIDC client identifier.
+    /// </summary>
+    public string ClientId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional OAuth/OIDC client secret. Do not use this in browser or mobile public-client builds.
+    /// </summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>
+    /// Default scopes requested from the token endpoint.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default audience or resource requested from the token endpoint.
+    /// </summary>
+    public string? Audience { get; init; }
+
+    /// <summary>
+    /// Token refresh skew applied before expiration. Defaults to five minutes.
+    /// </summary>
+    public TimeSpan RefreshSkew { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Extra token endpoint parameters for identity-provider-specific requirements.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> AdditionalParameters { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// Options for the built-in OAuth/OIDC authorization-code token provider.
+/// </summary>
+public sealed class HonuaOAuthAuthorizationCodeTokenProviderOptions
+{
+    /// <summary>
+    /// OAuth/OIDC token endpoint.
+    /// </summary>
+    public Uri? TokenEndpoint { get; init; }
+
+    /// <summary>
+    /// OAuth/OIDC client identifier.
+    /// </summary>
+    public string ClientId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional OAuth/OIDC client secret. Do not use this in browser or mobile public-client builds.
+    /// </summary>
+    public string? ClientSecret { get; init; }
+
+    /// <summary>
+    /// Initial authorization code to exchange when no refresh token is available.
+    /// </summary>
+    public string? AuthorizationCode { get; init; }
+
+    /// <summary>
+    /// Redirect URI used for the authorization-code exchange.
+    /// </summary>
+    public Uri? RedirectUri { get; init; }
+
+    /// <summary>
+    /// Optional PKCE code verifier used for public-client authorization-code flows.
+    /// </summary>
+    public string? CodeVerifier { get; init; }
+
+    /// <summary>
+    /// Optional initial refresh token used instead of an authorization-code exchange.
+    /// </summary>
+    public string? RefreshToken { get; init; }
+
+    /// <summary>
+    /// Default scopes requested from the token endpoint.
+    /// </summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default audience or resource requested from the token endpoint.
+    /// </summary>
+    public string? Audience { get; init; }
+
+    /// <summary>
+    /// Token refresh skew applied before expiration. Defaults to five minutes.
+    /// </summary>
+    public TimeSpan RefreshSkew { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Extra token endpoint parameters for identity-provider-specific requirements.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> AdditionalParameters { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+}
+
+/// <summary>
+/// OAuth/OIDC client-credentials provider with in-memory access-token refresh.
+/// </summary>
+public sealed class HonuaOAuthClientCredentialsTokenProvider : IHonuaAccessTokenProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly HonuaOAuthClientCredentialsTokenProviderOptions _options;
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<string, HonuaAccessToken> _cachedTokens = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Task<HonuaAccessToken?>> _refreshTasks = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaOAuthClientCredentialsTokenProvider"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to call the token endpoint.</param>
+    /// <param name="options">Provider options.</param>
+    public HonuaOAuthClientCredentialsTokenProvider(
+        HttpClient httpClient,
+        HonuaOAuthClientCredentialsTokenProviderOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        HonuaOAuthTokenEndpoint.ValidateTokenEndpoint(options.TokenEndpoint);
+        HonuaOAuthTokenEndpoint.ValidateRefreshSkew(options.RefreshSkew);
+        if (string.IsNullOrWhiteSpace(options.ClientId))
+        {
+            throw new ArgumentException("OAuth client id must be configured.", nameof(options));
+        }
+
+        _httpClient = httpClient;
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+        HonuaAuthenticationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cacheKey = HonuaOAuthTokenEndpoint.CreateCacheKey(
+            _options.Scopes,
+            request.Scopes,
+            request.Audience ?? _options.Audience);
+        lock (_syncRoot)
+        {
+            if (_cachedTokens.TryGetValue(cacheKey, out var cachedToken) &&
+                cachedToken.IsUsable(DateTimeOffset.UtcNow, _options.RefreshSkew))
+            {
+                return ValueTask.FromResult<HonuaAccessToken?>(cachedToken);
+            }
+        }
+
+        return new ValueTask<HonuaAccessToken?>(GetOrRefreshAsync(request, cacheKey, cancellationToken));
+    }
+
+    private Task<HonuaAccessToken?> GetOrRefreshAsync(
+        HonuaAuthenticationRequest request,
+        string cacheKey,
+        CancellationToken cancellationToken)
+    {
+        lock (_syncRoot)
+        {
+            if (_cachedTokens.TryGetValue(cacheKey, out var cachedToken) &&
+                cachedToken.IsUsable(DateTimeOffset.UtcNow, _options.RefreshSkew))
+            {
+                return Task.FromResult<HonuaAccessToken?>(cachedToken);
+            }
+
+            if (!_refreshTasks.TryGetValue(cacheKey, out var refreshTask) || refreshTask.IsCompleted)
+            {
+                refreshTask = RequestTokenAsync(request, cacheKey, cancellationToken);
+                _refreshTasks[cacheKey] = refreshTask;
+            }
+
+            return refreshTask;
+        }
+    }
+
+    private async Task<HonuaAccessToken?> RequestTokenAsync(
+        HonuaAuthenticationRequest request,
+        string cacheKey,
+        CancellationToken cancellationToken)
+    {
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("grant_type", "client_credentials"),
+            new("client_id", _options.ClientId)
+        };
+        HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "client_secret", _options.ClientSecret);
+        HonuaOAuthTokenEndpoint.AddScope(parameters, _options.Scopes, request.Scopes);
+        HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "audience", request.Audience ?? _options.Audience);
+        HonuaOAuthTokenEndpoint.AddAdditionalParameters(parameters, _options.AdditionalParameters);
+
+        var response = await HonuaOAuthTokenEndpoint.RequestAsync(
+            _httpClient,
+            _options.TokenEndpoint!,
+            parameters,
+            cancellationToken).ConfigureAwait(false);
+
+        lock (_syncRoot)
+        {
+            _cachedTokens[cacheKey] = response.AccessToken;
+        }
+
+        return response.AccessToken;
+    }
+}
+
+/// <summary>
+/// OAuth/OIDC authorization-code provider with in-memory access-token refresh.
+/// </summary>
+public sealed class HonuaOAuthAuthorizationCodeTokenProvider : IHonuaAccessTokenProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly HonuaOAuthAuthorizationCodeTokenProviderOptions _options;
+    private readonly object _syncRoot = new();
+    private readonly Dictionary<string, HonuaAccessToken> _cachedTokens = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Task<HonuaAccessToken?>> _refreshTasks = new(StringComparer.Ordinal);
+    private string? _refreshToken;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaOAuthAuthorizationCodeTokenProvider"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client used to call the token endpoint.</param>
+    /// <param name="options">Provider options.</param>
+    public HonuaOAuthAuthorizationCodeTokenProvider(
+        HttpClient httpClient,
+        HonuaOAuthAuthorizationCodeTokenProviderOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+
+        HonuaOAuthTokenEndpoint.ValidateTokenEndpoint(options.TokenEndpoint);
+        HonuaOAuthTokenEndpoint.ValidateRefreshSkew(options.RefreshSkew);
+        if (string.IsNullOrWhiteSpace(options.ClientId))
+        {
+            throw new ArgumentException("OAuth client id must be configured.", nameof(options));
+        }
+
+        if (string.IsNullOrWhiteSpace(options.AuthorizationCode) &&
+            string.IsNullOrWhiteSpace(options.RefreshToken))
+        {
+            throw new ArgumentException(
+                "OAuth authorization-code provider requires an authorization code or refresh token.",
+                nameof(options));
+        }
+
+        _httpClient = httpClient;
+        _options = options;
+        _refreshToken = options.RefreshToken;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+        HonuaAuthenticationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var cacheKey = HonuaOAuthTokenEndpoint.CreateCacheKey(
+            _options.Scopes,
+            request.Scopes,
+            request.Audience ?? _options.Audience);
+        lock (_syncRoot)
+        {
+            if (_cachedTokens.TryGetValue(cacheKey, out var cachedToken) &&
+                cachedToken.IsUsable(DateTimeOffset.UtcNow, _options.RefreshSkew))
+            {
+                return ValueTask.FromResult<HonuaAccessToken?>(cachedToken);
+            }
+        }
+
+        return new ValueTask<HonuaAccessToken?>(GetOrRefreshAsync(request, cacheKey, cancellationToken));
+    }
+
+    private Task<HonuaAccessToken?> GetOrRefreshAsync(
+        HonuaAuthenticationRequest request,
+        string cacheKey,
+        CancellationToken cancellationToken)
+    {
+        lock (_syncRoot)
+        {
+            if (_cachedTokens.TryGetValue(cacheKey, out var cachedToken) &&
+                cachedToken.IsUsable(DateTimeOffset.UtcNow, _options.RefreshSkew))
+            {
+                return Task.FromResult<HonuaAccessToken?>(cachedToken);
+            }
+
+            if (!_refreshTasks.TryGetValue(cacheKey, out var refreshTask) || refreshTask.IsCompleted)
+            {
+                refreshTask = RequestTokenAsync(request, cacheKey, cancellationToken);
+                _refreshTasks[cacheKey] = refreshTask;
+            }
+
+            return refreshTask;
+        }
+    }
+
+    private async Task<HonuaAccessToken?> RequestTokenAsync(
+        HonuaAuthenticationRequest request,
+        string cacheKey,
+        CancellationToken cancellationToken)
+    {
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("client_id", _options.ClientId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(_refreshToken))
+        {
+            parameters.Add(new KeyValuePair<string, string>("grant_type", "refresh_token"));
+            HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "refresh_token", _refreshToken);
+        }
+        else
+        {
+            parameters.Add(new KeyValuePair<string, string>("grant_type", "authorization_code"));
+            HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "code", _options.AuthorizationCode);
+            HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "redirect_uri", _options.RedirectUri?.ToString());
+            HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "code_verifier", _options.CodeVerifier);
+        }
+
+        HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "client_secret", _options.ClientSecret);
+        HonuaOAuthTokenEndpoint.AddScope(parameters, _options.Scopes, request.Scopes);
+        HonuaOAuthTokenEndpoint.AddIfNotEmpty(parameters, "audience", request.Audience ?? _options.Audience);
+        HonuaOAuthTokenEndpoint.AddAdditionalParameters(parameters, _options.AdditionalParameters);
+
+        var response = await HonuaOAuthTokenEndpoint.RequestAsync(
+            _httpClient,
+            _options.TokenEndpoint!,
+            parameters,
+            cancellationToken).ConfigureAwait(false);
+
+        lock (_syncRoot)
+        {
+            _cachedTokens[cacheKey] = response.AccessToken;
+            if (!string.IsNullOrWhiteSpace(response.RefreshToken))
+            {
+                _refreshToken = response.RefreshToken;
+            }
+        }
+
+        return response.AccessToken;
+    }
+}
+
+internal static class HonuaOAuthTokenEndpoint
+{
+    public static void AddAdditionalParameters(
+        ICollection<KeyValuePair<string, string>> parameters,
+        IEnumerable<KeyValuePair<string, string>> additionalParameters)
+    {
+        foreach (var parameter in additionalParameters)
+        {
+            AddIfNotEmpty(parameters, parameter.Key, parameter.Value);
+        }
+    }
+
+    public static void AddIfNotEmpty(
+        ICollection<KeyValuePair<string, string>> parameters,
+        string name,
+        string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(value))
+        {
+            parameters.Add(new KeyValuePair<string, string>(name, value));
+        }
+    }
+
+    public static void AddScope(
+        ICollection<KeyValuePair<string, string>> parameters,
+        IEnumerable<string> defaultScopes,
+        IEnumerable<string> requestScopes)
+    {
+        var scopes = HonuaAuthenticationSupport.NormalizeScopes(defaultScopes.Concat(requestScopes));
+        if (scopes.Count > 0)
+        {
+            parameters.Add(new KeyValuePair<string, string>("scope", string.Join(' ', scopes)));
+        }
+    }
+
+    public static string CreateCacheKey(
+        IEnumerable<string> defaultScopes,
+        IEnumerable<string> requestScopes,
+        string? audience)
+    {
+        var scopes = HonuaAuthenticationSupport.NormalizeScopes(defaultScopes.Concat(requestScopes));
+        return string.Concat(string.Join(' ', scopes), "|", audience ?? string.Empty);
+    }
+
+    public static void ValidateTokenEndpoint(Uri? tokenEndpoint)
+    {
+        if (tokenEndpoint is null)
+        {
+            throw new ArgumentException("OAuth token endpoint must be configured.", nameof(tokenEndpoint));
+        }
+
+        if (!tokenEndpoint.IsAbsoluteUri)
+        {
+            throw new ArgumentException("OAuth token endpoint must be an absolute URI.", nameof(tokenEndpoint));
+        }
+
+        if (!string.Equals(tokenEndpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+            !IsLocalDevelopmentHttp(tokenEndpoint))
+        {
+            throw new ArgumentException(
+                "OAuth token endpoint must use HTTPS, except loopback HTTP for local development.",
+                nameof(tokenEndpoint));
+        }
+    }
+
+    public static void ValidateRefreshSkew(TimeSpan refreshSkew)
+    {
+        if (refreshSkew < TimeSpan.Zero || refreshSkew > TimeSpan.FromHours(1))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(refreshSkew),
+                refreshSkew,
+                "OAuth refresh skew must be between zero and one hour.");
+        }
+    }
+
+    public static async Task<HonuaOAuthTokenEndpointResponse> RequestAsync(
+        HttpClient httpClient,
+        Uri tokenEndpoint,
+        IEnumerable<KeyValuePair<string, string>> parameters,
+        CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(parameters)
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(responseStream, default, cancellationToken).ConfigureAwait(false);
+        return HonuaOAuthTokenEndpointResponse.Parse(document.RootElement, DateTimeOffset.UtcNow);
+    }
+
+    private static bool IsLocalDevelopmentHttp(Uri uri)
+        => string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+           (uri.IsLoopback || string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
+}
+
+internal sealed class HonuaOAuthTokenEndpointResponse
+{
+    private HonuaOAuthTokenEndpointResponse(HonuaAccessToken accessToken, string? refreshToken)
+    {
+        AccessToken = accessToken;
+        RefreshToken = refreshToken;
+    }
+
+    public HonuaAccessToken AccessToken { get; }
+
+    public string? RefreshToken { get; }
+
+    public static HonuaOAuthTokenEndpointResponse Parse(JsonElement root, DateTimeOffset utcNow)
+    {
+        var accessToken = ReadString(root, "access_token");
+        if (string.IsNullOrWhiteSpace(accessToken))
+        {
+            throw new InvalidOperationException("OAuth token endpoint response did not include an access token.");
+        }
+
+        var tokenType = ReadString(root, "token_type");
+        var scope = ReadString(root, "scope");
+        var audience = ReadString(root, "audience");
+        var expiresIn = ReadExpiresIn(root);
+
+        return new HonuaOAuthTokenEndpointResponse(
+            new HonuaAccessToken
+            {
+                Token = accessToken,
+                TokenType = string.IsNullOrWhiteSpace(tokenType) ? "Bearer" : tokenType,
+                ExpiresAtUtc = expiresIn.HasValue ? utcNow.AddSeconds(expiresIn.Value) : null,
+                Scopes = SplitScope(scope),
+                Audience = audience
+            },
+            ReadString(root, "refresh_token"));
+    }
+
+    private static string? ReadString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String ? property.GetString() : property.ToString();
+    }
+
+    private static double? ReadExpiresIn(JsonElement root)
+    {
+        if (!root.TryGetProperty("expires_in", out var property))
+        {
+            return null;
+        }
+
+        if (property.ValueKind == JsonValueKind.Number && property.TryGetDouble(out var seconds))
+        {
+            return seconds;
+        }
+
+        if (property.ValueKind == JsonValueKind.String &&
+            double.TryParse(property.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out seconds))
+        {
+            return seconds;
+        }
+
+        return null;
+    }
+
+    private static string[] SplitScope(string? scope)
+        => string.IsNullOrWhiteSpace(scope)
+            ? Array.Empty<string>()
+            : scope.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class ServiceCollectionExtensions
             client.Timeout = options.Timeout;
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
     }
@@ -69,8 +70,21 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
         httpBuilder.AddTypedClient<IHonuaGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaAdminClientOptions> configure)
+    {
+        var opts = new HonuaAdminClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
+++ b/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Admin;
@@ -26,41 +26,25 @@ internal sealed class HonuaAdminAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaAdminClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaAdminClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "admin");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send admin credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "admin",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.Admin;
 
 /// <summary>
 /// Configuration options for the Honua Admin client.
 /// </summary>
-public sealed class HonuaAdminClientOptions
+public sealed class HonuaAdminClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base address of the Honua server.
@@ -36,6 +38,34 @@ public sealed class HonuaAdminClientOptions
     /// an empty string omits the authorization header.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by the admin client.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by the admin client.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -45,6 +45,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
     }
@@ -74,8 +75,21 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaGeoServicesClientOptions> configure)
+    {
+        var opts = new HonuaGeoServicesClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.GeoServices;
@@ -26,41 +26,25 @@ internal sealed class HonuaGeoServicesAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaGeoServicesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaGeoServicesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "geoservices");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "geoservices",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.GeoServices;
 
 /// <summary>
 /// Configuration options shared by the FeatureServer and OGC Features clients.
 /// </summary>
-public sealed class HonuaGeoServicesClientOptions
+public sealed class HonuaGeoServicesClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base address of the Honua server.
@@ -36,6 +38,34 @@ public sealed class HonuaGeoServicesClientOptions
     /// an empty string omits the authorization header.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by GeoServices clients.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by GeoServices clients.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Configuration;
+using Honua.Sdk.Abstractions.Authentication;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Grpc.Conversion;
 using Microsoft.Extensions.Options;
@@ -70,6 +71,10 @@ public sealed class HonuaGrpcClient :
                 HasCredentials(opts) && HonuaGrpcClientOptions.IsLocalDevelopmentHttp(address),
             ServiceConfig = BuildServiceConfig(opts)
         };
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            channelOptions.HttpHandler = primaryHandlerFactory();
+        }
 
         _ownedChannel = GrpcChannel.ForAddress(address, channelOptions);
         _client = new Proto.FeatureService.FeatureServiceClient(_ownedChannel);
@@ -171,7 +176,7 @@ public sealed class HonuaGrpcClient :
         var protoRequest = ProtoAdapter.ToProtoRequest(request);
         try
         {
-            var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+            var metadata = await BuildMetadataAsync("QueryFeatures", ct).ConfigureAwait(false);
             var protoResponse = await _client.QueryFeaturesAsync(
                 protoRequest,
                 metadata,
@@ -214,7 +219,7 @@ public sealed class HonuaGrpcClient :
         var protoRequest = ProtoAdapter.ToProtoApplyEditsRequest(request);
         try
         {
-            var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+            var metadata = await BuildMetadataAsync("ApplyEdits", ct).ConfigureAwait(false);
             var protoResponse = await _client.ApplyEditsAsync(
                 protoRequest,
                 metadata,
@@ -273,7 +278,7 @@ public sealed class HonuaGrpcClient :
         ArgumentNullException.ThrowIfNull(request);
 
         var protoRequest = ProtoAdapter.ToProtoRequest(request);
-        var metadata = await BuildMetadataAsync(ct).ConfigureAwait(false);
+        var metadata = await BuildMetadataAsync("QueryFeaturesStream", ct).ConfigureAwait(false);
         var call = _client.QueryFeaturesStream(
             protoRequest,
             metadata,
@@ -351,7 +356,7 @@ public sealed class HonuaGrpcClient :
         return serviceConfig;
     }
 
-    private async Task<Metadata> BuildMetadataAsync(CancellationToken cancellationToken)
+    private async Task<Metadata> BuildMetadataAsync(string methodName, CancellationToken cancellationToken)
     {
         if (_metadataOverride is not null)
         {
@@ -359,16 +364,21 @@ public sealed class HonuaGrpcClient :
         }
 
         var metadata = new Metadata();
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
+        var context = HonuaAuthenticationSupport.CreateGrpcRequest(_options, "grpc", methodName);
+        var apiKey = await HonuaAuthenticationSupport.ResolveApiKeyAsync(_options, cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrEmpty(apiKey))
         {
             metadata.Add("x-api-key", apiKey);
         }
 
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
+        var accessToken = await HonuaAuthenticationSupport.ResolveAccessTokenAsync(
+            _options,
+            context,
+            cancellationToken).ConfigureAwait(false);
+        if (accessToken is not null && !string.IsNullOrWhiteSpace(accessToken.Token))
         {
-            metadata.Add("authorization", $"Bearer {bearerToken}");
+            var tokenType = string.IsNullOrWhiteSpace(accessToken.TokenType) ? "Bearer" : accessToken.TokenType;
+            metadata.Add("authorization", $"{tokenType} {accessToken.Token}");
         }
 
         if (_options.EnableCompressionNegotiation && !string.IsNullOrWhiteSpace(_options.AcceptedCompressionEncodings))
@@ -376,21 +386,19 @@ public sealed class HonuaGrpcClient :
             metadata.Add("grpc-accept-encoding", _options.AcceptedCompressionEncodings);
         }
 
+        await HonuaAuthenticationSupport.EmitCredentialAppliedDiagnosticAsync(
+            _options,
+            context,
+            hasApiKey: !string.IsNullOrWhiteSpace(apiKey),
+            authorizationScheme: accessToken?.TokenType,
+            hasAuthorization: accessToken is not null && !string.IsNullOrWhiteSpace(accessToken.Token),
+            cancellationToken).ConfigureAwait(false);
+
         return metadata;
     }
 
     private DateTime CreateDeadline()
         => DateTime.UtcNow.Add(_options.Timeout);
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 
     private static void ValidateAuthenticationTransport(HonuaGrpcClientOptions opts, Uri address)
     {
@@ -408,10 +416,7 @@ public sealed class HonuaGrpcClient :
     }
 
     private static bool HasCredentials(HonuaGrpcClientOptions opts)
-        => !string.IsNullOrWhiteSpace(opts.ApiKey) ||
-           !string.IsNullOrWhiteSpace(opts.BearerToken) ||
-           opts.ApiKeyProvider is not null ||
-           opts.BearerTokenProvider is not null;
+        => HonuaAuthenticationSupport.HasCredentialSource(opts);
 
     private static Uri ResolveChannelAddress(GrpcChannel channel)
     {

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.Grpc;
 
 /// <summary>
 /// Configuration options for the Honua gRPC client.
 /// </summary>
-public sealed class HonuaGrpcClientOptions
+public sealed class HonuaGrpcClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Address of the Honua gRPC server.
@@ -36,6 +38,34 @@ public sealed class HonuaGrpcClientOptions
     /// an empty string omits the authorization metadata entry.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by the gRPC client.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by the gRPC client.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Enables gRPC compression negotiation for responses.

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -42,8 +42,21 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaOgcFeaturesClientOptions> configure)
+    {
+        var opts = new HonuaOgcFeaturesClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.OgcFeatures;
@@ -26,41 +26,25 @@ internal sealed class HonuaOgcFeaturesAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaOgcFeaturesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaOgcFeaturesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "ogc-features");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "ogc-features",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.OgcFeatures;
 
 /// <summary>
 /// Configuration options for the OGC API Features client.
 /// </summary>
-public sealed class HonuaOgcFeaturesClientOptions
+public sealed class HonuaOgcFeaturesClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base address of the Honua server.
@@ -36,6 +38,34 @@ public sealed class HonuaOgcFeaturesClientOptions
     /// an empty string omits the authorization header.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by OGC API Features clients.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by OGC API Features clients.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
@@ -38,8 +38,21 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaSceneAuthHandler>();
         services.AddTransient<IHonuaSceneClient>(sp => sp.GetRequiredService<HonuaSceneClient>());
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaSceneClientOptions> configure)
+    {
+        var opts = new HonuaSceneClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.Scenes/HonuaSceneAuthHandler.cs
+++ b/src/Honua.Sdk.Scenes/HonuaSceneAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Scenes;
@@ -26,41 +26,25 @@ internal sealed class HonuaSceneAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaSceneClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaSceneClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "scenes");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "scenes",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Scenes/HonuaSceneClientOptions.cs
+++ b/src/Honua.Sdk.Scenes/HonuaSceneClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.Scenes;
 
 /// <summary>
 /// Configuration options for the Honua scene metadata client.
 /// </summary>
-public sealed class HonuaSceneClientOptions
+public sealed class HonuaSceneClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base address of the Honua server.
@@ -37,6 +39,34 @@ public sealed class HonuaSceneClientOptions
     /// Optional bearer token provider invoked before each request.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by the scenes client.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by the scenes client.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures.

--- a/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
@@ -37,8 +37,21 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaSpecAuthHandler>();
 
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaSpecClientOptions> configure)
+    {
+        var opts = new HonuaSpecClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.Spec/Honua.Sdk.Spec.csproj
+++ b/src/Honua.Sdk.Spec/Honua.Sdk.Spec.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Honua.Sdk.Spec/HonuaSpecAuthHandler.cs
+++ b/src/Honua.Sdk.Spec/HonuaSpecAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Spec;
@@ -26,41 +26,25 @@ internal sealed class HonuaSpecAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaSpecClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaSpecClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "spec");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send spec credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "spec",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Spec/HonuaSpecClientOptions.cs
+++ b/src/Honua.Sdk.Spec/HonuaSpecClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.Spec;
 
 /// <summary>
 /// Options for the Honua spec client.
 /// </summary>
-public sealed class HonuaSpecClientOptions
+public sealed class HonuaSpecClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base Honua Server address.
@@ -36,6 +38,34 @@ public sealed class HonuaSpecClientOptions
     /// an empty string omits the authorization header.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by the spec client.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by the spec client.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -41,8 +41,21 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
+        ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;
+    }
+
+    private static void ConfigurePrimaryHandler(
+        IHttpClientBuilder httpBuilder,
+        Action<HonuaWfsClientOptions> configure)
+    {
+        var opts = new HonuaWfsClientOptions();
+        configure(opts);
+        if (opts.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
     }
 
     private static void ConfigureResilience(

--- a/src/Honua.Sdk.Wfs/HonuaWfsAuthHandler.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsAuthHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Net.Http.Headers;
+using Honua.Sdk.Abstractions.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Wfs;
@@ -26,41 +26,25 @@ internal sealed class HonuaWfsAuthHandler : DelegatingHandler
     /// <inheritdoc />
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        if (HasCredentialSource() && HonuaWfsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaWfsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
         {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "wfs");
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "Refusing to send WFS credentials over an insecure connection. Use HTTPS, " +
                 "or use loopback HTTP only for local development.");
         }
 
-        var apiKey = await ResolveApiKeyAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            request.Headers.TryAddWithoutValidation("X-API-Key", apiKey);
-        }
-
-        var bearerToken = await ResolveBearerTokenAsync(cancellationToken).ConfigureAwait(false);
-        if (!string.IsNullOrEmpty(bearerToken))
-        {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-        }
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            "wfs",
+            cancellationToken).ConfigureAwait(false);
 
         return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
-
-    private bool HasCredentialSource()
-        => !string.IsNullOrEmpty(_options.ApiKey) ||
-           !string.IsNullOrEmpty(_options.BearerToken) ||
-           _options.ApiKeyProvider is not null ||
-           _options.BearerTokenProvider is not null;
-
-    private Task<string?> ResolveApiKeyAsync(CancellationToken cancellationToken)
-        => _options.ApiKeyProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.ApiKey);
-
-    private Task<string?> ResolveBearerTokenAsync(CancellationToken cancellationToken)
-        => _options.BearerTokenProvider is { } provider
-            ? provider(cancellationToken)
-            : Task.FromResult(_options.BearerToken);
 }

--- a/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClientOptions.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Abstractions.Authentication;
+
 namespace Honua.Sdk.Wfs;
 
 /// <summary>
 /// Configuration options for the Honua WFS client.
 /// </summary>
-public sealed class HonuaWfsClientOptions
+public sealed class HonuaWfsClientOptions : IHonuaAuthenticationOptions
 {
     /// <summary>
     /// Base address of the Honua server.
@@ -36,6 +38,34 @@ public sealed class HonuaWfsClientOptions
     /// an empty string omits the authorization header.
     /// </summary>
     public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; set; }
+
+    /// <summary>
+    /// Optional request-aware access token provider. When configured, this value
+    /// takes precedence over <see cref="BearerTokenProvider"/> and <see cref="BearerToken"/>.
+    /// </summary>
+    public IHonuaAccessTokenProvider? AccessTokenProvider { get; set; }
+
+    /// <summary>
+    /// Default OAuth/OIDC scopes requested by the WFS client.
+    /// </summary>
+    public IReadOnlyList<string> AuthenticationScopes { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default OAuth/OIDC audience or resource requested by the WFS client.
+    /// </summary>
+    public string? AuthenticationAudience { get; set; }
+
+    /// <summary>
+    /// Optional sanitized authentication diagnostics callback. Raw credential
+    /// values are never supplied to this callback.
+    /// </summary>
+    public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
 
     /// <summary>
     /// Whether to enable automatic retry on transient HTTP failures (default: true).

--- a/tests/Honua.Sdk.Abstractions.Tests/AuthenticationTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/AuthenticationTests.cs
@@ -1,0 +1,240 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.Abstractions.Authentication;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class AuthenticationTests
+{
+    [Fact]
+    public async Task ClientCredentialsProvider_RequestsMergedScopesAndCachesToken()
+    {
+        var calls = 0;
+        var formBodies = new List<string>();
+        using var http = new HttpClient(new RecordingHandler(async (request, cancellationToken) =>
+        {
+            calls++;
+            formBodies.Add(await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+            return JsonResponse(
+                $$"""
+                {
+                  "access_token": "access-{{calls}}",
+                  "token_type": "Bearer",
+                  "expires_in": 3600,
+                  "scope": "sdk.read admin.write"
+                }
+                """);
+        }));
+        var provider = new HonuaOAuthClientCredentialsTokenProvider(
+            http,
+            new HonuaOAuthClientCredentialsTokenProviderOptions
+            {
+                TokenEndpoint = new Uri("http://localhost/oauth/token"),
+                ClientId = "client-1",
+                ClientSecret = "secret-1",
+                Scopes = ["sdk.read"],
+                Audience = "server-default",
+                RefreshSkew = TimeSpan.Zero
+            });
+
+        var request = new HonuaAuthenticationRequest
+        {
+            Transport = HonuaAuthenticationTransport.Http,
+            ServiceName = "admin",
+            Scopes = ["admin.write"],
+            Audience = "server-override"
+        };
+
+        var first = await provider.GetAccessTokenAsync(request);
+        var second = await provider.GetAccessTokenAsync(request);
+        var third = await provider.GetAccessTokenAsync(new HonuaAuthenticationRequest
+        {
+            Transport = request.Transport,
+            ServiceName = request.ServiceName,
+            Scopes = ["admin.write", "admin.delete"],
+            Audience = request.Audience
+        });
+
+        Assert.Same(first, second);
+        Assert.Equal(2, calls);
+        Assert.NotNull(first);
+        Assert.Equal("access-1", first!.Token);
+        Assert.Equal("access-2", third!.Token);
+        var form = ParseForm(formBodies[0]);
+        Assert.Equal("client_credentials", form["grant_type"]);
+        Assert.Equal("client-1", form["client_id"]);
+        Assert.Equal("secret-1", form["client_secret"]);
+        Assert.Equal("sdk.read admin.write", form["scope"]);
+        Assert.Equal("server-override", form["audience"]);
+        Assert.Equal("sdk.read admin.write admin.delete", ParseForm(formBodies[1])["scope"]);
+    }
+
+    [Fact]
+    public async Task AuthorizationCodeProvider_RefreshesWithReturnedRefreshToken()
+    {
+        var requests = new List<IReadOnlyDictionary<string, string>>();
+        using var http = new HttpClient(new RecordingHandler(async (request, cancellationToken) =>
+        {
+            requests.Add(ParseForm(await request.Content!.ReadAsStringAsync(cancellationToken).ConfigureAwait(false)));
+            return JsonResponse(requests.Count == 1
+                ? """
+                  {
+                    "access_token": "access-1",
+                    "refresh_token": "refresh-1",
+                    "expires_in": 0
+                  }
+                  """
+                : """
+                  {
+                    "access_token": "access-2",
+                    "expires_in": 3600
+                  }
+                  """);
+        }));
+        var provider = new HonuaOAuthAuthorizationCodeTokenProvider(
+            http,
+            new HonuaOAuthAuthorizationCodeTokenProviderOptions
+            {
+                TokenEndpoint = new Uri("http://localhost/oauth/token"),
+                ClientId = "client-1",
+                AuthorizationCode = "code-1",
+                RedirectUri = new Uri("https://app.example/callback"),
+                CodeVerifier = "verifier-1",
+                RefreshSkew = TimeSpan.Zero
+            });
+
+        var context = new HonuaAuthenticationRequest
+        {
+            Transport = HonuaAuthenticationTransport.Http,
+            ServiceName = "admin"
+        };
+        var first = await provider.GetAccessTokenAsync(context);
+        var second = await provider.GetAccessTokenAsync(context);
+
+        Assert.Equal("access-1", first!.Token);
+        Assert.Equal("access-2", second!.Token);
+        Assert.Collection(
+            requests,
+            initial =>
+            {
+                Assert.Equal("authorization_code", initial["grant_type"]);
+                Assert.Equal("code-1", initial["code"]);
+                Assert.Equal("https://app.example/callback", initial["redirect_uri"]);
+                Assert.Equal("verifier-1", initial["code_verifier"]);
+            },
+            refresh =>
+            {
+                Assert.Equal("refresh_token", refresh["grant_type"]);
+                Assert.Equal("refresh-1", refresh["refresh_token"]);
+            });
+    }
+
+    [Fact]
+    public async Task ApplyHttpCredentials_UsesAccessTokenProviderAndSanitizedDiagnostics()
+    {
+        HonuaAuthenticationRequest? providerRequest = null;
+        HonuaAuthenticationDiagnostic? diagnostic = null;
+        var options = new TestAuthenticationOptions
+        {
+            ApiKey = "api-secret",
+            AccessTokenProvider = new DelegateAccessTokenProvider(request =>
+            {
+                providerRequest = request;
+                return new HonuaAccessToken { Token = "bearer-secret" };
+            }),
+            AuthenticationScopes = ["admin.read"],
+            AuthenticationAudience = "honua-admin",
+            AuthenticationDiagnostics = (authDiagnostic, _) =>
+            {
+                diagnostic = authDiagnostic;
+                return ValueTask.CompletedTask;
+            }
+        };
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://honua.example/admin/services?token=raw-secret");
+
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            options,
+            "admin",
+            CancellationToken.None);
+
+        Assert.Equal("api-secret", request.Headers.GetValues("X-API-Key").Single());
+        Assert.Equal("Bearer bearer-secret", request.Headers.Authorization?.ToString());
+        Assert.NotNull(providerRequest);
+        Assert.Equal("admin", providerRequest!.ServiceName);
+        Assert.Equal(["admin.read"], providerRequest.Scopes);
+        Assert.Equal("honua-admin", providerRequest.Audience);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(HonuaAuthenticationSupport.CredentialAppliedEvent, diagnostic!.EventName);
+        Assert.Equal("https://honua.example/admin/services", diagnostic.RequestUri?.ToString());
+        Assert.Equal("present", diagnostic.Attributes["apiKey"]);
+        Assert.Equal("present", diagnostic.Attributes["authorization"]);
+        Assert.DoesNotContain("secret", string.Join(',', diagnostic.Attributes.Values), StringComparison.Ordinal);
+        Assert.Equal("[redacted]", HonuaAuthenticationSupport.RedactSecret("raw-secret"));
+    }
+
+    private static HttpResponseMessage JsonResponse(string json)
+        => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json)
+        };
+
+    private static IReadOnlyDictionary<string, string> ParseForm(string body)
+        => body
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+
+    private static string Decode(string value)
+        => Uri.UnescapeDataString(value.Replace("+", "%20", StringComparison.Ordinal));
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _responder;
+
+        public RecordingHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => _responder(request, cancellationToken);
+    }
+
+    private sealed class DelegateAccessTokenProvider : IHonuaAccessTokenProvider
+    {
+        private readonly Func<HonuaAuthenticationRequest, HonuaAccessToken?> _provider;
+
+        public DelegateAccessTokenProvider(Func<HonuaAuthenticationRequest, HonuaAccessToken?> provider)
+            => _provider = provider;
+
+        public ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+            HonuaAuthenticationRequest request,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_provider(request));
+    }
+
+    private sealed class TestAuthenticationOptions : IHonuaAuthenticationOptions
+    {
+        public string? ApiKey { get; init; }
+
+        public Func<CancellationToken, Task<string?>>? ApiKeyProvider { get; init; }
+
+        public string? BearerToken { get; init; }
+
+        public Func<CancellationToken, Task<string?>>? BearerTokenProvider { get; init; }
+
+        public IHonuaAccessTokenProvider? AccessTokenProvider { get; init; }
+
+        public IReadOnlyList<string> AuthenticationScopes { get; init; } = Array.Empty<string>();
+
+        public string? AuthenticationAudience { get; init; }
+
+        public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; init; }
+    }
+}

--- a/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Honua.Sdk.Admin.Extensions;
 using Honua.Sdk.Admin.Geocoding;
+using Honua.Sdk.Admin.Tests.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Sdk.Admin.Tests;
@@ -65,6 +66,30 @@ public sealed class ClientOptionsTests
         Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task AddHonuaAdmin_UsesPrimaryHttpMessageHandlerFactory()
+    {
+        var handled = false;
+        var services = new ServiceCollection();
+        services.AddHonuaAdmin(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.PrimaryHttpMessageHandlerFactory = () => new DelegateHandler(_ =>
+            {
+                handled = true;
+                return Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>()));
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHonuaAdminClient>();
+
+        await client.ListServicesAsync();
+
+        Assert.True(handled);
+    }
+
     private static HttpClient GetHttpClient(object client, string fieldName)
     {
         var field = client.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
@@ -72,5 +97,18 @@ public sealed class ClientOptionsTests
 
         var value = field!.GetValue(client);
         return Assert.IsType<HttpClient>(value);
+    }
+
+    private sealed class DelegateHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _responder;
+
+        public DelegateHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder)
+            => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => _responder(request);
     }
 }

--- a/tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj
+++ b/tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Honua.Sdk.Admin\Honua.Sdk.Admin.csproj" />
   </ItemGroup>
 

--- a/tests/Honua.Sdk.Admin.Tests/HonuaAdminClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaAdminClientTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text.Json;
+using Honua.Sdk.Abstractions.Authentication;
 using Honua.Sdk.Admin.Exceptions;
 using Honua.Sdk.Admin.Tests.Fixtures;
 using Microsoft.Extensions.Options;
@@ -216,6 +217,58 @@ public sealed class HonuaAdminClientTests
     }
 
     [Fact]
+    public async Task AuthHandler_UsesAccessTokenProviderContextAndDiagnostics()
+    {
+        HonuaAuthenticationRequest? providerRequest = null;
+        HonuaAuthenticationDiagnostic? diagnostic = null;
+        string? capturedAuth = null;
+        var options = Options.Create(new HonuaAdminClientOptions
+        {
+            AccessTokenProvider = new DelegateAccessTokenProvider(request =>
+            {
+                providerRequest = request;
+                return new HonuaAccessToken { Token = "admin-access" };
+            }),
+            AuthenticationScopes = ["admin.read"],
+            AuthenticationAudience = "honua-admin",
+            AuthenticationDiagnostics = (authDiagnostic, _) =>
+            {
+                diagnostic = authDiagnostic;
+                return ValueTask.CompletedTask;
+            }
+        });
+
+        var innerHandler = new MockHttpHandler(req =>
+        {
+            capturedAuth = req.Headers.Authorization?.ToString();
+            return Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>()));
+        });
+
+        var authHandler = new HonuaAdminAuthHandler(options)
+        {
+            InnerHandler = innerHandler
+        };
+
+        var httpClient = new HttpClient(authHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+
+        var client = new HonuaAdminClient(httpClient);
+        await client.ListServicesAsync();
+
+        Assert.Equal("Bearer admin-access", capturedAuth);
+        Assert.NotNull(providerRequest);
+        Assert.Equal("admin", providerRequest!.ServiceName);
+        Assert.Equal(HonuaAuthenticationTransport.Http, providerRequest.Transport);
+        Assert.Equal(["admin.read"], providerRequest.Scopes);
+        Assert.Equal("honua-admin", providerRequest.Audience);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(HonuaAuthenticationSupport.CredentialAppliedEvent, diagnostic!.EventName);
+        Assert.Equal("present", diagnostic.Attributes["authorization"]);
+    }
+
+    [Fact]
     public async Task AuthHandler_RejectsCredentialsOverRemoteHttp()
     {
         var options = Options.Create(new HonuaAdminClientOptions
@@ -387,5 +440,18 @@ public sealed class HonuaAdminClientTests
 
         Assert.Equal(HttpStatusCode.OK, ex.StatusCode);
         Assert.Equal("Operation failed.", ex.Message);
+    }
+
+    private sealed class DelegateAccessTokenProvider : IHonuaAccessTokenProvider
+    {
+        private readonly Func<HonuaAuthenticationRequest, HonuaAccessToken?> _provider;
+
+        public DelegateAccessTokenProvider(Func<HonuaAuthenticationRequest, HonuaAccessToken?> provider)
+            => _provider = provider;
+
+        public ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+            HonuaAuthenticationRequest request,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_provider(request));
     }
 }

--- a/tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj
+++ b/tests/Honua.Sdk.Grpc.Tests/Honua.Sdk.Grpc.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Honua.Sdk.Grpc\Honua.Sdk.Grpc.csproj" />
   </ItemGroup>
 

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using Grpc.Core;
 using Grpc.Net.Client;
+using Honua.Sdk.Abstractions.Authentication;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Grpc.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -749,6 +750,57 @@ public class HonuaGrpcClientTests
     }
 
     [Fact]
+    public async Task Metadata_UsesAccessTokenProviderContextAndDiagnostics()
+    {
+        var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
+        Metadata? capturedMetadata = null;
+        HonuaAuthenticationRequest? providerRequest = null;
+        HonuaAuthenticationDiagnostic? diagnostic = null;
+
+        var protoResponse = new Proto.QueryFeaturesResponse();
+        mockClient
+            .Setup(c => c.QueryFeaturesAsync(
+                It.IsAny<Proto.QueryFeaturesRequest>(),
+                It.IsAny<Metadata>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.QueryFeaturesRequest, Metadata, DateTime?, CancellationToken>(
+                (_, metadata, _, _) => capturedMetadata = metadata)
+            .Returns(CreateAsyncUnaryCall(protoResponse));
+
+        var client = new HonuaGrpcClient(mockClient.Object, new HonuaGrpcClientOptions
+        {
+            EnableCompressionNegotiation = false,
+            AccessTokenProvider = new DelegateAccessTokenProvider(request =>
+            {
+                providerRequest = request;
+                return new HonuaAccessToken { Token = "grpc-access" };
+            }),
+            AuthenticationScopes = ["features.read"],
+            AuthenticationAudience = "honua-grpc",
+            AuthenticationDiagnostics = (authDiagnostic, _) =>
+            {
+                diagnostic = authDiagnostic;
+                return ValueTask.CompletedTask;
+            }
+        });
+
+        await client.QueryFeaturesAsync(new Models.QueryFeaturesRequest { ServiceId = "svc" });
+
+        Assert.NotNull(capturedMetadata);
+        Assert.Equal("Bearer grpc-access", GetMetadataValue(capturedMetadata!, "authorization"));
+        Assert.NotNull(providerRequest);
+        Assert.Equal(HonuaAuthenticationTransport.Grpc, providerRequest!.Transport);
+        Assert.Equal("grpc", providerRequest.ServiceName);
+        Assert.Equal("QueryFeatures", providerRequest.Method);
+        Assert.Equal(["features.read"], providerRequest.Scopes);
+        Assert.Equal("honua-grpc", providerRequest.Audience);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(HonuaAuthenticationSupport.CredentialAppliedEvent, diagnostic!.EventName);
+        Assert.Equal("present", diagnostic.Attributes["authorization"]);
+    }
+
+    [Fact]
     public async Task Metadata_ProviderReturningNullOrEmpty_OmitsCredentials()
     {
         var mockClient = new Mock<Proto.FeatureService.FeatureServiceClient>();
@@ -921,5 +973,18 @@ public class HonuaGrpcClientTests
 
         public Task<bool> MoveNext(CancellationToken cancellationToken)
             => Task.FromException<bool>(exception);
+    }
+
+    private sealed class DelegateAccessTokenProvider : IHonuaAccessTokenProvider
+    {
+        private readonly Func<HonuaAuthenticationRequest, HonuaAccessToken?> _provider;
+
+        public DelegateAccessTokenProvider(Func<HonuaAuthenticationRequest, HonuaAccessToken?> provider)
+            => _provider = provider;
+
+        public ValueTask<HonuaAccessToken?> GetAccessTokenAsync(
+            HonuaAuthenticationRequest request,
+            CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(_provider(request));
     }
 }


### PR DESCRIPTION
Closes #57.

## Summary
- add shared authentication request/access-token abstractions plus OAuth client-credentials and authorization-code token providers
- wire request-aware access token providers, scopes/audience, sanitized diagnostics, and primary handler hooks across REST and gRPC clients
- document production OAuth/OIDC, diagnostics, and mTLS configuration paths

## Validation
- dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- scripts/validate-api-compat.sh origin/trunk
- git diff --check