### PR TITLE
feat: add feature stream contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Official .NET client libraries for [Honua](https://github.com/honua-io/honua-ser
 an open-source geospatial feature server. The SDK provides typed clients for
 querying and editing features over gRPC, querying via OGC WFS 2.0, managing
 services through the Admin REST API, geocoding addresses, and reading features
-through GeoServices FeatureServer, OGC API Features, and scene metadata
-endpoints.
+through GeoServices FeatureServer, OGC API Features, scene metadata endpoints,
+and shared real-time feature stream contracts.
 
 ## Packages
 
 | Package | Description |
 |---------|-------------|
-| **Honua.Sdk.Abstractions** | Shared feature query/edit abstractions implemented by provider-specific clients |
+| **Honua.Sdk.Abstractions** | Shared feature query/edit/stream abstractions implemented by provider-specific clients |
 | **Honua.Sdk.Offline.Abstractions** | Browser-safe offline manifests, sync state, checkpoints, conflicts, and storage contracts |
 | **Honua.Sdk.Offline** | Provider-neutral offline push/pull planner and sync engine over the shared feature abstractions |
 | **Honua.Sdk.Grpc** | gRPC client for `FeatureService` -- typed queries, streaming, edits, spatial filters |
@@ -208,6 +208,15 @@ var result = await edits.ApplyEditsAsync(new FeatureEditRequest
 
 See [docs/feature-edits.md](docs/feature-edits.md) for shared result models,
 provider support, and unsupported-provider behavior.
+
+## Shared stream abstraction
+
+Real-time feature feed clients use `IHonuaFeatureStreamClient` from
+`Honua.Sdk.Abstractions`. The contract covers connect, reconnect, heartbeat,
+subscribe, and unsubscribe workflows; normalizes insert/update/delete event
+envelopes; and includes bounded buffering plus duplicate/stale sequence
+rejection helpers. Concrete Honua Server transport wiring depends on
+honua-server#339 and honua-server#692.
 
 ## Offline sync core
 

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -104,6 +104,15 @@ capabilities are available through `IHonuaFeatureEditClient`; gRPC,
 GeoServices FeatureServer, and OGC API Features currently advertise write
 support, while WFS reports unsupported edit capabilities with a reason.
 
+Shared real-time feed contracts are available through
+`IHonuaFeatureStreamClient` in `Honua.Sdk.Abstractions`. The SDK normalizes
+connect, reconnect, heartbeat, subscribe, unsubscribe, insert, update, and
+delete envelopes with source IDs, feature IDs, timestamps, geometry, attributes,
+sequence numbers, and sequence tokens. `FeatureStreamEventProcessor` rejects
+duplicate and stale sequence events, and `FeatureStreamEventBuffer` provides
+bounded backpressure behavior. Concrete server transport wiring remains tied to
+`honua-server#339` and `honua-server#692`.
+
 `Honua.Sdk.Abstractions` also exposes the source-oriented facade used for
 cross-provider application code: `SourceDescriptor`, `SourceLocator`,
 `SourceQuery`, `IHonuaSource`, and `HonuaSource`. It wraps the existing

--- a/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventBuffer.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventBuffer.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Outcome returned when a feature stream event is written to a bounded buffer.
+/// </summary>
+public enum FeatureStreamBufferWriteDecision
+{
+    /// <summary>The event was accepted into the buffer.</summary>
+    Accepted = 0,
+
+    /// <summary>The event was rejected by sequence tracking as a duplicate.</summary>
+    DuplicateSequence = 1,
+
+    /// <summary>The event was rejected by sequence tracking as stale.</summary>
+    StaleSequence = 2,
+
+    /// <summary>The buffer was full and the configured policy rejects incoming events.</summary>
+    BackpressureRejected = 3,
+
+    /// <summary>The buffer was full and the configured policy dropped the incoming event.</summary>
+    DroppedNewest = 4,
+
+    /// <summary>The buffer has been completed and does not accept new events.</summary>
+    Completed = 5
+}
+
+/// <summary>
+/// Result from writing a feature stream event to a bounded buffer.
+/// </summary>
+public sealed record FeatureStreamBufferWriteResult
+{
+    /// <summary>Write decision.</summary>
+    public required FeatureStreamBufferWriteDecision Decision { get; init; }
+
+    /// <summary>Whether the incoming event was accepted into the buffer.</summary>
+    public bool Accepted => Decision == FeatureStreamBufferWriteDecision.Accepted;
+
+    /// <summary>Whether an older buffered event was dropped to accept the incoming event.</summary>
+    public bool DroppedOldest { get; init; }
+
+    /// <summary>Sequence processing result, when a processor was configured.</summary>
+    public FeatureStreamEventProcessResult? SequenceResult { get; init; }
+}
+
+/// <summary>
+/// Browser-safe bounded buffer for normalized feature stream events.
+/// </summary>
+public sealed class FeatureStreamEventBuffer : IDisposable
+{
+    private readonly FeatureStreamBackpressureOptions _options;
+    private readonly FeatureStreamEventProcessor? _processor;
+    private readonly Queue<FeatureStreamEvent> _queue = new();
+    private readonly SemaphoreSlim _items = new(0);
+    private readonly SemaphoreSlim _space;
+    private readonly object _gate = new();
+    private bool _completed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FeatureStreamEventBuffer"/> class.
+    /// </summary>
+    /// <param name="options">Bounded buffer options.</param>
+    /// <param name="processor">Optional sequence processor used before events enter the buffer.</param>
+    public FeatureStreamEventBuffer(
+        FeatureStreamBackpressureOptions? options = null,
+        FeatureStreamEventProcessor? processor = null)
+    {
+        _options = NormalizeOptions(options);
+        _processor = processor;
+        _space = new SemaphoreSlim(_options.Capacity, _options.Capacity);
+    }
+
+    /// <summary>
+    /// Attempts to write an event without waiting for buffer capacity.
+    /// </summary>
+    /// <param name="featureEvent">Event to write.</param>
+    /// <returns>Write result.</returns>
+    public FeatureStreamBufferWriteResult TryWrite(FeatureStreamEvent featureEvent)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        var sequenceResult = ProcessSequence(featureEvent);
+        if (sequenceResult is not null && !sequenceResult.Accepted)
+        {
+            return SequenceRejected(sequenceResult);
+        }
+
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return new FeatureStreamBufferWriteResult
+                {
+                    Decision = FeatureStreamBufferWriteDecision.Completed,
+                    SequenceResult = sequenceResult
+                };
+            }
+
+            if (_queue.Count >= _options.Capacity)
+            {
+                return _options.Mode switch
+                {
+                    FeatureStreamBackpressureMode.DropOldest => EnqueueDroppingOldest(featureEvent, sequenceResult),
+                    FeatureStreamBackpressureMode.DropNewest => new FeatureStreamBufferWriteResult
+                    {
+                        Decision = FeatureStreamBufferWriteDecision.DroppedNewest,
+                        SequenceResult = sequenceResult
+                    },
+                    _ => new FeatureStreamBufferWriteResult
+                    {
+                        Decision = FeatureStreamBufferWriteDecision.BackpressureRejected,
+                        SequenceResult = sequenceResult
+                    }
+                };
+            }
+
+            if (_options.Mode == FeatureStreamBackpressureMode.Wait && !_space.Wait(0))
+            {
+                return new FeatureStreamBufferWriteResult
+                {
+                    Decision = FeatureStreamBufferWriteDecision.BackpressureRejected,
+                    SequenceResult = sequenceResult
+                };
+            }
+
+            _queue.Enqueue(featureEvent);
+            _items.Release();
+            return new FeatureStreamBufferWriteResult
+            {
+                Decision = FeatureStreamBufferWriteDecision.Accepted,
+                SequenceResult = sequenceResult
+            };
+        }
+    }
+
+    /// <summary>
+    /// Writes an event, waiting for capacity when the mode is <see cref="FeatureStreamBackpressureMode.Wait"/>.
+    /// </summary>
+    /// <param name="featureEvent">Event to write.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Write result.</returns>
+    public async ValueTask<FeatureStreamBufferWriteResult> WriteAsync(
+        FeatureStreamEvent featureEvent,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        if (_options.Mode != FeatureStreamBackpressureMode.Wait)
+        {
+            return TryWrite(featureEvent);
+        }
+
+        var sequenceResult = ProcessSequence(featureEvent);
+        if (sequenceResult is not null && !sequenceResult.Accepted)
+        {
+            return SequenceRejected(sequenceResult);
+        }
+
+        await _space.WaitAsync(ct).ConfigureAwait(false);
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                _space.Release();
+                return new FeatureStreamBufferWriteResult
+                {
+                    Decision = FeatureStreamBufferWriteDecision.Completed,
+                    SequenceResult = sequenceResult
+                };
+            }
+
+            _queue.Enqueue(featureEvent);
+            _items.Release();
+            return new FeatureStreamBufferWriteResult
+            {
+                Decision = FeatureStreamBufferWriteDecision.Accepted,
+                SequenceResult = sequenceResult
+            };
+        }
+    }
+
+    /// <summary>
+    /// Reads buffered events until the buffer is completed or cancellation is requested.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Buffered events.</returns>
+    public async IAsyncEnumerable<FeatureStreamEvent> ReadAllAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        while (true)
+        {
+            await _items.WaitAsync(ct).ConfigureAwait(false);
+
+            FeatureStreamEvent? featureEvent = null;
+            var completeAfterYield = false;
+            var shouldStop = false;
+            lock (_gate)
+            {
+                if (_queue.Count == 0)
+                {
+                    shouldStop = _completed;
+                }
+                else
+                {
+                    featureEvent = _queue.Dequeue();
+                    if (_options.Mode == FeatureStreamBackpressureMode.Wait)
+                    {
+                        _space.Release();
+                    }
+
+                    completeAfterYield = _completed && _queue.Count == 0;
+                }
+            }
+
+            if (shouldStop)
+            {
+                yield break;
+            }
+
+            if (featureEvent is null)
+            {
+                continue;
+            }
+
+            yield return featureEvent;
+            if (completeAfterYield)
+            {
+                yield break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Completes the buffer and wakes pending readers.
+    /// </summary>
+    public void Complete()
+    {
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            _completed = true;
+            if (_queue.Count == 0)
+            {
+                _items.Release();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Completes the buffer and releases synchronization resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Complete();
+        _items.Dispose();
+        _space.Dispose();
+    }
+
+    private FeatureStreamBufferWriteResult EnqueueDroppingOldest(
+        FeatureStreamEvent featureEvent,
+        FeatureStreamEventProcessResult? sequenceResult)
+    {
+        _queue.Dequeue();
+        _queue.Enqueue(featureEvent);
+        return new FeatureStreamBufferWriteResult
+        {
+            Decision = FeatureStreamBufferWriteDecision.Accepted,
+            DroppedOldest = true,
+            SequenceResult = sequenceResult
+        };
+    }
+
+    private FeatureStreamEventProcessResult? ProcessSequence(FeatureStreamEvent featureEvent)
+        => _processor?.Process(featureEvent);
+
+    private static FeatureStreamBufferWriteResult SequenceRejected(FeatureStreamEventProcessResult sequenceResult)
+        => new()
+        {
+            Decision = sequenceResult.Decision == FeatureStreamEventDecision.DuplicateSequence
+                ? FeatureStreamBufferWriteDecision.DuplicateSequence
+                : FeatureStreamBufferWriteDecision.StaleSequence,
+            SequenceResult = sequenceResult
+        };
+
+    private static FeatureStreamBackpressureOptions NormalizeOptions(FeatureStreamBackpressureOptions? options)
+    {
+        var normalized = options ?? new FeatureStreamBackpressureOptions();
+        if (normalized.Capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Feature stream buffer capacity must be greater than zero.");
+        }
+
+        return normalized;
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventProcessor.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventProcessor.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Outcome returned when a feature stream event is accepted or rejected by sequence tracking.
+/// </summary>
+public enum FeatureStreamEventDecision
+{
+    /// <summary>The event was accepted.</summary>
+    Accepted = 0,
+
+    /// <summary>The event repeats the last accepted sequence number or sequence token.</summary>
+    DuplicateSequence = 1,
+
+    /// <summary>The event is older than the last accepted sequence number.</summary>
+    StaleSequence = 2
+}
+
+/// <summary>
+/// Result from applying sequence tracking to a feature stream event.
+/// </summary>
+public sealed record FeatureStreamEventProcessResult
+{
+    /// <summary>Sequence decision for the event.</summary>
+    public required FeatureStreamEventDecision Decision { get; init; }
+
+    /// <summary>Whether the event should be delivered to consumers.</summary>
+    public bool Accepted => Decision == FeatureStreamEventDecision.Accepted;
+
+    /// <summary>Last accepted monotonic sequence number for the event stream key.</summary>
+    public long? LastSequenceNumber { get; init; }
+
+    /// <summary>Last accepted sequence token for the event stream key.</summary>
+    public string? LastSequenceToken { get; init; }
+}
+
+/// <summary>
+/// Tracks feature stream sequence state and rejects duplicate or stale events.
+/// </summary>
+public sealed class FeatureStreamEventProcessor
+{
+    private readonly Dictionary<string, StreamCursor> _cursors = new(StringComparer.Ordinal);
+    private readonly object _gate = new();
+
+    /// <summary>
+    /// Applies sequence tracking to a normalized feature stream event.
+    /// </summary>
+    /// <param name="featureEvent">Event to evaluate.</param>
+    /// <returns>Processing decision and the current cursor state.</returns>
+    public FeatureStreamEventProcessResult Process(FeatureStreamEvent featureEvent)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        lock (_gate)
+        {
+            var key = GetCursorKey(featureEvent);
+            if (!_cursors.TryGetValue(key, out var cursor))
+            {
+                cursor = new StreamCursor();
+                _cursors.Add(key, cursor);
+            }
+
+            if (featureEvent.SequenceNumber.HasValue)
+            {
+                var sequenceNumber = featureEvent.SequenceNumber.Value;
+                if (cursor.LastSequenceNumber.HasValue)
+                {
+                    if (sequenceNumber == cursor.LastSequenceNumber.Value)
+                    {
+                        return ToResult(FeatureStreamEventDecision.DuplicateSequence, cursor);
+                    }
+
+                    if (sequenceNumber < cursor.LastSequenceNumber.Value)
+                    {
+                        return ToResult(FeatureStreamEventDecision.StaleSequence, cursor);
+                    }
+                }
+
+                cursor.LastSequenceNumber = sequenceNumber;
+                cursor.LastSequenceToken = featureEvent.SequenceToken ?? cursor.LastSequenceToken;
+                return ToResult(FeatureStreamEventDecision.Accepted, cursor);
+            }
+
+            if (!string.IsNullOrWhiteSpace(featureEvent.SequenceToken) &&
+                string.Equals(featureEvent.SequenceToken, cursor.LastSequenceToken, StringComparison.Ordinal))
+            {
+                return ToResult(FeatureStreamEventDecision.DuplicateSequence, cursor);
+            }
+
+            cursor.LastSequenceToken = featureEvent.SequenceToken ?? cursor.LastSequenceToken;
+            return ToResult(FeatureStreamEventDecision.Accepted, cursor);
+        }
+    }
+
+    /// <summary>
+    /// Clears all tracked stream cursors.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            _cursors.Clear();
+        }
+    }
+
+    private static FeatureStreamEventProcessResult ToResult(
+        FeatureStreamEventDecision decision,
+        StreamCursor cursor)
+        => new()
+        {
+            Decision = decision,
+            LastSequenceNumber = cursor.LastSequenceNumber,
+            LastSequenceToken = cursor.LastSequenceToken
+        };
+
+    private static string GetCursorKey(FeatureStreamEvent featureEvent)
+        => string.Join(
+            "|",
+            featureEvent.SubscriptionId,
+            featureEvent.Source.ServiceId ?? string.Empty,
+            featureEvent.Source.LayerId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            featureEvent.Source.CollectionId ?? string.Empty,
+            featureEvent.Source.TypeName ?? string.Empty);
+
+    private sealed class StreamCursor
+    {
+        public long? LastSequenceNumber { get; set; }
+
+        public string? LastSequenceToken { get; set; }
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Features/FeatureStreamModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureStreamModels.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Provider stream capabilities exposed through the shared feature stream abstraction.
+/// </summary>
+public sealed record FeatureStreamCapabilities
+{
+    /// <summary>Whether the provider supports opening real-time feature streams.</summary>
+    public bool SupportsConnect { get; init; }
+
+    /// <summary>Whether the provider supports reconnecting with resume or sequence tokens.</summary>
+    public bool SupportsReconnect { get; init; }
+
+    /// <summary>Whether the provider supports heartbeat messages.</summary>
+    public bool SupportsHeartbeat { get; init; }
+
+    /// <summary>Whether the provider supports explicit subscribe messages after connection.</summary>
+    public bool SupportsSubscribe { get; init; }
+
+    /// <summary>Whether the provider supports explicit unsubscribe messages.</summary>
+    public bool SupportsUnsubscribe { get; init; }
+
+    /// <summary>Whether the provider supplies monotonic sequence numbers.</summary>
+    public bool SupportsSequenceNumbers { get; init; }
+
+    /// <summary>Whether the provider supplies opaque resume tokens.</summary>
+    public bool SupportsResumeTokens { get; init; }
+
+    /// <summary>Whether the provider can honor bounded-buffer backpressure hints.</summary>
+    public bool SupportsBackpressure { get; init; }
+
+    /// <summary>Native protocol surface used by the provider, when useful for diagnostics.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason streams are unsupported when no stream operation is available.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Stream connection lifecycle state.
+/// </summary>
+public enum FeatureStreamConnectionState
+{
+    /// <summary>Connection state is unknown.</summary>
+    Unknown = 0,
+
+    /// <summary>Connection is open.</summary>
+    Connected = 1,
+
+    /// <summary>Connection is reconnecting.</summary>
+    Reconnecting = 2,
+
+    /// <summary>Connection is closed normally.</summary>
+    Closed = 3,
+
+    /// <summary>Connection failed.</summary>
+    Failed = 4
+}
+
+/// <summary>
+/// Feature stream event kind.
+/// </summary>
+public enum FeatureStreamEventKind
+{
+    /// <summary>Event kind is unknown.</summary>
+    Unknown = 0,
+
+    /// <summary>A feature was inserted.</summary>
+    Insert = 1,
+
+    /// <summary>A feature was updated.</summary>
+    Update = 2,
+
+    /// <summary>A feature was deleted.</summary>
+    Delete = 3,
+
+    /// <summary>A provider heartbeat was observed.</summary>
+    Heartbeat = 4,
+
+    /// <summary>A subscription was acknowledged.</summary>
+    Subscribed = 5,
+
+    /// <summary>A subscription was removed.</summary>
+    Unsubscribed = 6,
+
+    /// <summary>The provider reported a stream error as an event.</summary>
+    Error = 7
+}
+
+/// <summary>
+/// Bounded-buffer behavior used when a feature stream producer is faster than its consumer.
+/// </summary>
+public enum FeatureStreamBackpressureMode
+{
+    /// <summary>Wait for buffer capacity before accepting another event.</summary>
+    Wait = 0,
+
+    /// <summary>Reject the incoming event when the buffer is full.</summary>
+    Reject = 1,
+
+    /// <summary>Drop the oldest buffered event and enqueue the incoming event.</summary>
+    DropOldest = 2,
+
+    /// <summary>Drop the incoming event when the buffer is full.</summary>
+    DropNewest = 3
+}
+
+/// <summary>
+/// Options for bounded real-time feature stream buffers.
+/// </summary>
+public sealed record FeatureStreamBackpressureOptions
+{
+    /// <summary>Default bounded buffer capacity.</summary>
+    public const int DefaultCapacity = 256;
+
+    /// <summary>Maximum number of events to buffer before backpressure applies.</summary>
+    public int Capacity { get; init; } = DefaultCapacity;
+
+    /// <summary>Behavior to apply when the buffer is full.</summary>
+    public FeatureStreamBackpressureMode Mode { get; init; } = FeatureStreamBackpressureMode.Wait;
+}
+
+/// <summary>
+/// Request to open a feature stream connection.
+/// </summary>
+public sealed record FeatureStreamConnectRequest
+{
+    /// <summary>Optional client-provided connection identifier for diagnostics.</summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>Initial subscriptions to attach when the provider supports subscribe-on-connect.</summary>
+    public IReadOnlyList<FeatureStreamSubscribeRequest> Subscriptions { get; init; } = [];
+
+    /// <summary>Requested heartbeat interval.</summary>
+    public TimeSpan? HeartbeatInterval { get; init; }
+
+    /// <summary>Requested bounded-buffer behavior.</summary>
+    public FeatureStreamBackpressureOptions Backpressure { get; init; } = new();
+}
+
+/// <summary>
+/// Request to reconnect a feature stream connection.
+/// </summary>
+public sealed record FeatureStreamReconnectRequest
+{
+    /// <summary>Provider connection identifier to resume.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Provider resume token from the last accepted event or heartbeat.</summary>
+    public string? ResumeToken { get; init; }
+
+    /// <summary>Last accepted monotonic sequence number.</summary>
+    public long? LastSequenceNumber { get; init; }
+
+    /// <summary>Subscriptions that should be active after reconnect.</summary>
+    public IReadOnlyList<FeatureStreamSubscribeRequest> Subscriptions { get; init; } = [];
+
+    /// <summary>Requested bounded-buffer behavior after reconnect.</summary>
+    public FeatureStreamBackpressureOptions Backpressure { get; init; } = new();
+}
+
+/// <summary>
+/// Provider-neutral feature stream connection state.
+/// </summary>
+public sealed record FeatureStreamConnection
+{
+    /// <summary>Provider connection identifier.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Current connection state.</summary>
+    public FeatureStreamConnectionState State { get; init; } = FeatureStreamConnectionState.Connected;
+
+    /// <summary>Time when the provider established the connection.</summary>
+    public DateTimeOffset ConnectedAt { get; init; }
+
+    /// <summary>Time when the connection or resume token expires, when known.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>Provider resume token for reconnect workflows.</summary>
+    public string? ResumeToken { get; init; }
+
+    /// <summary>Last accepted monotonic sequence number.</summary>
+    public long? LastSequenceNumber { get; init; }
+
+    /// <summary>Provider heartbeat interval for this connection.</summary>
+    public TimeSpan? HeartbeatInterval { get; init; }
+}
+
+/// <summary>
+/// Request to subscribe to feature events.
+/// </summary>
+public sealed record FeatureStreamSubscribeRequest
+{
+    /// <summary>Client or provider subscription identifier.</summary>
+    public required string SubscriptionId { get; init; }
+
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Filter expression in the language specified by <see cref="FilterLanguage"/>.</summary>
+    public string? Filter { get; init; }
+
+    /// <summary>Filter language. <see cref="FeatureFilterLanguage.ProviderDefault"/> uses the provider's native default.</summary>
+    public FeatureFilterLanguage FilterLanguage { get; init; } = FeatureFilterLanguage.ProviderDefault;
+
+    /// <summary>Fields/properties to include in streamed feature payloads.</summary>
+    public IReadOnlyList<string>? OutFields { get; init; }
+
+    /// <summary>Whether streamed insert/update events should include geometry.</summary>
+    public bool? ReturnGeometry { get; init; }
+
+    /// <summary>Optional bounding box spatial filter.</summary>
+    public FeatureBoundingBox? Bbox { get; init; }
+
+    /// <summary>Optional time instant or interval filter.</summary>
+    public FeatureTimeFilter? TimeFilter { get; init; }
+
+    /// <summary>Resume after this provider sequence number when supported.</summary>
+    public long? StartAfterSequenceNumber { get; init; }
+
+    /// <summary>Resume after this provider sequence token when supported.</summary>
+    public string? StartAfterSequenceToken { get; init; }
+}
+
+/// <summary>
+/// Request to remove a feature stream subscription.
+/// </summary>
+public sealed record FeatureStreamUnsubscribeRequest
+{
+    /// <summary>Provider connection identifier, when the protocol requires it.</summary>
+    public string? ConnectionId { get; init; }
+
+    /// <summary>Subscription identifier to remove.</summary>
+    public required string SubscriptionId { get; init; }
+}
+
+/// <summary>
+/// Request to send or observe a stream heartbeat.
+/// </summary>
+public sealed record FeatureStreamHeartbeatRequest
+{
+    /// <summary>Provider connection identifier.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Last accepted monotonic sequence number.</summary>
+    public long? LastSequenceNumber { get; init; }
+
+    /// <summary>Last provider sequence token.</summary>
+    public string? LastSequenceToken { get; init; }
+
+    /// <summary>Last provider resume token.</summary>
+    public string? ResumeToken { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral stream heartbeat state.
+/// </summary>
+public sealed record FeatureStreamHeartbeat
+{
+    /// <summary>Provider connection identifier.</summary>
+    public required string ConnectionId { get; init; }
+
+    /// <summary>Time when the heartbeat was sent or observed.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Provider resume token for reconnect workflows.</summary>
+    public string? ResumeToken { get; init; }
+
+    /// <summary>Last accepted monotonic sequence number.</summary>
+    public long? LastSequenceNumber { get; init; }
+
+    /// <summary>Last provider sequence token.</summary>
+    public string? LastSequenceToken { get; init; }
+}
+
+/// <summary>
+/// Provider-neutral real-time feature event envelope.
+/// </summary>
+public sealed record FeatureStreamEvent
+{
+    /// <summary>Provider name that produced the event.</summary>
+    public string ProviderName { get; init; } = string.Empty;
+
+    /// <summary>Provider connection identifier, when available.</summary>
+    public string? ConnectionId { get; init; }
+
+    /// <summary>Subscription identifier that produced the event.</summary>
+    public required string SubscriptionId { get; init; }
+
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Normalized event kind.</summary>
+    public required FeatureStreamEventKind Kind { get; init; }
+
+    /// <summary>Provider feature identifier, when available.</summary>
+    public string? FeatureId { get; init; }
+
+    /// <summary>Provider object identifier, when available.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Event timestamp from the provider or adapter.</summary>
+    public required DateTimeOffset Timestamp { get; init; }
+
+    /// <summary>Monotonic provider sequence number, when available.</summary>
+    public long? SequenceNumber { get; init; }
+
+    /// <summary>Opaque provider sequence token, when available.</summary>
+    public string? SequenceToken { get; init; }
+
+    /// <summary>Provider resume token for reconnect workflows.</summary>
+    public string? ResumeToken { get; init; }
+
+    /// <summary>Feature attributes/properties as JSON values.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Attributes { get; init; } =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>Feature geometry as a provider-native JSON object, when supplied.</summary>
+    public JsonElement? Geometry { get; init; }
+
+    /// <summary>Stream error details when <see cref="Kind"/> is <see cref="FeatureStreamEventKind.Error"/>.</summary>
+    public FeatureEditError? Error { get; init; }
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureStreamClient.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureStreamClient.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Shared real-time feature stream contract implemented by stream-capable Honua clients.
+/// </summary>
+public interface IHonuaFeatureStreamClient
+{
+    /// <summary>
+    /// Provider name for diagnostics and provider selection.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Provider stream capabilities exposed by this client.
+    /// </summary>
+    FeatureStreamCapabilities StreamCapabilities { get; }
+
+    /// <summary>
+    /// Opens a stream connection and returns provider-neutral connection state.
+    /// </summary>
+    /// <param name="request">Connection request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral connection state.</returns>
+    Task<FeatureStreamConnection> ConnectAsync(FeatureStreamConnectRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Reopens a stream connection using the last known resume and sequence tokens.
+    /// </summary>
+    /// <param name="request">Reconnect request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral connection state.</returns>
+    Task<FeatureStreamConnection> ReconnectAsync(FeatureStreamReconnectRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribes to feature events and returns a normalized event stream.
+    /// </summary>
+    /// <param name="request">Subscription request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Normalized feature stream events.</returns>
+    IAsyncEnumerable<FeatureStreamEvent> SubscribeAsync(FeatureStreamSubscribeRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Unsubscribes from a feature event subscription.
+    /// </summary>
+    /// <param name="request">Unsubscribe request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task UnsubscribeAsync(FeatureStreamUnsubscribeRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sends or observes a provider heartbeat for an active stream connection.
+    /// </summary>
+    /// <param name="request">Heartbeat request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Provider-neutral heartbeat state.</returns>
+    Task<FeatureStreamHeartbeat> HeartbeatAsync(FeatureStreamHeartbeatRequest request, CancellationToken ct = default);
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/FeatureStreamContractTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/FeatureStreamContractTests.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class FeatureStreamContractTests
+{
+    [Fact]
+    public void Processor_RejectsDuplicateAndStaleSequencesPerSubscription()
+    {
+        var processor = new FeatureStreamEventProcessor();
+
+        var first = processor.Process(Event(sequenceNumber: 10, subscriptionId: "parks"));
+        var duplicate = processor.Process(Event(sequenceNumber: 10, subscriptionId: "parks"));
+        var stale = processor.Process(Event(sequenceNumber: 9, subscriptionId: "parks"));
+        var next = processor.Process(Event(sequenceNumber: 11, subscriptionId: "parks"));
+        var otherSubscription = processor.Process(Event(sequenceNumber: 1, subscriptionId: "roads"));
+
+        Assert.True(first.Accepted);
+        Assert.Equal(FeatureStreamEventDecision.DuplicateSequence, duplicate.Decision);
+        Assert.Equal(FeatureStreamEventDecision.StaleSequence, stale.Decision);
+        Assert.True(next.Accepted);
+        Assert.True(otherSubscription.Accepted);
+        Assert.Equal(11, next.LastSequenceNumber);
+    }
+
+    [Fact]
+    public void Processor_RejectsDuplicateOpaqueSequenceToken()
+    {
+        var processor = new FeatureStreamEventProcessor();
+
+        var first = processor.Process(Event(sequenceToken: "token-1"));
+        var duplicate = processor.Process(Event(sequenceToken: "token-1"));
+        var next = processor.Process(Event(sequenceToken: "token-2"));
+
+        Assert.True(first.Accepted);
+        Assert.Equal(FeatureStreamEventDecision.DuplicateSequence, duplicate.Decision);
+        Assert.True(next.Accepted);
+        Assert.Equal("token-2", next.LastSequenceToken);
+    }
+
+    [Fact]
+    public async Task Buffer_RejectsIncomingEventWhenFull()
+    {
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 1,
+            Mode = FeatureStreamBackpressureMode.Reject
+        });
+
+        var first = buffer.TryWrite(Event("first"));
+        var second = buffer.TryWrite(Event("second"));
+        buffer.Complete();
+
+        var events = await DrainAsync(buffer.ReadAllAsync());
+
+        Assert.True(first.Accepted);
+        Assert.Equal(FeatureStreamBufferWriteDecision.BackpressureRejected, second.Decision);
+        var item = Assert.Single(events);
+        Assert.Equal("first", item.FeatureId);
+    }
+
+    [Fact]
+    public async Task Buffer_DropsOldestWhenConfigured()
+    {
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 1,
+            Mode = FeatureStreamBackpressureMode.DropOldest
+        });
+
+        var first = buffer.TryWrite(Event("first"));
+        var second = buffer.TryWrite(Event("second"));
+        buffer.Complete();
+
+        var events = await DrainAsync(buffer.ReadAllAsync());
+
+        Assert.True(first.Accepted);
+        Assert.True(second.Accepted);
+        Assert.True(second.DroppedOldest);
+        var item = Assert.Single(events);
+        Assert.Equal("second", item.FeatureId);
+    }
+
+    [Fact]
+    public async Task Buffer_AppliesSequenceProcessorBeforeQueueing()
+    {
+        var processor = new FeatureStreamEventProcessor();
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 2,
+            Mode = FeatureStreamBackpressureMode.Reject
+        }, processor);
+
+        var first = buffer.TryWrite(Event("first", sequenceNumber: 1));
+        var duplicate = buffer.TryWrite(Event("first-duplicate", sequenceNumber: 1));
+        buffer.Complete();
+
+        var events = await DrainAsync(buffer.ReadAllAsync());
+
+        Assert.True(first.Accepted);
+        Assert.Equal(FeatureStreamBufferWriteDecision.DuplicateSequence, duplicate.Decision);
+        var item = Assert.Single(events);
+        Assert.Equal("first", item.FeatureId);
+    }
+
+    [Fact]
+    public async Task Interface_ModelsConnectReconnectHeartbeatAndSubscriptionWorkflows()
+    {
+        var client = new FakeStreamClient();
+        var subscription = new FeatureStreamSubscribeRequest
+        {
+            SubscriptionId = "sub-1",
+            Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+            Filter = "status = 'open'",
+            ReturnGeometry = true
+        };
+
+        var connection = await client.ConnectAsync(new FeatureStreamConnectRequest
+        {
+            ClientId = "mobile-1",
+            Subscriptions = [subscription],
+            HeartbeatInterval = TimeSpan.FromSeconds(30),
+            Backpressure = new FeatureStreamBackpressureOptions { Capacity = 32 }
+        });
+        var heartbeat = await client.HeartbeatAsync(new FeatureStreamHeartbeatRequest
+        {
+            ConnectionId = connection.ConnectionId,
+            LastSequenceNumber = 2,
+            ResumeToken = "resume-2"
+        });
+        var reconnected = await client.ReconnectAsync(new FeatureStreamReconnectRequest
+        {
+            ConnectionId = connection.ConnectionId,
+            LastSequenceNumber = heartbeat.LastSequenceNumber,
+            ResumeToken = heartbeat.ResumeToken,
+            Subscriptions = [subscription]
+        });
+        await client.UnsubscribeAsync(new FeatureStreamUnsubscribeRequest
+        {
+            ConnectionId = reconnected.ConnectionId,
+            SubscriptionId = subscription.SubscriptionId
+        });
+
+        var events = await DrainAsync(client.SubscribeAsync(subscription));
+
+        Assert.Equal("fake-stream", client.ProviderName);
+        Assert.True(client.StreamCapabilities.SupportsReconnect);
+        Assert.Equal(FeatureStreamConnectionState.Connected, connection.State);
+        Assert.Equal(2, heartbeat.LastSequenceNumber);
+        Assert.Equal("resume-2", reconnected.ResumeToken);
+        Assert.Equal([FeatureStreamEventKind.Subscribed, FeatureStreamEventKind.Insert], events.Select(item => item.Kind));
+    }
+
+    private static FeatureStreamEvent Event(
+        string featureId = "feature-1",
+        long? sequenceNumber = null,
+        string? sequenceToken = null,
+        string subscriptionId = "sub-1")
+        => new()
+        {
+            ProviderName = "test",
+            SubscriptionId = subscriptionId,
+            Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+            Kind = FeatureStreamEventKind.Update,
+            FeatureId = featureId,
+            Timestamp = Timestamp(),
+            SequenceNumber = sequenceNumber,
+            SequenceToken = sequenceToken
+        };
+
+    private static DateTimeOffset Timestamp(int minute = 0, int second = 0)
+        => new(2026, 4, 30, 0, minute, second, TimeSpan.Zero);
+
+    private static async Task<List<T>> DrainAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var items = new List<T>();
+        await foreach (var item in source)
+        {
+            items.Add(item);
+        }
+
+        return items;
+    }
+
+    private sealed class FakeStreamClient : IHonuaFeatureStreamClient
+    {
+        public string ProviderName => "fake-stream";
+
+        public FeatureStreamCapabilities StreamCapabilities { get; } = new()
+        {
+            SupportsConnect = true,
+            SupportsReconnect = true,
+            SupportsHeartbeat = true,
+            SupportsSubscribe = true,
+            SupportsUnsubscribe = true,
+            SupportsSequenceNumbers = true,
+            SupportsResumeTokens = true,
+            SupportsBackpressure = true,
+            NativeSurface = "test"
+        };
+
+        public Task<FeatureStreamConnection> ConnectAsync(
+            FeatureStreamConnectRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureStreamConnection
+            {
+                ConnectionId = request.ClientId ?? "connection-1",
+                State = FeatureStreamConnectionState.Connected,
+                ConnectedAt = Timestamp(),
+                HeartbeatInterval = request.HeartbeatInterval,
+                LastSequenceNumber = request.Subscriptions.Count
+            });
+
+        public Task<FeatureStreamConnection> ReconnectAsync(
+            FeatureStreamReconnectRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureStreamConnection
+            {
+                ConnectionId = request.ConnectionId,
+                State = FeatureStreamConnectionState.Connected,
+                ConnectedAt = Timestamp(minute: 1),
+                LastSequenceNumber = request.LastSequenceNumber,
+                ResumeToken = request.ResumeToken
+            });
+
+        public async IAsyncEnumerable<FeatureStreamEvent> SubscribeAsync(
+            FeatureStreamSubscribeRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return Event(sequenceNumber: request.StartAfterSequenceNumber, subscriptionId: request.SubscriptionId) with
+            {
+                Kind = FeatureStreamEventKind.Subscribed,
+                FeatureId = null
+            };
+            await Task.Yield();
+            ct.ThrowIfCancellationRequested();
+            yield return Event("feature-1", sequenceNumber: 2, subscriptionId: request.SubscriptionId) with
+            {
+                Kind = FeatureStreamEventKind.Insert,
+                Source = request.Source
+            };
+        }
+
+        public Task UnsubscribeAsync(
+            FeatureStreamUnsubscribeRequest request,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task<FeatureStreamHeartbeat> HeartbeatAsync(
+            FeatureStreamHeartbeatRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureStreamHeartbeat
+            {
+                ConnectionId = request.ConnectionId,
+                Timestamp = Timestamp(second: 30),
+                LastSequenceNumber = request.LastSequenceNumber,
+                LastSequenceToken = request.LastSequenceToken,
+                ResumeToken = request.ResumeToken
+            });
+    }
+}


### PR DESCRIPTION
## Summary
- adds `IHonuaFeatureStreamClient` for connect, reconnect, heartbeat, subscribe, and unsubscribe workflows
- adds normalized real-time feature event contracts for insert/update/delete/control/error events with source IDs, feature IDs, timestamps, geometry, attributes, sequence numbers, sequence tokens, and resume tokens
- adds `FeatureStreamEventProcessor` for duplicate and stale sequence rejection
- adds `FeatureStreamEventBuffer` for bounded backpressure modes (`Wait`, `Reject`, `DropOldest`, `DropNewest`)
- documents the contract boundary and server transport dependencies

Closes #61 as the SDK contract slice.
Server transport remains dependent on honua-io/honua-server#339 and honua-io/honua-server#692.

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release --no-restore`
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `scripts/validate-api-compat.sh origin/trunk`
