### PR TITLE
feat: add catalog discovery client

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -89,7 +89,7 @@ Current typed endpoint coverage is:
 
 | Package | Covered surfaces |
 |---------|------------------|
-| `Honua.Sdk.Admin` | Service listing/settings/protocols, MapServer/access/time/layer metadata settings, metadata resources and manifests, version/capabilities/compatibility/config, secure connections/encryption, layer publishing/table discovery/styles, observability, migrations, deploy preflight/plans/operations, and geocoding. |
+| `Honua.Sdk.Admin` | Service listing/settings/protocols, catalog discovery, MapServer/access/time/layer metadata settings, metadata resources and manifests, version/capabilities/compatibility/config, secure connections/encryption, layer publishing/table discovery/styles, observability, migrations, deploy preflight/plans/operations, and geocoding. |
 | `Honua.Sdk.Spec` | Spec validation, plan compilation, apply SSE event streaming, and apply cancellation over `/v1/spec/*`. |
 | `Honua.Sdk.Grpc` | Feature query, streaming feature query, and feature edits. |
 | `Honua.Sdk.Wfs` | `GetCapabilities`, `DescribeFeatureType`, `GetFeature`, feature count via hits, custom output handlers, and auto-pagination. |
@@ -117,6 +117,14 @@ returns enriched `SourceDescriptor` metadata when the backing client supports
 OGC API Features combines collection metadata with queryables, WFS combines
 capabilities with DescribeFeatureType, and gRPC derives schema from query
 metadata plus an extent-only query until the proto adds a dedicated schema RPC.
+
+Portal/catalog discovery is available through `IHonuaCatalogClient` in
+`Honua.Sdk.Admin.Catalog`. It aggregates existing Honua Server admin service
+summaries, FeatureServer service/layer metadata, and metadata resources into
+searchable service, layer, group, and saved source descriptor items. Groups and
+saved source descriptors are metadata-resource backed until the server exposes
+first-class typed catalog endpoints tracked by
+`honua-server#869`; display documents remain out of SDK scope.
 
 Shared query support is intentionally provider-aware. GeoServices FeatureServer
 maps provider-neutral time filters, statistics, group-by, and having clauses to

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -191,6 +191,22 @@ Then add the following after the feature query:
         Console.WriteLine($"\nService '{settings.ServiceName}' details retrieved.");
 ```
 
+For richer non-display catalog discovery, inject `IHonuaCatalogClient` from
+`Honua.Sdk.Admin.Catalog`. `AddHonuaAdmin` registers it automatically, and
+`AddHonuaCatalog` is available when an app only needs discovery:
+
+```csharp
+var catalog = await catalogClient.SearchAsync(
+    new CatalogQueryOptions
+    {
+        Kinds = [CatalogItemKind.Layer],
+        ServiceTypes = ["FeatureServer"],
+        Tags = ["public"],
+        Limit = 10
+    },
+    ct);
+```
+
 ## Step 5: Add geocoding (60 seconds)
 
 Inject `IHonuaGeocodingClient` the same way and add a forward-geocode call:

--- a/src/Honua.Sdk.Admin/Catalog/CatalogModels.cs
+++ b/src/Honua.Sdk.Admin/Catalog/CatalogModels.cs
@@ -1,0 +1,347 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Admin.Models;
+
+namespace Honua.Sdk.Admin.Catalog;
+
+/// <summary>
+/// Catalog item categories returned by the portal and catalog discovery client.
+/// </summary>
+public enum CatalogItemKind
+{
+    /// <summary>A published service.</summary>
+    Service = 0,
+
+    /// <summary>A layer within a published service.</summary>
+    Layer = 1,
+
+    /// <summary>A metadata-backed catalog group.</summary>
+    Group = 2,
+
+    /// <summary>A saved SDK source descriptor.</summary>
+    SourceDescriptor = 3
+}
+
+/// <summary>
+/// Catalog sort fields supported by the SDK client.
+/// </summary>
+public enum CatalogSortBy
+{
+    /// <summary>Sort by display name.</summary>
+    Name = 0,
+
+    /// <summary>Sort by catalog item kind.</summary>
+    Kind = 1,
+
+    /// <summary>Sort by owning service name.</summary>
+    ServiceName = 2,
+
+    /// <summary>Sort by metadata creation timestamp when available.</summary>
+    CreatedAt = 3,
+
+    /// <summary>Sort by metadata update timestamp when available.</summary>
+    UpdatedAt = 4
+}
+
+/// <summary>
+/// Catalog sort direction.
+/// </summary>
+public enum CatalogSortDirection
+{
+    /// <summary>Ascending sort order.</summary>
+    Ascending = 0,
+
+    /// <summary>Descending sort order.</summary>
+    Descending = 1
+}
+
+/// <summary>
+/// Search, filter, paging, and sorting options for catalog operations.
+/// </summary>
+public sealed record CatalogQueryOptions
+{
+    /// <summary>Free-text search applied to names, descriptions, service names, tags, and owners.</summary>
+    public string? Query { get; init; }
+
+    /// <summary>Catalog item kinds to include when using the unified search API.</summary>
+    public IReadOnlyList<CatalogItemKind>? Kinds { get; init; }
+
+    /// <summary>Service protocol or service type filters, such as FeatureServer, MapServer, OgcFeatures, OData, or Grpc.</summary>
+    public IReadOnlyList<string>? ServiceTypes { get; init; }
+
+    /// <summary>Tags that must be present on the catalog item.</summary>
+    public IReadOnlyList<string>? Tags { get; init; }
+
+    /// <summary>Owner filter from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Namespace filter for metadata-backed catalog resources.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Geometry type filters, such as Point, Polyline, Polygon, or esriGeometryPoint.</summary>
+    public IReadOnlyList<string>? GeometryTypes { get; init; }
+
+    /// <summary>Capability filters, such as Query, Create, Update, Delete, Attachments, Statistics, or FeatureServer.</summary>
+    public IReadOnlyList<string>? Capabilities { get; init; }
+
+    /// <summary>Zero-based result offset. Defaults to 0.</summary>
+    public int? Offset { get; init; }
+
+    /// <summary>Maximum number of results to return. A null value returns all filtered results.</summary>
+    public int? Limit { get; init; }
+
+    /// <summary>Field used to sort results.</summary>
+    public CatalogSortBy SortBy { get; init; } = CatalogSortBy.Name;
+
+    /// <summary>Sort direction.</summary>
+    public CatalogSortDirection SortDirection { get; init; } = CatalogSortDirection.Ascending;
+}
+
+/// <summary>
+/// Unified catalog search result.
+/// </summary>
+public sealed record CatalogSearchResult
+{
+    /// <summary>Filtered and paged catalog items.</summary>
+    public IReadOnlyList<CatalogItem> Items { get; init; } = [];
+
+    /// <summary>Total item count after filters and before paging.</summary>
+    public int TotalCount { get; init; }
+
+    /// <summary>Offset applied to this page.</summary>
+    public int Offset { get; init; }
+
+    /// <summary>Next offset when more results are available.</summary>
+    public int? NextOffset { get; init; }
+}
+
+/// <summary>
+/// Unified catalog item envelope.
+/// </summary>
+public sealed record CatalogItem
+{
+    /// <summary>Stable item identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Catalog item kind.</summary>
+    public required CatalogItemKind Kind { get; init; }
+
+    /// <summary>Display name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Optional human-readable description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Owning service name when the item belongs to a service.</summary>
+    public string? ServiceName { get; init; }
+
+    /// <summary>Layer ID when the item represents a layer.</summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>Metadata namespace when available.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Owner from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Tags from metadata labels or annotations.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Service protocol or service type values associated with the item.</summary>
+    public IReadOnlyList<string> ServiceTypes { get; init; } = [];
+
+    /// <summary>Capability values associated with the item.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Geometry type when known.</summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>Spatial extent when known.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Created timestamp from metadata when available.</summary>
+    public DateTimeOffset? CreatedAt { get; init; }
+
+    /// <summary>Updated timestamp from metadata when available.</summary>
+    public DateTimeOffset? UpdatedAt { get; init; }
+
+    /// <summary>Service detail when <see cref="Kind"/> is <see cref="CatalogItemKind.Service"/>.</summary>
+    public CatalogService? Service { get; init; }
+
+    /// <summary>Layer detail when <see cref="Kind"/> is <see cref="CatalogItemKind.Layer"/>.</summary>
+    public CatalogLayer? Layer { get; init; }
+
+    /// <summary>Group detail when <see cref="Kind"/> is <see cref="CatalogItemKind.Group"/>.</summary>
+    public CatalogGroup? Group { get; init; }
+
+    /// <summary>Saved source descriptor detail when <see cref="Kind"/> is <see cref="CatalogItemKind.SourceDescriptor"/>.</summary>
+    public CatalogSourceDescriptor? SourceDescriptor { get; init; }
+}
+
+/// <summary>
+/// Catalog service detail.
+/// </summary>
+public sealed record CatalogService
+{
+    /// <summary>Stable service identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Service name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Service description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Number of layers advertised by the service list endpoint.</summary>
+    public int LayerCount { get; init; }
+
+    /// <summary>Enabled service protocols.</summary>
+    public IReadOnlyList<string> ServiceTypes { get; init; } = [];
+
+    /// <summary>Service-level capabilities.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Geometry types discovered from layer details when available.</summary>
+    public IReadOnlyList<string> GeometryTypes { get; init; } = [];
+
+    /// <summary>Service extent when available.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Metadata namespace when available.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Owner from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Tags from metadata labels or annotations.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Backing metadata resource when one was discovered.</summary>
+    public MetadataResource? MetadataResource { get; init; }
+}
+
+/// <summary>
+/// Catalog layer detail.
+/// </summary>
+public sealed record CatalogLayer
+{
+    /// <summary>Stable layer identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Owning service name.</summary>
+    public required string ServiceName { get; init; }
+
+    /// <summary>Layer ID within the service.</summary>
+    public int LayerId { get; init; }
+
+    /// <summary>Layer name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Layer description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Enabled service protocols on the owning service.</summary>
+    public IReadOnlyList<string> ServiceTypes { get; init; } = [];
+
+    /// <summary>Layer capabilities.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Layer geometry type when known.</summary>
+    public string? GeometryType { get; init; }
+
+    /// <summary>Layer extent when known.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>SDK source descriptor for the FeatureServer-backed layer.</summary>
+    public SourceDescriptor SourceDescriptor { get; init; } = new()
+    {
+        Id = string.Empty,
+        Protocol = FeatureProtocolIds.GeoServicesFeatureService
+    };
+
+    /// <summary>Metadata namespace when available.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Owner from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Tags from metadata labels or annotations.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Backing metadata resource when one was discovered.</summary>
+    public MetadataResource? MetadataResource { get; init; }
+}
+
+/// <summary>
+/// Metadata-backed catalog group detail.
+/// </summary>
+public sealed record CatalogGroup
+{
+    /// <summary>Stable group identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Group name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Group namespace.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Group description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Owner from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Tags from metadata labels or annotations.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Backing metadata resource.</summary>
+    public required MetadataResource Resource { get; init; }
+}
+
+/// <summary>
+/// Metadata-backed saved SDK source descriptor.
+/// </summary>
+public sealed record CatalogSourceDescriptor
+{
+    /// <summary>Stable descriptor identifier.</summary>
+    public required string Id { get; init; }
+
+    /// <summary>Descriptor name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Descriptor namespace.</summary>
+    public string? Namespace { get; init; }
+
+    /// <summary>Owner from metadata labels or annotations.</summary>
+    public string? Owner { get; init; }
+
+    /// <summary>Tags from metadata labels or annotations.</summary>
+    public IReadOnlyList<string> Tags { get; init; } = [];
+
+    /// <summary>Parsed SDK source descriptor.</summary>
+    public required SourceDescriptor Descriptor { get; init; }
+
+    /// <summary>Backing metadata resource.</summary>
+    public required MetadataResource Resource { get; init; }
+}
+
+/// <summary>
+/// Known metadata resource kinds used by the catalog client.
+/// </summary>
+public static class CatalogMetadataKinds
+{
+    /// <summary>Service metadata resource kind.</summary>
+    public const string Service = "Service";
+
+    /// <summary>Layer metadata resource kind.</summary>
+    public const string Layer = "Layer";
+
+    /// <summary>Catalog group metadata resource kind.</summary>
+    public const string Group = "Group";
+
+    /// <summary>Saved SDK source descriptor metadata resource kind.</summary>
+    public const string SourceDescriptor = "SourceDescriptor";
+}

--- a/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
+++ b/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
@@ -1,0 +1,1187 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Admin.Exceptions;
+using Honua.Sdk.Admin.Models;
+
+namespace Honua.Sdk.Admin.Catalog;
+
+/// <summary>
+/// HTTP client implementation for Honua portal and catalog discovery.
+/// </summary>
+public sealed class HonuaCatalogClient : IHonuaCatalogClient
+{
+    private const string ApiPrefix = "/api/v1/admin";
+    private const string FeatureServerProtocol = "FeatureServer";
+
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaCatalogClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client configured with base address and auth handlers.</param>
+    public HonuaCatalogClient(HttpClient httpClient)
+    {
+        _http = httpClient;
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogSearchResult> SearchAsync(CatalogQueryOptions? options = null, CancellationToken ct = default)
+    {
+        var normalizedOptions = NormalizeOptions(options);
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var services = await LoadServicesAsync(metadata, ct).ConfigureAwait(false);
+
+        var items = new List<CatalogItem>();
+        if (IncludesKind(normalizedOptions, CatalogItemKind.Service))
+        {
+            items.AddRange(services.Select(ToItem));
+        }
+
+        if (IncludesKind(normalizedOptions, CatalogItemKind.Layer))
+        {
+            var layers = await LoadLayersAsync(services, metadata, ct).ConfigureAwait(false);
+            items.AddRange(layers.Select(ToItem));
+        }
+
+        if (IncludesKind(normalizedOptions, CatalogItemKind.Group))
+        {
+            items.AddRange(BuildGroups(metadata.Groups).Select(ToItem));
+        }
+
+        if (IncludesKind(normalizedOptions, CatalogItemKind.SourceDescriptor))
+        {
+            items.AddRange(BuildSourceDescriptors(metadata.SourceDescriptors).Select(ToItem));
+        }
+
+        return ApplySearchQuery(items, normalizedOptions);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CatalogService>> ListServicesAsync(
+        CatalogQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        var normalizedOptions = NormalizeOptions(options);
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var services = await LoadServicesAsync(metadata, ct).ConfigureAwait(false);
+        return ApplyDetailQuery(services, WithoutKindFilter(normalizedOptions), ToItem, static item => item.Service!);
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogService?> GetServiceAsync(string serviceName, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var services = await LoadServicesAsync(metadata, ct).ConfigureAwait(false);
+        return services.FirstOrDefault(service => string.Equals(service.Name, serviceName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CatalogLayer>> ListLayersAsync(
+        CatalogQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        var normalizedOptions = NormalizeOptions(options);
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var services = await LoadServicesAsync(metadata, ct).ConfigureAwait(false);
+        var layers = await LoadLayersAsync(services, metadata, ct).ConfigureAwait(false);
+        return ApplyDetailQuery(layers, WithoutKindFilter(normalizedOptions), ToItem, static item => item.Layer!);
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogLayer?> GetLayerAsync(string serviceName, int layerId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var service = (await LoadServicesAsync(metadata, ct).ConfigureAwait(false))
+            .FirstOrDefault(candidate => string.Equals(candidate.Name, serviceName, StringComparison.OrdinalIgnoreCase));
+        if (service is null)
+        {
+            return null;
+        }
+
+        var layer = await GetFeatureServerLayerInfoOrNullAsync(serviceName, layerId, ct).ConfigureAwait(false);
+        return layer is null
+            ? null
+            : BuildCatalogLayer(service, layer, metadata);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CatalogGroup>> ListGroupsAsync(
+        CatalogQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        var normalizedOptions = NormalizeOptions(options);
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var groups = BuildGroups(metadata.Groups);
+        return ApplyDetailQuery(groups, WithoutKindFilter(normalizedOptions), ToItem, static item => item.Group!);
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogGroup?> GetGroupAsync(string ns, string name, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ns);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var resource = await GetMetadataResourceOrNullAsync(CatalogMetadataKinds.Group, ns, name, ct).ConfigureAwait(false);
+        return resource is null ? null : BuildGroup(resource);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CatalogSourceDescriptor>> ListSourceDescriptorsAsync(
+        CatalogQueryOptions? options = null,
+        CancellationToken ct = default)
+    {
+        var normalizedOptions = NormalizeOptions(options);
+        var metadata = await LoadMetadataIndexAsync(ct).ConfigureAwait(false);
+        var descriptors = BuildSourceDescriptors(metadata.SourceDescriptors);
+        return ApplyDetailQuery(
+            descriptors,
+            WithoutKindFilter(normalizedOptions),
+            ToItem,
+            static item => item.SourceDescriptor!);
+    }
+
+    /// <inheritdoc />
+    public async Task<CatalogSourceDescriptor?> GetSourceDescriptorAsync(string ns, string name, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ns);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        var resource = await GetMetadataResourceOrNullAsync(CatalogMetadataKinds.SourceDescriptor, ns, name, ct)
+            .ConfigureAwait(false);
+        return resource is null ? null : TryBuildSourceDescriptor(resource);
+    }
+
+    private async Task<IReadOnlyList<CatalogService>> LoadServicesAsync(
+        CatalogMetadataIndex metadata,
+        CancellationToken ct)
+    {
+        var summaries = await GetAdminEnvelopeAsync<ServiceSummary[]>(
+            $"{ApiPrefix}/services/",
+            HonuaAdminJsonContext.Default.ApiResponseServiceSummaryArray,
+            ct).ConfigureAwait(false) ?? [];
+
+        var services = new List<CatalogService>(summaries.Length);
+        foreach (var summary in summaries.OrderBy(static service => service.ServiceName, StringComparer.OrdinalIgnoreCase))
+        {
+            var serviceMetadata = metadata.FindService(summary.ServiceName);
+            var serviceInfo = HasServiceType(summary.EnabledProtocols, FeatureServerProtocol)
+                ? await GetFeatureServerServiceInfoOrNullAsync(summary.ServiceName, ct).ConfigureAwait(false)
+                : null;
+
+            services.Add(BuildCatalogService(summary, serviceInfo, serviceMetadata));
+        }
+
+        return services.AsReadOnly();
+    }
+
+    private async Task<IReadOnlyList<CatalogLayer>> LoadLayersAsync(
+        IReadOnlyList<CatalogService> services,
+        CatalogMetadataIndex metadata,
+        CancellationToken ct)
+    {
+        var layers = new List<CatalogLayer>();
+        foreach (var service in services)
+        {
+            if (!HasServiceType(service.ServiceTypes, FeatureServerProtocol))
+            {
+                continue;
+            }
+
+            var serviceInfo = await GetFeatureServerServiceInfoOrNullAsync(service.Name, ct).ConfigureAwait(false);
+            if (serviceInfo?.Layers is not { Count: > 0 })
+            {
+                continue;
+            }
+
+            foreach (var layerSummary in serviceInfo.Layers)
+            {
+                var layer = await GetFeatureServerLayerInfoOrNullAsync(service.Name, layerSummary.Id, ct).ConfigureAwait(false);
+                if (layer is not null)
+                {
+                    layers.Add(BuildCatalogLayer(service, layer, metadata));
+                }
+            }
+        }
+
+        return layers.AsReadOnly();
+    }
+
+    private async Task<CatalogMetadataIndex> LoadMetadataIndexAsync(CancellationToken ct)
+    {
+        var services = await ListMetadataResourcesByKindAsync(CatalogMetadataKinds.Service, ct).ConfigureAwait(false);
+        var layers = await ListMetadataResourcesByKindAsync(CatalogMetadataKinds.Layer, ct).ConfigureAwait(false);
+        var groups = await ListMetadataResourcesByKindAsync(CatalogMetadataKinds.Group, ct).ConfigureAwait(false);
+        var sourceDescriptors = await ListMetadataResourcesByKindAsync(CatalogMetadataKinds.SourceDescriptor, ct).ConfigureAwait(false);
+        return new CatalogMetadataIndex(services, layers, groups, sourceDescriptors);
+    }
+
+    private async Task<IReadOnlyList<MetadataResource>> ListMetadataResourcesByKindAsync(
+        string kind,
+        CancellationToken ct)
+    {
+        var query = BuildQuery(("kind", kind));
+        return await GetAdminEnvelopeAsync<MetadataResource[]>(
+            $"{ApiPrefix}/metadata/resources{query}",
+            HonuaAdminJsonContext.Default.ApiResponseMetadataResourceArray,
+            ct).ConfigureAwait(false) ?? [];
+    }
+
+    private async Task<MetadataResource?> GetMetadataResourceOrNullAsync(
+        string kind,
+        string ns,
+        string name,
+        CancellationToken ct)
+    {
+        var url = $"{ApiPrefix}/metadata/resources/{Uri.EscapeDataString(kind)}/{Uri.EscapeDataString(ns)}/{Uri.EscapeDataString(name)}";
+        try
+        {
+            return await GetAdminEnvelopeAsync<MetadataResource>(
+                url,
+                HonuaAdminJsonContext.Default.ApiResponseMetadataResource,
+                ct).ConfigureAwait(false);
+        }
+        catch (HonuaAdminApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private async Task<CatalogFeatureServerServiceInfo?> GetFeatureServerServiceInfoOrNullAsync(
+        string serviceName,
+        CancellationToken ct)
+    {
+        var url = $"/rest/services/{Uri.EscapeDataString(serviceName)}/FeatureServer?f=json";
+        try
+        {
+            return await GetRawAsync(url, HonuaAdminJsonContext.Default.CatalogFeatureServerServiceInfo, ct)
+                .ConfigureAwait(false);
+        }
+        catch (HonuaAdminApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private async Task<CatalogFeatureServerLayerInfo?> GetFeatureServerLayerInfoOrNullAsync(
+        string serviceName,
+        int layerId,
+        CancellationToken ct)
+    {
+        var url = $"/rest/services/{Uri.EscapeDataString(serviceName)}/FeatureServer/{layerId}?f=json";
+        try
+        {
+            return await GetRawAsync(url, HonuaAdminJsonContext.Default.CatalogFeatureServerLayerInfo, ct)
+                .ConfigureAwait(false);
+        }
+        catch (HonuaAdminApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    private static CatalogService BuildCatalogService(
+        ServiceSummary summary,
+        CatalogFeatureServerServiceInfo? serviceInfo,
+        MetadataResource? metadata)
+    {
+        var serviceTypes = NormalizeValues(summary.EnabledProtocols);
+        var capabilities = MergeValues(serviceTypes, SplitCsv(serviceInfo?.Capabilities));
+        var tags = GetTags(metadata);
+        var owner = GetOwner(metadata);
+
+        return new CatalogService
+        {
+            Id = summary.ServiceName,
+            Name = summary.ServiceName,
+            Description = FirstNonWhiteSpace(
+                summary.Description,
+                serviceInfo?.ServiceDescription,
+                GetSpecString(metadata?.Spec, "description", "title")),
+            LayerCount = summary.LayerCount,
+            ServiceTypes = serviceTypes,
+            Capabilities = capabilities,
+            GeometryTypes = [],
+            Extent = ToBoundingBox(serviceInfo?.FullExtent ?? serviceInfo?.InitialExtent),
+            Namespace = metadata?.Metadata?.Namespace,
+            Owner = owner,
+            Tags = tags,
+            MetadataResource = metadata
+        };
+    }
+
+    private static CatalogLayer BuildCatalogLayer(
+        CatalogService service,
+        CatalogFeatureServerLayerInfo layer,
+        CatalogMetadataIndex metadata)
+    {
+        var layerName = FirstNonWhiteSpace(layer.Name, layer.Id.ToString(CultureInfo.InvariantCulture))!;
+        var layerMetadata = metadata.FindLayer(service.Name, layer.Id, layerName);
+        var geometryType = NormalizeGeometryType(layer.GeometryType ?? GetSpecString(layerMetadata?.Spec, "geometryType"));
+        var capabilities = MergeValues(
+            service.ServiceTypes,
+            SplitCsv(layer.Capabilities),
+            layer.SupportsStatistics ? ["Statistics"] : [],
+            layer.HasAttachments ? ["Attachments"] : []);
+        var source = new SourceDescriptor
+        {
+            Id = $"{service.Name}/{layer.Id}",
+            Protocol = FeatureProtocolIds.GeoServicesFeatureService,
+            Locator = new SourceLocator
+            {
+                Url = $"/rest/services/{Uri.EscapeDataString(service.Name)}/FeatureServer/{layer.Id}",
+                ServiceId = service.Name,
+                LayerId = layer.Id
+            },
+            Capabilities = capabilities,
+            Schema = new SourceSchema
+            {
+                GeometryType = ToFeatureGeometryType(geometryType),
+                Extent = ToBoundingBox(layer.Extent),
+                SpatialReference = ToSpatialReference(layer.SpatialReference ?? layer.Extent?.SpatialReference),
+                ObjectIdField = layer.ObjectIdField,
+                GlobalIdField = layer.GlobalIdField
+            }
+        };
+
+        return new CatalogLayer
+        {
+            Id = source.Id,
+            ServiceName = service.Name,
+            LayerId = layer.Id,
+            Name = layerName,
+            Description = FirstNonWhiteSpace(layer.Description, GetSpecString(layerMetadata?.Spec, "description", "title")),
+            ServiceTypes = service.ServiceTypes,
+            Capabilities = capabilities,
+            GeometryType = geometryType,
+            Extent = ToBoundingBox(layer.Extent),
+            SourceDescriptor = source,
+            Namespace = layerMetadata?.Metadata?.Namespace,
+            Owner = GetOwner(layerMetadata),
+            Tags = GetTags(layerMetadata),
+            MetadataResource = layerMetadata
+        };
+    }
+
+    private static ReadOnlyCollection<CatalogGroup> BuildGroups(IReadOnlyList<MetadataResource> resources)
+        => resources.Select(BuildGroup).ToList().AsReadOnly();
+
+    private static CatalogGroup BuildGroup(MetadataResource resource)
+    {
+        var name = GetResourceName(resource);
+        return new CatalogGroup
+        {
+            Id = GetResourceId(resource),
+            Name = name,
+            Namespace = resource.Metadata?.Namespace,
+            Description = GetSpecString(resource.Spec, "description", "title"),
+            Owner = GetOwner(resource),
+            Tags = GetTags(resource),
+            Resource = resource
+        };
+    }
+
+    private static ReadOnlyCollection<CatalogSourceDescriptor> BuildSourceDescriptors(IReadOnlyList<MetadataResource> resources)
+        => resources
+            .Select(TryBuildSourceDescriptor)
+            .Where(static descriptor => descriptor is not null)
+            .Select(static descriptor => descriptor!)
+            .ToList()
+            .AsReadOnly();
+
+    private static CatalogSourceDescriptor? TryBuildSourceDescriptor(MetadataResource resource)
+    {
+        if (!TryReadSourceDescriptor(resource.Spec, out var descriptor))
+        {
+            return null;
+        }
+
+        return new CatalogSourceDescriptor
+        {
+            Id = GetResourceId(resource),
+            Name = GetResourceName(resource),
+            Namespace = resource.Metadata?.Namespace,
+            Owner = GetOwner(resource),
+            Tags = GetTags(resource),
+            Descriptor = descriptor,
+            Resource = resource
+        };
+    }
+
+    private static CatalogItem ToItem(CatalogService service)
+        => new()
+        {
+            Id = service.Id,
+            Kind = CatalogItemKind.Service,
+            Name = service.Name,
+            Description = service.Description,
+            ServiceName = service.Name,
+            Namespace = service.Namespace,
+            Owner = service.Owner,
+            Tags = service.Tags,
+            ServiceTypes = service.ServiceTypes,
+            Capabilities = service.Capabilities,
+            Extent = service.Extent,
+            CreatedAt = service.MetadataResource?.Metadata?.CreatedAt,
+            UpdatedAt = service.MetadataResource?.Metadata?.UpdatedAt,
+            Service = service
+        };
+
+    private static CatalogItem ToItem(CatalogLayer layer)
+        => new()
+        {
+            Id = layer.Id,
+            Kind = CatalogItemKind.Layer,
+            Name = layer.Name,
+            Description = layer.Description,
+            ServiceName = layer.ServiceName,
+            LayerId = layer.LayerId,
+            Namespace = layer.Namespace,
+            Owner = layer.Owner,
+            Tags = layer.Tags,
+            ServiceTypes = layer.ServiceTypes,
+            Capabilities = layer.Capabilities,
+            GeometryType = layer.GeometryType,
+            Extent = layer.Extent,
+            CreatedAt = layer.MetadataResource?.Metadata?.CreatedAt,
+            UpdatedAt = layer.MetadataResource?.Metadata?.UpdatedAt,
+            Layer = layer
+        };
+
+    private static CatalogItem ToItem(CatalogGroup group)
+        => new()
+        {
+            Id = group.Id,
+            Kind = CatalogItemKind.Group,
+            Name = group.Name,
+            Description = group.Description,
+            Namespace = group.Namespace,
+            Owner = group.Owner,
+            Tags = group.Tags,
+            CreatedAt = group.Resource.Metadata?.CreatedAt,
+            UpdatedAt = group.Resource.Metadata?.UpdatedAt,
+            Group = group
+        };
+
+    private static CatalogItem ToItem(CatalogSourceDescriptor descriptor)
+        => new()
+        {
+            Id = descriptor.Id,
+            Kind = CatalogItemKind.SourceDescriptor,
+            Name = descriptor.Name,
+            Namespace = descriptor.Namespace,
+            Owner = descriptor.Owner,
+            Tags = descriptor.Tags,
+            ServiceTypes = [descriptor.Descriptor.Protocol],
+            Capabilities = descriptor.Descriptor.Capabilities,
+            GeometryType = descriptor.Descriptor.Schema?.GeometryType.ToString(),
+            Extent = descriptor.Descriptor.Schema?.Extent,
+            CreatedAt = descriptor.Resource.Metadata?.CreatedAt,
+            UpdatedAt = descriptor.Resource.Metadata?.UpdatedAt,
+            SourceDescriptor = descriptor
+        };
+
+    private static CatalogSearchResult ApplySearchQuery(
+        IReadOnlyList<CatalogItem> items,
+        CatalogQueryOptions options)
+    {
+        var filtered = FilterAndSortItems(items, options).ToList();
+        var totalCount = filtered.Count;
+        var paged = PageItems(filtered, options).ToList().AsReadOnly();
+        var nextOffset = options.Limit.HasValue && options.Offset.GetValueOrDefault() + options.Limit.Value < totalCount
+            ? options.Offset.GetValueOrDefault() + options.Limit.Value
+            : (int?)null;
+
+        return new CatalogSearchResult
+        {
+            Items = paged,
+            TotalCount = totalCount,
+            Offset = options.Offset.GetValueOrDefault(),
+            NextOffset = nextOffset
+        };
+    }
+
+    private static ReadOnlyCollection<T> ApplyDetailQuery<T>(
+        IReadOnlyList<T> values,
+        CatalogQueryOptions options,
+        Func<T, CatalogItem> toItem,
+        Func<CatalogItem, T> fromItem)
+    {
+        var selected = FilterAndSortItems(values.Select(toItem), options)
+            .Select(fromItem);
+
+        return PageItems(selected, options).ToList().AsReadOnly();
+    }
+
+    private static IEnumerable<CatalogItem> FilterAndSortItems(
+        IEnumerable<CatalogItem> items,
+        CatalogQueryOptions options)
+    {
+        var filtered = items.Where(item => MatchesFilters(item, options));
+        return options.SortBy switch
+        {
+            CatalogSortBy.Kind => Sort(filtered, item => item.Kind.ToString(), options.SortDirection),
+            CatalogSortBy.ServiceName => Sort(filtered, item => item.ServiceName ?? string.Empty, options.SortDirection),
+            CatalogSortBy.CreatedAt => Sort(filtered, item => item.CreatedAt, options.SortDirection),
+            CatalogSortBy.UpdatedAt => Sort(filtered, item => item.UpdatedAt, options.SortDirection),
+            _ => Sort(filtered, item => item.Name, options.SortDirection)
+        };
+    }
+
+    private static IEnumerable<T> Sort<T, TKey>(
+        IEnumerable<T> values,
+        Func<T, TKey> keySelector,
+        CatalogSortDirection direction)
+        => direction == CatalogSortDirection.Descending
+            ? values.OrderByDescending(keySelector)
+            : values.OrderBy(keySelector);
+
+    private static IEnumerable<T> PageItems<T>(IEnumerable<T> items, CatalogQueryOptions options)
+    {
+        var paged = items.Skip(options.Offset.GetValueOrDefault());
+        return options.Limit.HasValue ? paged.Take(options.Limit.Value) : paged;
+    }
+
+    private static bool MatchesFilters(CatalogItem item, CatalogQueryOptions options)
+    {
+        if (options.Kinds is { Count: > 0 } && !options.Kinds.Contains(item.Kind))
+        {
+            return false;
+        }
+
+        if (!MatchesQuery(item, options.Query))
+        {
+            return false;
+        }
+
+        if (!MatchesAny(item.ServiceTypes, options.ServiceTypes))
+        {
+            return false;
+        }
+
+        if (!MatchesAll(item.Tags, options.Tags))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Owner) &&
+            !string.Equals(item.Owner, options.Owner, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.Namespace) &&
+            !string.Equals(item.Namespace, options.Namespace, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (options.GeometryTypes is { Count: > 0 } &&
+            !ContainsValue(options.GeometryTypes.Select(NormalizeGeometryType), item.GeometryType))
+        {
+            return false;
+        }
+
+        return MatchesAll(item.Capabilities, options.Capabilities);
+    }
+
+    private static bool MatchesQuery(CatalogItem item, string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return true;
+        }
+
+        var haystack = new[]
+        {
+            item.Id,
+            item.Name,
+            item.Description,
+            item.ServiceName,
+            item.Namespace,
+            item.Owner,
+            item.GeometryType
+        }.Concat(item.Tags).Concat(item.ServiceTypes).Concat(item.Capabilities);
+
+        return haystack.Any(value => value?.Contains(query, StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    private static bool MatchesAny(IReadOnlyList<string> actual, IReadOnlyList<string>? filters)
+        => filters is null or { Count: 0 } ||
+           filters.Any(filter => actual.Any(value => string.Equals(value, filter, StringComparison.OrdinalIgnoreCase)));
+
+    private static bool MatchesAll(IReadOnlyList<string> actual, IReadOnlyList<string>? filters)
+        => filters is null or { Count: 0 } ||
+           filters.All(filter => actual.Any(value => string.Equals(value, filter, StringComparison.OrdinalIgnoreCase)));
+
+    private static bool ContainsValue(IEnumerable<string?> values, string? candidate)
+        => !string.IsNullOrWhiteSpace(candidate) &&
+           values.Any(value => string.Equals(value, candidate, StringComparison.OrdinalIgnoreCase));
+
+    private static bool IncludesKind(CatalogQueryOptions options, CatalogItemKind kind)
+        => options.Kinds is null or { Count: 0 } || options.Kinds.Contains(kind);
+
+    private static CatalogQueryOptions NormalizeOptions(CatalogQueryOptions? options)
+    {
+        var normalized = options ?? new CatalogQueryOptions();
+        if (normalized.Offset is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Catalog query offset cannot be negative.");
+        }
+
+        if (normalized.Limit is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Catalog query limit cannot be negative.");
+        }
+
+        return normalized;
+    }
+
+    private static CatalogQueryOptions WithoutKindFilter(CatalogQueryOptions options)
+        => options.Kinds is null ? options : options with { Kinds = null };
+
+    private async Task<T?> GetAdminEnvelopeAsync<T>(
+        string url,
+        JsonTypeInfo<ApiResponse<T>> typeInfo,
+        CancellationToken ct)
+    {
+        using var response = await _http.GetAsync(CreateRequestUri(url), ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        EnsureEnvelopeSucceeded(response, body);
+
+        var envelope = JsonSerializer.Deserialize(body, typeInfo);
+        return envelope is not null ? envelope.Data : default;
+    }
+
+    private async Task<T?> GetRawAsync<T>(
+        string url,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        using var response = await _http.GetAsync(CreateRequestUri(url), ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+
+        return JsonSerializer.Deserialize(body, typeInfo);
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string body)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var message = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "Catalog request failed";
+        throw new HonuaAdminApiException(response.StatusCode, message, body);
+    }
+
+    private static void EnsureEnvelopeSucceeded(HttpResponseMessage response, string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("success", out var success) &&
+                success.ValueKind == JsonValueKind.False)
+            {
+                var message = TryExtractErrorMessage(body) ?? "API response indicated failure.";
+                throw new HonuaAdminApiException(response.StatusCode, message, body);
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON or invalid JSON envelope, ignore.
+        }
+    }
+
+    private static string? TryExtractErrorMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
+            {
+                return msg.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("error", out var error) &&
+                error.ValueKind == JsonValueKind.Object &&
+                error.TryGetProperty("message", out var errorMessage) &&
+                errorMessage.ValueKind == JsonValueKind.String)
+            {
+                return errorMessage.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
+            {
+                return detail.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("title", out var title) && title.ValueKind == JsonValueKind.String)
+            {
+                return title.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON, that's fine.
+        }
+
+        return null;
+    }
+
+    private static bool TryReadSourceDescriptor(JsonElement spec, out SourceDescriptor descriptor)
+    {
+        foreach (var candidate in EnumerateDescriptorCandidates(spec))
+        {
+            try
+            {
+                var parsed = JsonSerializer.Deserialize(candidate.GetRawText(), HonuaAdminJsonContext.Default.SourceDescriptor);
+                if (parsed is not null)
+                {
+                    descriptor = parsed;
+                    return true;
+                }
+            }
+            catch (JsonException)
+            {
+                // Try the next known descriptor shape.
+            }
+        }
+
+        descriptor = default!;
+        return false;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateDescriptorCandidates(JsonElement spec)
+    {
+        if (spec.ValueKind != JsonValueKind.Object)
+        {
+            yield break;
+        }
+
+        if (spec.TryGetProperty("sourceDescriptor", out var sourceDescriptor) &&
+            sourceDescriptor.ValueKind == JsonValueKind.Object)
+        {
+            yield return sourceDescriptor;
+        }
+
+        if (spec.TryGetProperty("descriptor", out var descriptor) &&
+            descriptor.ValueKind == JsonValueKind.Object)
+        {
+            yield return descriptor;
+        }
+
+        yield return spec;
+    }
+
+    private static string? GetSpecString(JsonElement? spec, params string[] names)
+    {
+        if (spec is null || spec.Value.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var name in names)
+        {
+            if (spec.Value.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String)
+            {
+                return value.GetString();
+            }
+        }
+
+        return null;
+    }
+
+    private static int? GetSpecInt(JsonElement? spec, params string[] names)
+    {
+        if (spec is null || spec.Value.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var name in names)
+        {
+            if (spec.Value.TryGetProperty(name, out var value) && value.TryGetInt32(out var parsed))
+            {
+                return parsed;
+            }
+        }
+
+        return null;
+    }
+
+    private static string GetResourceId(MetadataResource resource)
+        => FirstNonWhiteSpace(resource.Metadata?.Id, resource.Metadata?.Name, GetSpecString(resource.Spec, "id", "name")) ??
+           string.Empty;
+
+    private static string GetResourceName(MetadataResource resource)
+        => FirstNonWhiteSpace(resource.Metadata?.Name, GetSpecString(resource.Spec, "name", "title"), resource.Metadata?.Id) ??
+           string.Empty;
+
+    private static string? GetOwner(MetadataResource? resource)
+        => FirstNonWhiteSpace(
+            GetDictionaryValue(resource?.Metadata?.Labels, "owner"),
+            GetDictionaryValue(resource?.Metadata?.Labels, "honua.io/owner"),
+            GetDictionaryValue(resource?.Metadata?.Annotations, "owner"),
+            GetDictionaryValue(resource?.Metadata?.Annotations, "honua.io/owner"));
+
+    private static ReadOnlyCollection<string> GetTags(MetadataResource? resource)
+    {
+        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddSplitValues(tags, GetDictionaryValue(resource?.Metadata?.Labels, "tags"));
+        AddSplitValues(tags, GetDictionaryValue(resource?.Metadata?.Labels, "honua.io/tags"));
+        AddSplitValues(tags, GetDictionaryValue(resource?.Metadata?.Annotations, "tags"));
+        AddSplitValues(tags, GetDictionaryValue(resource?.Metadata?.Annotations, "honua.io/tags"));
+
+        if (resource?.Metadata?.Labels is not null)
+        {
+            foreach (var (key, value) in resource.Metadata.Labels)
+            {
+                if (key.StartsWith("tag/", StringComparison.OrdinalIgnoreCase) ||
+                    key.StartsWith("tags/", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddSplitValues(tags, value);
+                }
+            }
+        }
+
+        return tags.OrderBy(static tag => tag, StringComparer.OrdinalIgnoreCase).ToList().AsReadOnly();
+    }
+
+    private static void AddSplitValues(HashSet<string> values, string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return;
+        }
+
+        foreach (var value in raw.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            values.Add(value);
+        }
+    }
+
+    private static string? GetDictionaryValue(Dictionary<string, string>? values, string key)
+        => values is not null && values.TryGetValue(key, out var value) ? value : null;
+
+    private static ReadOnlyCollection<string> NormalizeValues(IEnumerable<string>? values)
+        => values is null
+            ? []
+            : values
+                .Where(static value => !string.IsNullOrWhiteSpace(value))
+                .Select(static value => value.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+                .ToList()
+                .AsReadOnly();
+
+    private static ReadOnlyCollection<string> MergeValues(params IEnumerable<string>[] valueSets)
+        => NormalizeValues(valueSets.SelectMany(static values => values));
+
+    private static ReadOnlyCollection<string> SplitCsv(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? []
+            : NormalizeValues(value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+    private static string? FirstNonWhiteSpace(params string?[] values)
+        => values.FirstOrDefault(static value => !string.IsNullOrWhiteSpace(value));
+
+    private static bool HasServiceType(IReadOnlyList<string>? serviceTypes, string serviceType)
+        => serviceTypes?.Any(type => string.Equals(type, serviceType, StringComparison.OrdinalIgnoreCase)) == true;
+
+    private static FeatureBoundingBox? ToBoundingBox(CatalogFeatureServerExtent? extent)
+    {
+        if (extent is null)
+        {
+            return null;
+        }
+
+        return new FeatureBoundingBox
+        {
+            MinX = extent.XMin,
+            MinY = extent.YMin,
+            MaxX = extent.XMax,
+            MaxY = extent.YMax,
+            Crs = ToSpatialReference(extent.SpatialReference)
+        };
+    }
+
+    private static string? ToSpatialReference(CatalogFeatureServerSpatialReference? spatialReference)
+    {
+        if (spatialReference is null)
+        {
+            return null;
+        }
+
+        return spatialReference.LatestWkid > 0
+            ? $"EPSG:{spatialReference.LatestWkid.ToString(CultureInfo.InvariantCulture)}"
+            : spatialReference.Wkid > 0
+                ? $"EPSG:{spatialReference.Wkid.ToString(CultureInfo.InvariantCulture)}"
+                : spatialReference.Wkt;
+    }
+
+    private static string? NormalizeGeometryType(string? geometryType)
+    {
+        if (string.IsNullOrWhiteSpace(geometryType))
+        {
+            return null;
+        }
+
+        return geometryType.Trim() switch
+        {
+            "esriGeometryPoint" => "Point",
+            "esriGeometryMultipoint" => "MultiPoint",
+            "esriGeometryPolyline" => "Polyline",
+            "esriGeometryPolygon" => "Polygon",
+            "esriGeometryEnvelope" => "Envelope",
+            var value => value
+        };
+    }
+
+    private static FeatureSpatialGeometryType ToFeatureGeometryType(string? geometryType)
+        => geometryType switch
+        {
+            "Point" => FeatureSpatialGeometryType.Point,
+            "MultiPoint" => FeatureSpatialGeometryType.MultiPoint,
+            "Polyline" => FeatureSpatialGeometryType.Polyline,
+            "Polygon" => FeatureSpatialGeometryType.Polygon,
+            "Envelope" => FeatureSpatialGeometryType.Envelope,
+            _ => FeatureSpatialGeometryType.Unspecified
+        };
+
+    private static string BuildQuery(params ReadOnlySpan<(string Key, string? Value)> parameters)
+    {
+        var parts = new List<string>();
+        foreach (var (key, value) in parameters)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                parts.Add($"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(value)}");
+            }
+        }
+
+        return parts.Count > 0 ? $"?{string.Join("&", parts)}" : string.Empty;
+    }
+
+    private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
+
+    private sealed class CatalogMetadataIndex
+    {
+        private readonly Dictionary<string, MetadataResource> _services;
+        private readonly Dictionary<string, MetadataResource> _layers;
+
+        public CatalogMetadataIndex(
+            IReadOnlyList<MetadataResource> services,
+            IReadOnlyList<MetadataResource> layers,
+            IReadOnlyList<MetadataResource> groups,
+            IReadOnlyList<MetadataResource> sourceDescriptors)
+        {
+            _services = BuildServiceIndex(services);
+            _layers = BuildLayerIndex(layers);
+            Groups = groups;
+            SourceDescriptors = sourceDescriptors;
+        }
+
+        public IReadOnlyList<MetadataResource> Groups { get; }
+
+        public IReadOnlyList<MetadataResource> SourceDescriptors { get; }
+
+        public MetadataResource? FindService(string serviceName)
+            => _services.TryGetValue(NormalizeKey(serviceName), out var resource) ? resource : null;
+
+        public MetadataResource? FindLayer(string serviceName, int layerId, string layerName)
+        {
+            var keys = new[]
+            {
+                $"{serviceName}/{layerId.ToString(CultureInfo.InvariantCulture)}",
+                $"{serviceName}/{layerName}",
+                layerId.ToString(CultureInfo.InvariantCulture),
+                layerName
+            };
+
+            foreach (var key in keys)
+            {
+                if (_layers.TryGetValue(NormalizeKey(key), out var resource))
+                {
+                    return resource;
+                }
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, MetadataResource> BuildServiceIndex(IReadOnlyList<MetadataResource> resources)
+        {
+            var index = new Dictionary<string, MetadataResource>(StringComparer.OrdinalIgnoreCase);
+            foreach (var resource in resources)
+            {
+                AddIndexValue(index, resource, resource.Metadata?.Name);
+                AddIndexValue(index, resource, resource.Metadata?.Id);
+                AddIndexValue(index, resource, GetSpecString(resource.Spec, "serviceName", "name"));
+            }
+
+            return index;
+        }
+
+        private static Dictionary<string, MetadataResource> BuildLayerIndex(IReadOnlyList<MetadataResource> resources)
+        {
+            var index = new Dictionary<string, MetadataResource>(StringComparer.OrdinalIgnoreCase);
+            foreach (var resource in resources)
+            {
+                var serviceName = GetSpecString(resource.Spec, "serviceName", "serviceId");
+                var layerId = GetSpecInt(resource.Spec, "layerId", "id");
+                var name = FirstNonWhiteSpace(resource.Metadata?.Name, GetSpecString(resource.Spec, "layerName", "name"));
+
+                AddIndexValue(index, resource, resource.Metadata?.Name);
+                AddIndexValue(index, resource, resource.Metadata?.Id);
+                AddIndexValue(index, resource, name);
+
+                if (!string.IsNullOrWhiteSpace(serviceName))
+                {
+                    AddIndexValue(index, resource, $"{serviceName}/{name}");
+                    if (layerId.HasValue)
+                    {
+                        AddIndexValue(index, resource, $"{serviceName}/{layerId.Value.ToString(CultureInfo.InvariantCulture)}");
+                    }
+                }
+
+                if (layerId.HasValue)
+                {
+                    AddIndexValue(index, resource, layerId.Value.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            return index;
+        }
+
+        private static void AddIndexValue(
+            Dictionary<string, MetadataResource> index,
+            MetadataResource resource,
+            string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                index.TryAdd(NormalizeKey(value), resource);
+            }
+        }
+
+        private static string NormalizeKey(string value) => value.Trim().ToUpperInvariant();
+    }
+}
+
+internal sealed class CatalogFeatureServerServiceInfo
+{
+    [JsonPropertyName("serviceDescription")]
+    public string? ServiceDescription { get; set; }
+
+    [JsonPropertyName("capabilities")]
+    public string? Capabilities { get; set; }
+
+    [JsonPropertyName("initialExtent")]
+    public CatalogFeatureServerExtent? InitialExtent { get; set; }
+
+    [JsonPropertyName("fullExtent")]
+    public CatalogFeatureServerExtent? FullExtent { get; set; }
+
+    [JsonPropertyName("layers")]
+    public IReadOnlyList<CatalogFeatureServerLayerSummary>? Layers { get; set; }
+}
+
+internal sealed class CatalogFeatureServerLayerSummary
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+}
+
+internal sealed class CatalogFeatureServerLayerInfo
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("geometryType")]
+    public string? GeometryType { get; set; }
+
+    [JsonPropertyName("spatialReference")]
+    public CatalogFeatureServerSpatialReference? SpatialReference { get; set; }
+
+    [JsonPropertyName("extent")]
+    public CatalogFeatureServerExtent? Extent { get; set; }
+
+    [JsonPropertyName("objectIdField")]
+    public string? ObjectIdField { get; set; }
+
+    [JsonPropertyName("globalIdField")]
+    public string? GlobalIdField { get; set; }
+
+    [JsonPropertyName("capabilities")]
+    public string? Capabilities { get; set; }
+
+    [JsonPropertyName("hasAttachments")]
+    public bool HasAttachments { get; set; }
+
+    [JsonPropertyName("supportsStatistics")]
+    public bool SupportsStatistics { get; set; }
+}
+
+internal sealed class CatalogFeatureServerExtent
+{
+    [JsonPropertyName("xmin")]
+    public double XMin { get; set; }
+
+    [JsonPropertyName("ymin")]
+    public double YMin { get; set; }
+
+    [JsonPropertyName("xmax")]
+    public double XMax { get; set; }
+
+    [JsonPropertyName("ymax")]
+    public double YMax { get; set; }
+
+    [JsonPropertyName("spatialReference")]
+    public CatalogFeatureServerSpatialReference? SpatialReference { get; set; }
+}
+
+internal sealed class CatalogFeatureServerSpatialReference
+{
+    [JsonPropertyName("wkid")]
+    public int Wkid { get; set; }
+
+    [JsonPropertyName("latestWkid")]
+    public int LatestWkid { get; set; }
+
+    [JsonPropertyName("wkt")]
+    public string? Wkt { get; set; }
+}

--- a/src/Honua.Sdk.Admin/Catalog/IHonuaCatalogClient.cs
+++ b/src/Honua.Sdk.Admin/Catalog/IHonuaCatalogClient.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Admin.Catalog;
+
+/// <summary>
+/// Client interface for portal and catalog discovery over Honua Server metadata.
+/// </summary>
+public interface IHonuaCatalogClient
+{
+    /// <summary>
+    /// Searches across services, layers, groups, and saved source descriptors.
+    /// </summary>
+    /// <param name="options">Search, filter, sort, and paging options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Filtered and paged catalog items.</returns>
+    Task<CatalogSearchResult> SearchAsync(CatalogQueryOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists published services.
+    /// </summary>
+    /// <param name="options">Filter, sort, and paging options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Published services.</returns>
+    Task<IReadOnlyList<CatalogService>> ListServicesAsync(CatalogQueryOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets one published service by name.
+    /// </summary>
+    /// <param name="serviceName">Service name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The service detail, or <c>null</c> when it is not found.</returns>
+    Task<CatalogService?> GetServiceAsync(string serviceName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists layers discovered from service metadata.
+    /// </summary>
+    /// <param name="options">Filter, sort, and paging options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Catalog layer details.</returns>
+    Task<IReadOnlyList<CatalogLayer>> ListLayersAsync(CatalogQueryOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets one layer by service name and layer ID.
+    /// </summary>
+    /// <param name="serviceName">Service name.</param>
+    /// <param name="layerId">Layer ID within the service.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The layer detail, or <c>null</c> when it is not found.</returns>
+    Task<CatalogLayer?> GetLayerAsync(string serviceName, int layerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists metadata-backed catalog groups.
+    /// </summary>
+    /// <param name="options">Filter, sort, and paging options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Catalog groups.</returns>
+    Task<IReadOnlyList<CatalogGroup>> ListGroupsAsync(CatalogQueryOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets one metadata-backed catalog group.
+    /// </summary>
+    /// <param name="ns">Metadata namespace.</param>
+    /// <param name="name">Group name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The group, or <c>null</c> when it is not found.</returns>
+    Task<CatalogGroup?> GetGroupAsync(string ns, string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Lists metadata-backed saved SDK source descriptors.
+    /// </summary>
+    /// <param name="options">Filter, sort, and paging options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Saved SDK source descriptors.</returns>
+    Task<IReadOnlyList<CatalogSourceDescriptor>> ListSourceDescriptorsAsync(CatalogQueryOptions? options = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets one metadata-backed saved SDK source descriptor.
+    /// </summary>
+    /// <param name="ns">Metadata namespace.</param>
+    /// <param name="name">Descriptor name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The source descriptor, or <c>null</c> when it is not found.</returns>
+    Task<CatalogSourceDescriptor?> GetSourceDescriptorAsync(string ns, string name, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Admin.Catalog;
 using Honua.Sdk.Admin.Geocoding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -29,6 +30,38 @@ public static class ServiceCollectionExtensions
         services.Configure(configure);
         services.AddTransient<HonuaAdminAuthHandler>();
         var httpBuilder = services.AddHttpClient<IHonuaAdminClient, HonuaAdminClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
+            HonuaAdminClientOptions.ValidateBaseAddress(options.BaseAddress);
+            HonuaAdminClientOptions.ValidateTimeout(options.Timeout);
+            client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
+        })
+        .AddHttpMessageHandler<HonuaAdminAuthHandler>();
+        httpBuilder.AddTypedClient<IHonuaCatalogClient>(httpClient => new HonuaCatalogClient(httpClient));
+        ConfigurePrimaryHandler(httpBuilder, configure);
+        ConfigureResilience(httpBuilder, configure);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Honua catalog discovery client with the DI container.
+    /// Uses the same <see cref="HonuaAdminClientOptions"/> and <see cref="HonuaAdminAuthHandler"/>
+    /// as the Admin client for authentication and base address configuration.
+    /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    /// <param name="configure">Configuration delegate for client options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaCatalog(
+        this IServiceCollection services,
+        Action<HonuaAdminClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.Configure(configure);
+        services.AddTransient<HonuaAdminAuthHandler>();
+        var httpBuilder = services.AddHttpClient<IHonuaCatalogClient, HonuaCatalogClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             HonuaAdminClientOptions.ValidateBaseAddress(options.BaseAddress);

--- a/src/Honua.Sdk.Admin/HonuaAdminJsonContext.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminJsonContext.cs
@@ -3,6 +3,8 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Admin.Catalog;
 using Honua.Sdk.Admin.Models;
 
 namespace Honua.Sdk.Admin;
@@ -14,6 +16,9 @@ namespace Honua.Sdk.Admin;
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 [JsonSerializable(typeof(ApiResponse<ServiceSummary[]>))]
+[JsonSerializable(typeof(CatalogFeatureServerServiceInfo))]
+[JsonSerializable(typeof(CatalogFeatureServerLayerInfo))]
+[JsonSerializable(typeof(SourceDescriptor))]
 [JsonSerializable(typeof(ApiResponse<ServiceSettingsResponse>))]
 [JsonSerializable(typeof(ApiResponse<LayerMetadataResponse>))]
 [JsonSerializable(typeof(ApiResponse<SecureConnectionSummary[]>))]

--- a/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Net;
+using Honua.Sdk.Admin.Catalog;
+using Honua.Sdk.Admin.Tests.Fixtures;
+
+namespace Honua.Sdk.Admin.Tests;
+
+public sealed class CatalogClientTests
+{
+    private static HonuaCatalogClient CreateCatalogClient(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+    {
+        var mockHandler = new MockHttpHandler(handler);
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+        return new HonuaCatalogClient(httpClient);
+    }
+
+    [Fact]
+    public async Task SearchAsync_ReturnsServicesLayersGroupsAndSavedSourceDescriptors()
+    {
+        var client = CreateCatalogClient(req =>
+        {
+            var pathAndQuery = req.RequestUri!.PathAndQuery;
+            return pathAndQuery switch
+            {
+                "/api/v1/admin/metadata/resources?kind=Service" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    MetadataResource("Service", "default", "parks", labels: new Dictionary<string, string>
+                    {
+                        ["tags"] = "public,reference",
+                        ["owner"] = "gis"
+                    })
+                })),
+                "/api/v1/admin/metadata/resources?kind=Layer" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    MetadataResource(
+                        "Layer",
+                        "default",
+                        "parks-layer",
+                        new { serviceName = "parks", layerId = 0, description = "Park asset layer" },
+                        new Dictionary<string, string> { ["tags"] = "public", ["owner"] = "gis" })
+                })),
+                "/api/v1/admin/metadata/resources?kind=Group" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    MetadataResource(
+                        "Group",
+                        "default",
+                        "field-ops",
+                        new { description = "Field operations catalog group" },
+                        new Dictionary<string, string> { ["tags"] = "operations", ["owner"] = "gis" })
+                })),
+                "/api/v1/admin/metadata/resources?kind=SourceDescriptor" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    MetadataResource(
+                        "SourceDescriptor",
+                        "default",
+                        "parks-source",
+                        new
+                        {
+                            sourceDescriptor = new
+                            {
+                                id = "parks-source",
+                                protocol = "geoservices-feature-service",
+                                locator = new { serviceId = "parks", layerId = 0 },
+                                capabilities = new[] { "Query" }
+                            }
+                        },
+                        new Dictionary<string, string> { ["tags"] = "saved", ["owner"] = "gis" })
+                })),
+                "/api/v1/admin/services/" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    new
+                    {
+                        serviceName = "parks",
+                        description = "Parks service",
+                        layerCount = 1,
+                        enabledProtocols = new[] { "FeatureServer", "MapServer" }
+                    }
+                })),
+                "/rest/services/parks/FeatureServer?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    serviceDescription = "Parks FeatureServer",
+                    capabilities = "Query,Extract",
+                    fullExtent = new
+                    {
+                        xmin = -158.3,
+                        ymin = 21.2,
+                        xmax = -157.6,
+                        ymax = 21.8,
+                        spatialReference = new { wkid = 4326, latestWkid = 4326 }
+                    },
+                    layers = new[] { new { id = 0, name = "Parks" } }
+                })),
+                "/rest/services/parks/FeatureServer/0?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    id = 0,
+                    name = "Parks",
+                    description = "Park points",
+                    geometryType = "esriGeometryPoint",
+                    capabilities = "Query,Create,Update",
+                    hasAttachments = true,
+                    supportsStatistics = true,
+                    objectIdField = "OBJECTID",
+                    extent = new
+                    {
+                        xmin = -158.1,
+                        ymin = 21.3,
+                        xmax = -157.7,
+                        ymax = 21.6,
+                        spatialReference = new { wkid = 4326, latestWkid = 4326 }
+                    }
+                })),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("""{"message":"not found"}""")
+                })
+            };
+        });
+
+        var result = await client.SearchAsync();
+
+        Assert.Equal(4, result.TotalCount);
+        Assert.Null(result.NextOffset);
+
+        var service = Assert.Single(result.Items, item => item.Kind == CatalogItemKind.Service);
+        Assert.Equal("parks", service.Service!.Name);
+        Assert.Contains("MapServer", service.ServiceTypes);
+        Assert.Equal("gis", service.Owner);
+
+        var layer = Assert.Single(result.Items, item => item.Kind == CatalogItemKind.Layer);
+        Assert.Equal("Parks", layer.Layer!.Name);
+        Assert.Equal("Point", layer.GeometryType);
+        Assert.Contains("Attachments", layer.Capabilities);
+        Assert.Equal("parks", layer.Layer.SourceDescriptor.Locator.ServiceId);
+        Assert.Equal(0, layer.Layer.SourceDescriptor.Locator.LayerId);
+
+        var group = Assert.Single(result.Items, item => item.Kind == CatalogItemKind.Group);
+        Assert.Equal("field-ops", group.Group!.Name);
+
+        var descriptor = Assert.Single(result.Items, item => item.Kind == CatalogItemKind.SourceDescriptor);
+        Assert.Equal("parks-source", descriptor.SourceDescriptor!.Descriptor.Id);
+    }
+
+    [Fact]
+    public async Task SearchAsync_FiltersAndPaginatesCatalogItems()
+    {
+        var client = CreateCatalogClient(req =>
+        {
+            var pathAndQuery = req.RequestUri!.PathAndQuery;
+            return pathAndQuery switch
+            {
+                "/api/v1/admin/metadata/resources?kind=Service" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/metadata/resources?kind=Layer" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    MetadataResource(
+                        "Layer",
+                        "default",
+                        "parks-layer",
+                        new { serviceName = "parks", layerId = 0 },
+                        new Dictionary<string, string> { ["tags"] = "public" })
+                })),
+                "/api/v1/admin/metadata/resources?kind=Group" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/metadata/resources?kind=SourceDescriptor" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/services/" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    new
+                    {
+                        serviceName = "parks",
+                        description = "Parks service",
+                        layerCount = 1,
+                        enabledProtocols = new[] { "FeatureServer" }
+                    }
+                })),
+                "/rest/services/parks/FeatureServer?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    capabilities = "Query",
+                    layers = new[] { new { id = 0, name = "Parks" } }
+                })),
+                "/rest/services/parks/FeatureServer/0?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    id = 0,
+                    name = "Parks",
+                    geometryType = "esriGeometryPoint",
+                    capabilities = "Query",
+                    hasAttachments = true
+                })),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("""{"message":"not found"}""")
+                })
+            };
+        });
+
+        var result = await client.SearchAsync(new CatalogQueryOptions
+        {
+            Kinds = [CatalogItemKind.Layer],
+            Query = "park",
+            ServiceTypes = ["FeatureServer"],
+            Tags = ["public"],
+            GeometryTypes = ["Point"],
+            Capabilities = ["Attachments"],
+            Limit = 1
+        });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal(CatalogItemKind.Layer, item.Kind);
+        Assert.Equal(1, result.TotalCount);
+        Assert.Null(result.NextOffset);
+    }
+
+    [Fact]
+    public async Task GetSourceDescriptorAsync_ReturnsNullForMissingResource()
+    {
+        var client = CreateCatalogClient(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("""{"message":"Resource not found."}""")
+        }));
+
+        var result = await client.GetSourceDescriptorAsync("default", "missing");
+
+        Assert.Null(result);
+    }
+
+    private static object MetadataResource(
+        string kind,
+        string ns,
+        string name,
+        object? spec = null,
+        Dictionary<string, string>? labels = null)
+        => new
+        {
+            apiVersion = "honua.io/v1alpha1",
+            kind,
+            metadata = new
+            {
+                id = $"{ns}/{kind}/{name}",
+                name,
+                @namespace = ns,
+                labels,
+                createdAt = DateTimeOffset.Parse("2026-04-30T00:00:00Z", CultureInfo.InvariantCulture)
+            },
+            spec = spec ?? new { description = $"{name} description" }
+        };
+}

--- a/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/ClientOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Reflection;
+using Honua.Sdk.Admin.Catalog;
 using Honua.Sdk.Admin.Extensions;
 using Honua.Sdk.Admin.Geocoding;
 using Honua.Sdk.Admin.Tests.Fixtures;
@@ -69,6 +70,24 @@ public sealed class ClientOptionsTests
         var client = provider.GetRequiredService<IHonuaBatchGeocodingClient>();
 
         Assert.IsType<HonuaGeocodingClient>(client);
+    }
+
+    [Fact]
+    public void AddHonuaCatalog_ConfiguresHttpClientTimeout()
+    {
+        var timeout = TimeSpan.FromSeconds(39);
+        var services = new ServiceCollection();
+        services.AddHonuaCatalog(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+            options.Timeout = timeout;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHonuaCatalogClient>();
+
+        Assert.Equal(timeout, GetHttpClient(client, "_http").Timeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- adds `IHonuaCatalogClient` and catalog discovery models under `Honua.Sdk.Admin.Catalog`
- aggregates existing admin service summaries, FeatureServer service/layer metadata, and metadata resources into searchable service/layer/group/source-descriptor items
- supports query filtering, kind/service/tag/owner/namespace/geometry/capability filters, sorting, paging, and DI registration via `AddHonuaAdmin`/`AddHonuaCatalog`
- documents metadata-backed groups/source descriptors and links the typed server contract follow-up

Closes #58.
Depends on honua-io/honua-server#869 for first-class typed group/source descriptor contracts.

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj --configuration Release --no-restore`
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `scripts/validate-api-compat.sh origin/trunk`
