### PR TITLE
feat: expand geocoding parity

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -213,7 +213,13 @@ Then add:
 
         var candidates = await geocodingClient.ForwardGeocodeAsync(
             "1600 Pennsylvania Ave NW, Washington, DC",
-            new ForwardGeocodeOptions { MaxResults = 3 },
+            new ForwardGeocodeOptions
+            {
+                MaxResults = 3,
+                Categories = ["Address"],
+                OutFields = ["Addr_type", "City", "Region"],
+                Location = new GeocodePoint(-77.0365, 38.8977)
+            },
             ct);
 
         foreach (var result in candidates)
@@ -223,6 +229,10 @@ Then add:
                               $"score={result.Score}");
         }
 ```
+
+For batch geocoding with partial-failure details, inject
+`IHonuaBatchGeocodingClient` or cast the default client and call
+`BatchGeocodeDetailedAsync`.
 
 Run again and you should see all three sections:
 

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
         httpBuilder.AddTypedClient<IHonuaGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
+        httpBuilder.AddTypedClient<IHonuaBatchGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
         ConfigurePrimaryHandler(httpBuilder, configure);
         ConfigureResilience(httpBuilder, configure);
         return services;

--- a/src/Honua.Sdk.Admin/Geocoding/GeocodingJsonContext.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/GeocodingJsonContext.cs
@@ -14,6 +14,10 @@ namespace Honua.Sdk.Admin.Geocoding;
 [JsonSerializable(typeof(GeoServicesFindAddressCandidatesResponse))]
 [JsonSerializable(typeof(GeoServicesReverseGeocodeResponse))]
 [JsonSerializable(typeof(GeoServicesSuggestResponse))]
+[JsonSerializable(typeof(GeoServicesRequestPoint))]
+[JsonSerializable(typeof(GeoServicesRequestExtent))]
+[JsonSerializable(typeof(GeoServicesBatchGeocodeRequest))]
+[JsonSerializable(typeof(GeoServicesBatchGeocodeResponse))]
 internal sealed partial class GeocodingJsonContext : JsonSerializerContext
 {
 }

--- a/src/Honua.Sdk.Admin/Geocoding/GeocodingModels.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/GeocodingModels.cs
@@ -46,6 +46,49 @@ public sealed record GeocodeSuggestion(
     string MagicKey,
     bool IsCollection);
 
+/// <summary>
+/// A point used to bias geocode and suggestion results.
+/// </summary>
+/// <param name="X">X coordinate, typically longitude for WGS84 inputs.</param>
+/// <param name="Y">Y coordinate, typically latitude for WGS84 inputs.</param>
+/// <param name="SpatialReferenceWkid">Optional spatial reference WKID for non-WGS84 coordinates.</param>
+public sealed record GeocodePoint(
+    double X,
+    double Y,
+    int? SpatialReferenceWkid = null);
+
+/// <summary>
+/// A rectangular search extent used to constrain geocode and suggestion results.
+/// </summary>
+/// <param name="XMin">Minimum X coordinate.</param>
+/// <param name="YMin">Minimum Y coordinate.</param>
+/// <param name="XMax">Maximum X coordinate.</param>
+/// <param name="YMax">Maximum Y coordinate.</param>
+/// <param name="SpatialReferenceWkid">Optional spatial reference WKID for non-WGS84 coordinates.</param>
+public sealed record GeocodeExtent(
+    double XMin,
+    double YMin,
+    double XMax,
+    double YMax,
+    int? SpatialReferenceWkid = null);
+
+/// <summary>
+/// Per-input batch geocode result with partial-failure metadata.
+/// </summary>
+/// <param name="InputId">One-based input record identifier sent to the service.</param>
+/// <param name="InputAddress">Original input address.</param>
+/// <param name="Status">Provider status code when returned, such as M for matched or U for unmatched.</param>
+/// <param name="Result">Geocode result for matched inputs, or null for partial failures.</param>
+/// <param name="ErrorMessage">Failure message for unmatched or missing inputs.</param>
+/// <param name="Attributes">Provider attributes returned for the batch row.</param>
+public sealed record BatchGeocodeResult(
+    int InputId,
+    string InputAddress,
+    string? Status,
+    GeocodeResult? Result,
+    string? ErrorMessage,
+    IReadOnlyDictionary<string, string?> Attributes);
+
 // ── Options records ──────────────────────────────────────────────────────
 
 /// <summary>
@@ -72,6 +115,26 @@ public sealed record ForwardGeocodeOptions
     /// An opaque key from a prior suggest call to accelerate the lookup.
     /// </summary>
     public string? MagicKey { get; init; }
+
+    /// <summary>
+    /// Optional point that biases candidates toward a local search origin.
+    /// </summary>
+    public GeocodePoint? Location { get; init; }
+
+    /// <summary>
+    /// Optional extent that constrains candidates to a local area.
+    /// </summary>
+    public GeocodeExtent? SearchExtent { get; init; }
+
+    /// <summary>
+    /// Optional categories, such as Address, POI, Postal, or custom locator categories.
+    /// </summary>
+    public IReadOnlyList<string>? Categories { get; init; }
+
+    /// <summary>
+    /// Optional provider attribute fields to include in candidate results.
+    /// </summary>
+    public IReadOnlyList<string>? OutFields { get; init; }
 }
 
 /// <summary>
@@ -99,6 +162,21 @@ public sealed record SuggestOptions
     /// Restrict suggestions to specific country codes (ISO 3166-1 alpha-3).
     /// </summary>
     public IReadOnlyList<string>? CountryCodes { get; init; }
+
+    /// <summary>
+    /// Optional point that biases suggestions toward a local search origin.
+    /// </summary>
+    public GeocodePoint? Location { get; init; }
+
+    /// <summary>
+    /// Optional extent that constrains suggestions to a local area.
+    /// </summary>
+    public GeocodeExtent? SearchExtent { get; init; }
+
+    /// <summary>
+    /// Optional categories, such as Address, POI, Postal, or custom locator categories.
+    /// </summary>
+    public IReadOnlyList<string>? Categories { get; init; }
 }
 
 /// <summary>
@@ -115,6 +193,21 @@ public sealed record BatchGeocodeOptions
     /// Restrict results to specific country codes (ISO 3166-1 alpha-3).
     /// </summary>
     public IReadOnlyList<string>? CountryCodes { get; init; }
+
+    /// <summary>
+    /// Optional extent that constrains batch candidates to a local area.
+    /// </summary>
+    public GeocodeExtent? SearchExtent { get; init; }
+
+    /// <summary>
+    /// Optional categories, such as Address, POI, Postal, or custom locator categories.
+    /// </summary>
+    public IReadOnlyList<string>? Categories { get; init; }
+
+    /// <summary>
+    /// Optional provider attribute fields to include in batch results.
+    /// </summary>
+    public IReadOnlyList<string>? OutFields { get; init; }
 }
 
 // ── Raw GeoServices wire models (internal) ───────────────────────────────
@@ -174,6 +267,75 @@ internal sealed class GeoServicesFindAddressCandidatesResponse
 
     [JsonPropertyName("candidates")]
     public List<GeoServicesCandidate>? Candidates { get; set; }
+}
+
+internal sealed class GeoServicesRequestSpatialReference
+{
+    [JsonPropertyName("wkid")]
+    public int Wkid { get; set; }
+}
+
+internal sealed class GeoServicesRequestPoint
+{
+    [JsonPropertyName("x")]
+    public double X { get; set; }
+
+    [JsonPropertyName("y")]
+    public double Y { get; set; }
+
+    [JsonPropertyName("spatialReference")]
+    public GeoServicesRequestSpatialReference? SpatialReference { get; set; }
+}
+
+internal sealed class GeoServicesRequestExtent
+{
+    [JsonPropertyName("xmin")]
+    public double XMin { get; set; }
+
+    [JsonPropertyName("ymin")]
+    public double YMin { get; set; }
+
+    [JsonPropertyName("xmax")]
+    public double XMax { get; set; }
+
+    [JsonPropertyName("ymax")]
+    public double YMax { get; set; }
+
+    [JsonPropertyName("spatialReference")]
+    public GeoServicesRequestSpatialReference? SpatialReference { get; set; }
+}
+
+internal sealed class GeoServicesBatchGeocodeRequest
+{
+    [JsonPropertyName("records")]
+    public List<GeoServicesBatchAddressRecord> Records { get; set; } = [];
+}
+
+internal sealed class GeoServicesBatchAddressRecord
+{
+    [JsonPropertyName("attributes")]
+    public Dictionary<string, object?> Attributes { get; set; } = new(StringComparer.Ordinal);
+}
+
+internal sealed class GeoServicesBatchGeocodeResponse
+{
+    [JsonPropertyName("locations")]
+    public List<GeoServicesBatchLocation>? Locations { get; set; }
+}
+
+internal sealed class GeoServicesBatchLocation
+{
+    [JsonPropertyName("address")]
+    public string Address { get; set; } = string.Empty;
+
+    [JsonPropertyName("location")]
+    public GeoServicesLocation? Location { get; set; }
+
+    [JsonPropertyName("score")]
+    public double Score { get; set; }
+
+    [JsonPropertyName("attributes")]
+    public Dictionary<string, object?>? Attributes { get; set; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Globalization;
+using System.Collections.ObjectModel;
 using System.Text.Json;
 using Honua.Sdk.Admin.Exceptions;
 
@@ -10,7 +11,7 @@ namespace Honua.Sdk.Admin.Geocoding;
 /// <summary>
 /// HTTP client implementation for the Honua Geocoding REST API (GeoServices-compatible).
 /// </summary>
-public sealed class HonuaGeocodingClient : IHonuaGeocodingClient
+public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
 {
     private const string DefaultLocatorName = "World";
     private const int DefaultSpatialReferenceWkid = 4326;
@@ -70,6 +71,13 @@ public sealed class HonuaGeocodingClient : IHonuaGeocodingClient
         {
             queryParams.Add(("countryCode", string.Join(",", options.CountryCodes)));
         }
+
+        AddCommonSearchParameters(
+            queryParams,
+            options?.Location,
+            options?.SearchExtent,
+            options?.Categories,
+            options?.OutFields);
 
         var url = $"{ServicePath}/findAddressCandidates{BuildQuery(queryParams)}";
 
@@ -173,6 +181,13 @@ public sealed class HonuaGeocodingClient : IHonuaGeocodingClient
             queryParams.Add(("countryCode", string.Join(",", options.CountryCodes)));
         }
 
+        AddCommonSearchParameters(
+            queryParams,
+            options?.Location,
+            options?.SearchExtent,
+            options?.Categories,
+            outFields: null);
+
         var url = $"{ServicePath}/suggest{BuildQuery(queryParams)}";
 
         using var response = await _http.GetAsync(CreateRequestUri(url), ct).ConfigureAwait(false);
@@ -193,14 +208,76 @@ public sealed class HonuaGeocodingClient : IHonuaGeocodingClient
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<GeocodeResult>> BatchGeocodeAsync(
+    public async Task<IReadOnlyList<GeocodeResult>> BatchGeocodeAsync(
         IReadOnlyList<string> addresses,
         BatchGeocodeOptions? options = null,
         CancellationToken ct = default)
     {
-        throw new NotSupportedException(
-            "Batch geocoding (geocodeAddresses) is not yet implemented server-side. " +
-            "Use ForwardGeocodeAsync for individual address geocoding.");
+        var detailedResults = await BatchGeocodeDetailedAsync(addresses, options, ct).ConfigureAwait(false);
+        return detailedResults
+            .Where(result => result.Result is not null)
+            .Select(result => result.Result!)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<BatchGeocodeResult>> BatchGeocodeDetailedAsync(
+        IReadOnlyList<string> addresses,
+        BatchGeocodeOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(addresses);
+        if (addresses.Count == 0)
+        {
+            return [];
+        }
+
+        var payload = CreateBatchRequest(addresses);
+        var queryParams = new List<KeyValuePair<string, string>>
+        {
+            new(
+                "addresses",
+                JsonSerializer.Serialize(payload, GeocodingJsonContext.Default.GeoServicesBatchGeocodeRequest)),
+            new("f", "json"),
+        };
+
+        var wkid = options?.SpatialReferenceWkid ?? DefaultSpatialReferenceWkid;
+        queryParams.Add(new KeyValuePair<string, string>("outSR", wkid.ToString(CultureInfo.InvariantCulture)));
+
+        if (options?.CountryCodes is { Count: > 0 })
+        {
+            queryParams.Add(new KeyValuePair<string, string>("sourceCountry", string.Join(",", options.CountryCodes)));
+        }
+
+        if (options?.SearchExtent is { } searchExtent)
+        {
+            queryParams.Add(new KeyValuePair<string, string>("searchExtent", FormatExtent(searchExtent)));
+        }
+
+        if (JoinCsv(options?.Categories) is { } category)
+        {
+            queryParams.Add(new KeyValuePair<string, string>("category", category));
+        }
+
+        if (JoinCsv(options?.OutFields) is { } outFields)
+        {
+            queryParams.Add(new KeyValuePair<string, string>("outFields", outFields));
+        }
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            CreateRequestUri($"{ServicePath}/geocodeAddresses"))
+        {
+            Content = new FormUrlEncodedContent(queryParams)
+        };
+
+        using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+
+        var result = JsonSerializer.Deserialize(body, GeocodingJsonContext.Default.GeoServicesBatchGeocodeResponse);
+        return MapBatchResults(addresses, result);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
@@ -303,6 +380,193 @@ public sealed class HonuaGeocodingClient : IHonuaGeocodingClient
 
         return result;
     }
+
+    private static void AddCommonSearchParameters(
+        List<(string Key, string? Value)> queryParams,
+        GeocodePoint? location,
+        GeocodeExtent? searchExtent,
+        IReadOnlyList<string>? categories,
+        IReadOnlyList<string>? outFields)
+    {
+        if (location is not null)
+        {
+            queryParams.Add(("location", FormatPoint(location)));
+        }
+
+        if (searchExtent is not null)
+        {
+            queryParams.Add(("searchExtent", FormatExtent(searchExtent)));
+        }
+
+        if (JoinCsv(categories) is { } category)
+        {
+            queryParams.Add(("category", category));
+        }
+
+        if (JoinCsv(outFields) is { } fields)
+        {
+            queryParams.Add(("outFields", fields));
+        }
+    }
+
+    private static string? JoinCsv(IReadOnlyList<string>? values)
+    {
+        if (values is null || values.Count == 0)
+        {
+            return null;
+        }
+
+        var normalized = values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .ToArray();
+        return normalized.Length == 0 ? null : string.Join(",", normalized);
+    }
+
+    private static string FormatPoint(GeocodePoint point)
+    {
+        if (!point.SpatialReferenceWkid.HasValue)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0},{1}", point.X, point.Y);
+        }
+
+        var requestPoint = new GeoServicesRequestPoint
+        {
+            X = point.X,
+            Y = point.Y,
+            SpatialReference = new GeoServicesRequestSpatialReference { Wkid = point.SpatialReferenceWkid.Value }
+        };
+        return JsonSerializer.Serialize(requestPoint, GeocodingJsonContext.Default.GeoServicesRequestPoint);
+    }
+
+    private static string FormatExtent(GeocodeExtent extent)
+    {
+        if (!extent.SpatialReferenceWkid.HasValue)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0},{1},{2},{3}",
+                extent.XMin,
+                extent.YMin,
+                extent.XMax,
+                extent.YMax);
+        }
+
+        var requestExtent = new GeoServicesRequestExtent
+        {
+            XMin = extent.XMin,
+            YMin = extent.YMin,
+            XMax = extent.XMax,
+            YMax = extent.YMax,
+            SpatialReference = new GeoServicesRequestSpatialReference { Wkid = extent.SpatialReferenceWkid.Value }
+        };
+        return JsonSerializer.Serialize(requestExtent, GeocodingJsonContext.Default.GeoServicesRequestExtent);
+    }
+
+    private static GeoServicesBatchGeocodeRequest CreateBatchRequest(IReadOnlyList<string> addresses)
+    {
+        var request = new GeoServicesBatchGeocodeRequest();
+        for (var index = 0; index < addresses.Count; index++)
+        {
+            var address = addresses[index];
+            if (address is null)
+            {
+                throw new ArgumentException("Batch geocode addresses cannot contain null values.", nameof(addresses));
+            }
+
+            request.Records.Add(new GeoServicesBatchAddressRecord
+            {
+                Attributes = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["OBJECTID"] = index + 1,
+                    ["SingleLine"] = address
+                }
+            });
+        }
+
+        return request;
+    }
+
+    private static ReadOnlyCollection<BatchGeocodeResult> MapBatchResults(
+        IReadOnlyList<string> addresses,
+        GeoServicesBatchGeocodeResponse? response)
+    {
+        var byInputId = new Dictionary<int, BatchGeocodeResult>();
+        if (response?.Locations is not null)
+        {
+            foreach (var location in response.Locations)
+            {
+                var attributes = FlattenAttributes(location.Attributes);
+                var inputId = ReadInputId(attributes) ?? byInputId.Count + 1;
+                var status = attributes.TryGetValue("Status", out var statusValue) ? statusValue : null;
+                var inputAddress = inputId > 0 && inputId <= addresses.Count ? addresses[inputId - 1] : string.Empty;
+                var result = CreateGeocodeResult(location, attributes, status);
+                byInputId[inputId] = new BatchGeocodeResult(
+                    inputId,
+                    inputAddress,
+                    status,
+                    result,
+                    result is null ? CreateBatchFailureMessage(status) : null,
+                    attributes);
+            }
+        }
+
+        var results = new List<BatchGeocodeResult>(addresses.Count);
+        for (var index = 0; index < addresses.Count; index++)
+        {
+            var inputId = index + 1;
+            if (byInputId.TryGetValue(inputId, out var batchResult))
+            {
+                results.Add(batchResult);
+                continue;
+            }
+
+            results.Add(new BatchGeocodeResult(
+                inputId,
+                addresses[index],
+                Status: null,
+                Result: null,
+                ErrorMessage: "No candidate returned for this input address.",
+                Attributes: new Dictionary<string, string?>()));
+        }
+
+        return results.AsReadOnly();
+    }
+
+    private static GeocodeResult? CreateGeocodeResult(
+        GeoServicesBatchLocation location,
+        Dictionary<string, string?> attributes,
+        string? status)
+    {
+        if (location.Location is null ||
+            string.Equals(status, "U", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return new GeocodeResult(
+            Address: location.Address,
+            Latitude: location.Location.Y,
+            Longitude: location.Location.X,
+            Score: location.Score,
+            Attributes: attributes);
+    }
+
+    private static int? ReadInputId(Dictionary<string, string?> attributes)
+    {
+        if (attributes.TryGetValue("ResultID", out var resultId) &&
+            int.TryParse(resultId, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return null;
+    }
+
+    private static string CreateBatchFailureMessage(string? status)
+        => string.IsNullOrWhiteSpace(status)
+            ? "No candidate returned for this input address."
+            : $"Geocoding service returned status '{status}' for this input address.";
 
     private static string BuildQuery(params ReadOnlySpan<(string Key, string? Value)> parameters)
     {

--- a/src/Honua.Sdk.Admin/Geocoding/IHonuaGeocodingClient.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/IHonuaGeocodingClient.cs
@@ -52,9 +52,26 @@ public interface IHonuaGeocodingClient
     /// <param name="addresses">The list of addresses to geocode.</param>
     /// <param name="options">Optional parameters to control the batch geocoding request.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>A list of geocode results, one per input address.</returns>
-    /// <exception cref="NotSupportedException">Thrown because batch geocoding is not yet implemented server-side.</exception>
+    /// <returns>A list of matched geocode results.</returns>
     Task<IReadOnlyList<GeocodeResult>> BatchGeocodeAsync(
+        IReadOnlyList<string> addresses,
+        BatchGeocodeOptions? options = null,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Extended batch geocoding client that preserves per-input partial-failure details.
+/// </summary>
+public interface IHonuaBatchGeocodingClient : IHonuaGeocodingClient
+{
+    /// <summary>
+    /// Geocodes multiple addresses and returns one result envelope for each input address.
+    /// </summary>
+    /// <param name="addresses">The list of addresses to geocode.</param>
+    /// <param name="options">Optional parameters to control the batch geocoding request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Batch geocode results keyed to the original input order.</returns>
+    Task<IReadOnlyList<BatchGeocodeResult>> BatchGeocodeDetailedAsync(
         IReadOnlyList<string> addresses,
         BatchGeocodeOptions? options = null,
         CancellationToken ct = default);

--- a/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
@@ -56,6 +56,22 @@ public sealed class ClientOptionsTests
     }
 
     [Fact]
+    public void AddHonuaGeocoding_RegistersDetailedBatchClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaGeocoding(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHonuaBatchGeocodingClient>();
+
+        Assert.IsType<HonuaGeocodingClient>(client);
+    }
+
+    [Fact]
     public void AddHonuaAdmin_InvalidTimeout_Throws()
     {
         var services = new ServiceCollection();

--- a/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
@@ -157,6 +157,10 @@ public sealed class HonuaGeocodingClientTests
             Assert.Contains("outSR=3857", req.RequestUri.Query);
             Assert.Contains("magicKey=abc123", req.RequestUri.Query);
             Assert.Contains("countryCode=USA%2CCAN", req.RequestUri.Query);
+            Assert.Contains("location=-89.65%2C39.78", req.RequestUri.Query);
+            Assert.Contains("searchExtent=-90%2C39%2C-89%2C40", req.RequestUri.Query);
+            Assert.Contains("category=Address%2CPOI", req.RequestUri.Query);
+            Assert.Contains("outFields=Addr_type%2CCity", req.RequestUri.Query);
             return Task.FromResult(CreateGeoJsonResponse(responseJson));
         });
 
@@ -165,7 +169,11 @@ public sealed class HonuaGeocodingClientTests
             MaxResults = 10,
             SpatialReferenceWkid = 3857,
             MagicKey = "abc123",
-            CountryCodes = new[] { "USA", "CAN" }
+            CountryCodes = new[] { "USA", "CAN" },
+            Location = new GeocodePoint(-89.65, 39.78),
+            SearchExtent = new GeocodeExtent(-90, 39, -89, 40),
+            Categories = new[] { "Address", "POI" },
+            OutFields = new[] { "Addr_type", "City" }
         };
 
         await client.ForwardGeocodeAsync("test", options);
@@ -397,13 +405,19 @@ public sealed class HonuaGeocodingClientTests
         {
             Assert.Contains("maxSuggestions=3", req.RequestUri!.Query);
             Assert.Contains("countryCode=USA", req.RequestUri.Query);
+            Assert.Contains("location=-89.65%2C39.78", req.RequestUri.Query);
+            Assert.Contains("searchExtent=-90%2C39%2C-89%2C40", req.RequestUri.Query);
+            Assert.Contains("category=Address", req.RequestUri.Query);
             return Task.FromResult(CreateGeoJsonResponse(responseJson));
         });
 
         await client.SuggestAsync("test", new SuggestOptions
         {
             MaxResults = 3,
-            CountryCodes = new[] { "USA" }
+            CountryCodes = new[] { "USA" },
+            Location = new GeocodePoint(-89.65, 39.78),
+            SearchExtent = new GeocodeExtent(-90, 39, -89, 40),
+            Categories = new[] { "Address" }
         });
     }
 
@@ -524,6 +538,26 @@ public sealed class HonuaGeocodingClientTests
     }
 
     [Fact]
+    public async Task ForwardGeocode_Http429_ThrowsRateLimitException()
+    {
+        var client = CreateGeocodingClient(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+            {
+                ReasonPhrase = "Too Many Requests",
+                Content = new StringContent(
+                    """{"error":{"code":429,"message":"Rate limit exceeded"}}""",
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            }));
+
+        var ex = await Assert.ThrowsAsync<HonuaAdminApiException>(
+            () => client.ForwardGeocodeAsync("test"));
+
+        Assert.Equal(HttpStatusCode.TooManyRequests, ex.StatusCode);
+        Assert.Equal("Rate limit exceeded", ex.Message);
+    }
+
+    [Fact]
     public async Task ReverseGeocode_Http500_ThrowsHonuaAdminApiException()
     {
         var client = CreateGeocodingClient(_ =>
@@ -580,12 +614,125 @@ public sealed class HonuaGeocodingClientTests
     // ── BatchGeocodeAsync ───────────────────────────────────────────────
 
     [Fact]
-    public async Task BatchGeocode_ThrowsNotSupportedException()
+    public async Task BatchGeocode_Detailed_ReturnsPartialFailures()
     {
-        var client = CreateGeocodingClient(_ =>
-            Task.FromResult(CreateGeoJsonResponse("{}")));
+        var responseJson = """
+        {
+            "locations": [
+                {
+                    "address": "123 Main St, Springfield, IL",
+                    "location": { "x": -89.6501, "y": 39.7817 },
+                    "score": 98.1,
+                    "attributes": { "ResultID": 1, "Status": "M", "City": "Springfield" }
+                },
+                {
+                    "address": "",
+                    "location": null,
+                    "score": 0,
+                    "attributes": { "ResultID": 2, "Status": "U" }
+                }
+            ]
+        }
+        """;
 
-        await Assert.ThrowsAsync<NotSupportedException>(
-            () => client.BatchGeocodeAsync(new[] { "addr1", "addr2" }));
+        var client = CreateGeocodingClient(async req =>
+        {
+            Assert.Equal(HttpMethod.Post, req.Method);
+            Assert.Contains("/rest/services/World/GeocodeServer/geocodeAddresses", req.RequestUri!.PathAndQuery);
+            var form = ParseForm(await req.Content!.ReadAsStringAsync());
+            Assert.Contains("\"SingleLine\":\"123 Main St\"", form["addresses"]);
+            Assert.Contains("\"SingleLine\":\"missing place\"", form["addresses"]);
+            Assert.Equal("json", form["f"]);
+            Assert.Equal("3857", form["outSR"]);
+            Assert.Equal("USA,CAN", form["sourceCountry"]);
+            Assert.Equal("-90,39,-89,40", form["searchExtent"]);
+            Assert.Equal("Address,POI", form["category"]);
+            Assert.Equal("City,Region", form["outFields"]);
+            return CreateGeoJsonResponse(responseJson);
+        });
+
+        var results = await ((IHonuaBatchGeocodingClient)client).BatchGeocodeDetailedAsync(
+            new[] { "123 Main St", "missing place" },
+            new BatchGeocodeOptions
+            {
+                SpatialReferenceWkid = 3857,
+                CountryCodes = new[] { "USA", "CAN" },
+                SearchExtent = new GeocodeExtent(-90, 39, -89, 40),
+                Categories = new[] { "Address", "POI" },
+                OutFields = new[] { "City", "Region" }
+            });
+
+        Assert.Collection(
+            results,
+            matched =>
+            {
+                Assert.Equal(1, matched.InputId);
+                Assert.Equal("123 Main St", matched.InputAddress);
+                Assert.Equal("M", matched.Status);
+                Assert.NotNull(matched.Result);
+                Assert.Equal("123 Main St, Springfield, IL", matched.Result!.Address);
+                Assert.Equal("Springfield", matched.Attributes["City"]);
+                Assert.Null(matched.ErrorMessage);
+            },
+            unmatched =>
+            {
+                Assert.Equal(2, unmatched.InputId);
+                Assert.Equal("missing place", unmatched.InputAddress);
+                Assert.Equal("U", unmatched.Status);
+                Assert.Null(unmatched.Result);
+                Assert.Contains("status 'U'", unmatched.ErrorMessage);
+            });
     }
+
+    [Fact]
+    public async Task BatchGeocode_ReturnsMatchedResults()
+    {
+        var responseJson = """
+        {
+            "locations": [
+                {
+                    "address": "123 Main St, Springfield, IL",
+                    "location": { "x": -89.6501, "y": 39.7817 },
+                    "score": 98.1,
+                    "attributes": { "ResultID": 1, "Status": "M" }
+                },
+                {
+                    "address": "",
+                    "location": null,
+                    "score": 0,
+                    "attributes": { "ResultID": 2, "Status": "U" }
+                }
+            ]
+        }
+        """;
+
+        var client = CreateGeocodingClient(_ => Task.FromResult(CreateGeoJsonResponse(responseJson)));
+
+        var results = await client.BatchGeocodeAsync(new[] { "123 Main St", "missing place" });
+
+        var result = Assert.Single(results);
+        Assert.Equal("123 Main St, Springfield, IL", result.Address);
+    }
+
+    [Fact]
+    public async Task BatchGeocode_EmptyInputs_ReturnsEmptyList()
+    {
+        var client = CreateGeocodingClient(_ => Task.FromResult(CreateGeoJsonResponse("{}")));
+
+        var results = await client.BatchGeocodeAsync(Array.Empty<string>());
+
+        Assert.Empty(results);
+    }
+
+    private static IReadOnlyDictionary<string, string> ParseForm(string body)
+        => body
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+
+    private static string Decode(string value)
+        => Uri.UnescapeDataString(value.Replace("+", "%20", StringComparison.Ordinal));
 }


### PR DESCRIPTION
## Summary
- add local bias, search extent, category filters, and outFields to geocode and suggest requests
- implement GeoServices batch geocoding with detailed per-input partial failure results
- register the detailed batch geocoding client and update quickstart coverage

Closes #59

## Validation
- dotnet build src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj --configuration Release --no-restore
- dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- scripts/validate-api-compat.sh origin/trunk
- git diff --check