### PR TITLE
feat: add OGC merge patch edit contracts

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -96,13 +96,16 @@ Current typed endpoint coverage is:
 | `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, auto-pagination, layer edit capabilities, and applyEdits/add/update/delete feature edits. |
 | `Honua.Sdk.Scenes` | Scene list, scene metadata detail, render endpoint resolution, access envelopes, attribution metadata, and offline scene package manifest parsing/validation. |
 | `Honua.Sdk.Field` | Provider-neutral form definitions, source-schema-to-form mapping, field validation, visibility rules, calculated fields, duplicate detection contracts, and record workflow transitions. No transport or display behavior. |
-| `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, and next-link pagination. |
+| `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, next-link pagination, and create/update/patch/delete edits. |
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
 WFS, GeoServices FeatureServer, and OGC API Features. Shared feature edit
 capabilities are available through `IHonuaFeatureEditClient`; gRPC,
 GeoServices FeatureServer, and OGC API Features currently advertise write
 support, while WFS reports unsupported edit capabilities with a reason.
+OGC API Features additionally supports shared RFC 7396 JSON Merge Patch edit
+payloads through `FeatureEditRequest.Patches` and native
+`IHonuaOgcFeaturesPatchClient.PatchItemAsync()`.
 
 Shared real-time feed contracts are available through
 `IHonuaFeatureStreamClient` in `Honua.Sdk.Abstractions`. The SDK normalizes

--- a/docs/feature-edits.md
+++ b/docs/feature-edits.md
@@ -44,7 +44,7 @@ provider object IDs, per-feature errors, top-level batch errors, and a
 | gRPC | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaGrpcClient.ApplyEditsAsync()` |
 | GeoServices FeatureServer | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaFeatureServerEditClient.ApplyEditsAsync()` plus add/update/delete convenience methods |
 | WFS | Registered as unsupported via `IHonuaFeatureEditClient` | WFS-T implementation decision tracked by #35 |
-| OGC API Features | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaOgcFeaturesEditClient.CreateItemAsync()`/`UpdateItemAsync()`/`DeleteItemAsync()` |
+| OGC API Features | Yes, via `IHonuaFeatureEditClient` | Yes, via `IHonuaOgcFeaturesEditClient.CreateItemAsync()`/`UpdateItemAsync()`/`DeleteItemAsync()` and `IHonuaOgcFeaturesPatchClient.PatchItemAsync()` |
 | Admin | Not applicable | Admin has control-plane mutations, not data-plane feature edits |
 
 Select from `IEnumerable<IHonuaFeatureEditClient>` and inspect
@@ -145,6 +145,9 @@ The OGC API Features shared adapter maps:
 - `Adds` to `POST` GeoJSON feature payloads.
 - `Updates` to `PUT` GeoJSON feature payloads at
   `/items/{featureId}` using `FeatureEditFeature.Id` or `ObjectId`.
+- `Patches` to `PATCH /items/{featureId}` with
+  `application/merge-patch+json` RFC 7396 JSON Merge Patch payloads using
+  `FeatureEditPatch.Id` or `ObjectId`.
 - `DeleteIds` and numeric `DeleteObjectIds` to `DELETE /items/{featureId}`.
 - OGC problem details and HTTP errors to shared `FeatureEditResult.Error`
   values.

--- a/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
@@ -16,6 +16,9 @@ public sealed record FeatureEditCapabilities
     /// <summary>Whether the provider supports updating features.</summary>
     public bool SupportsUpdates { get; init; }
 
+    /// <summary>Whether the provider supports partial feature patch operations.</summary>
+    public bool SupportsPatches { get; init; }
+
     /// <summary>Whether the provider supports deleting features.</summary>
     public bool SupportsDeletes { get; init; }
 
@@ -30,7 +33,7 @@ public sealed record FeatureEditCapabilities
 }
 
 /// <summary>
-/// Provider-neutral edit request for add, update, and delete operations.
+/// Provider-neutral edit request for add, update, patch, and delete operations.
 /// </summary>
 public sealed record FeatureEditRequest
 {
@@ -42,6 +45,9 @@ public sealed record FeatureEditRequest
 
     /// <summary>Features to update. Providers that use object IDs require each update to include an ID.</summary>
     public IReadOnlyList<FeatureEditFeature> Updates { get; init; } = [];
+
+    /// <summary>Features to patch with provider-native partial update payloads.</summary>
+    public IReadOnlyList<FeatureEditPatch> Patches { get; init; } = [];
 
     /// <summary>String feature identifiers to delete.</summary>
     public IReadOnlyList<string> DeleteIds { get; init; } = [];
@@ -76,6 +82,21 @@ public sealed record FeatureEditFeature
 }
 
 /// <summary>
+/// Provider-neutral partial feature edit payload.
+/// </summary>
+public sealed record FeatureEditPatch
+{
+    /// <summary>Provider feature identifier, when available.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Provider object identifier, when available.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Provider-native partial edit payload. OGC API Features uses RFC 7396 JSON Merge Patch.</summary>
+    public required JsonElement Patch { get; init; }
+}
+
+/// <summary>
 /// Provider-neutral response from applying a batch of feature edits.
 /// </summary>
 public sealed record FeatureEditResponse
@@ -89,6 +110,9 @@ public sealed record FeatureEditResponse
     /// <summary>Results for update operations.</summary>
     public IReadOnlyList<FeatureEditResult> UpdateResults { get; init; } = [];
 
+    /// <summary>Results for patch operations.</summary>
+    public IReadOnlyList<FeatureEditResult> PatchResults { get; init; } = [];
+
     /// <summary>Results for delete operations.</summary>
     public IReadOnlyList<FeatureEditResult> DeleteResults { get; init; } = [];
 
@@ -100,6 +124,7 @@ public sealed record FeatureEditResponse
         Error is null &&
         AddResults.All(result => result.Succeeded) &&
         UpdateResults.All(result => result.Succeeded) &&
+        PatchResults.All(result => result.Succeeded) &&
         DeleteResults.All(result => result.Succeeded);
 }
 

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -248,7 +248,10 @@ public sealed class HonuaSource : IHonuaSource
 
         if (editClient?.EditCapabilities is { } editCapabilities &&
             SupportsEditProtocol(descriptor, editClient) &&
-            (editCapabilities.SupportsAdds || editCapabilities.SupportsUpdates || editCapabilities.SupportsDeletes))
+            (editCapabilities.SupportsAdds ||
+             editCapabilities.SupportsUpdates ||
+             editCapabilities.SupportsPatches ||
+             editCapabilities.SupportsDeletes))
         {
             if (declared.Contains(FeatureCapabilities.ApplyEdits, StringComparer.Ordinal) || descriptor.Capabilities.Count == 0)
             {

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -253,6 +253,7 @@ public sealed class HonuaFeatureServerClient :
         FeatureEditRequest request, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+        EnsureNoPatchEdits(request);
         var (serviceId, layerId) = GetEditSource(request);
         var objectIdField = await ResolveObjectIdFieldAsync(serviceId, layerId, request, ct).ConfigureAwait(false);
         var response = await ApplyEditsAsync(
@@ -1136,6 +1137,14 @@ public sealed class HonuaFeatureServerClient :
         }
 
         return layer.ObjectIdField;
+    }
+
+    private static void EnsureNoPatchEdits(FeatureEditRequest request)
+    {
+        if (request.Patches.Count > 0)
+        {
+            throw new NotSupportedException("GeoServices FeatureServer shared edits do not support JSON Merge Patch operations.");
+        }
     }
 
     private static FeatureServerEditRequest BuildFeatureServerEditRequest(

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClient.cs
@@ -541,6 +541,11 @@ public sealed class HonuaGrpcClient :
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        if (request.Patches.Count > 0)
+        {
+            throw new NotSupportedException("gRPC shared edits do not support JSON Merge Patch operations.");
+        }
+
         if (string.IsNullOrWhiteSpace(request.Source.ServiceId))
         {
             throw new ArgumentException("A service ID is required for gRPC feature edits.", nameof(request));

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcFeaturesClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaOgcFeaturesEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
+        services.AddTransient<IHonuaOgcFeaturesPatchClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -18,6 +18,7 @@ namespace Honua.Sdk.OgcFeatures;
 public sealed class HonuaOgcFeaturesClient :
     IHonuaOgcFeaturesClient,
     IHonuaOgcFeaturesEditClient,
+    IHonuaOgcFeaturesPatchClient,
     IHonuaFeatureQueryClient,
     IHonuaFeatureEditClient,
     IHonuaFeatureDescriptorClient,
@@ -33,8 +34,9 @@ public sealed class HonuaOgcFeaturesClient :
     {
         SupportsAdds = true,
         SupportsUpdates = true,
+        SupportsPatches = true,
         SupportsDeletes = true,
-        NativeSurface = "OGC API Features create/update/delete"
+        NativeSurface = "OGC API Features create/update/patch/delete"
     };
     private static readonly FeatureAttachmentCapabilities OgcAttachmentCapabilities = new()
     {
@@ -182,6 +184,12 @@ public sealed class HonuaOgcFeaturesClient :
             updateResults.Add(await ApplyUpdateAsync(collectionId, feature, ct).ConfigureAwait(false));
         }
 
+        var patchResults = new List<FeatureEditResult>();
+        foreach (var patch in request.Patches)
+        {
+            patchResults.Add(await ApplyPatchAsync(collectionId, patch, ct).ConfigureAwait(false));
+        }
+
         var deleteResults = new List<FeatureEditResult>();
         foreach (var featureId in ResolveDeleteIds(request))
         {
@@ -193,6 +201,7 @@ public sealed class HonuaOgcFeaturesClient :
             ProviderName = ProviderName,
             AddResults = addResults,
             UpdateResults = updateResults,
+            PatchResults = patchResults,
             DeleteResults = deleteResults
         };
     }
@@ -370,8 +379,19 @@ public sealed class HonuaOgcFeaturesClient :
             };
         }
 
-        return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeature)
-            ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize patched feature.", body);
+        try
+        {
+            return JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeature)
+                ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize patched feature.", body);
+        }
+        catch (JsonException ex)
+        {
+            throw new HonuaOgcFeaturesException(
+                HttpStatusCode.OK,
+                "Failed to deserialize patched feature.",
+                body,
+                ex);
+        }
     }
 
     private static StringContent CreateGeoJsonContent(OgcFeature feature)
@@ -785,7 +805,11 @@ public sealed class HonuaOgcFeaturesClient :
             throw new NotSupportedException("OGC API Features edits do not support ForceWrite.");
         }
 
-        var operationCount = request.Adds.Count + request.Updates.Count + request.DeleteIds.Count + request.DeleteObjectIds.Count;
+        var operationCount = request.Adds.Count +
+            request.Updates.Count +
+            request.Patches.Count +
+            request.DeleteIds.Count +
+            request.DeleteObjectIds.Count;
         if (operationCount == 0)
         {
             throw new ArgumentException("At least one OGC API Features edit operation is required.", nameof(request));
@@ -794,6 +818,15 @@ public sealed class HonuaOgcFeaturesClient :
         foreach (var update in request.Updates)
         {
             _ = ResolveFeatureId(update);
+        }
+
+        foreach (var patch in request.Patches)
+        {
+            _ = ResolveFeatureId(patch);
+            if (patch.Patch.ValueKind == JsonValueKind.Undefined)
+            {
+                throw new ArgumentException("OGC API Features patches require a JSON Merge Patch payload.", nameof(request));
+            }
         }
 
         foreach (var deleteId in request.DeleteIds)
@@ -838,6 +871,21 @@ public sealed class HonuaOgcFeaturesClient :
         }
     }
 
+    private async Task<FeatureEditResult> ApplyPatchAsync(string collectionId, FeatureEditPatch patch, CancellationToken ct)
+    {
+        var featureId = ResolveFeatureId(patch);
+
+        try
+        {
+            var response = await PatchItemAsync(collectionId, featureId, patch.Patch, ct).ConfigureAwait(false);
+            return ToFeatureEditResult(response, patch);
+        }
+        catch (HonuaOgcFeaturesException ex)
+        {
+            return ToFeatureEditResult(patch, ex);
+        }
+    }
+
     private async Task<FeatureEditResult> ApplyDeleteAsync(string collectionId, string featureId, CancellationToken ct)
     {
         try
@@ -876,6 +924,10 @@ public sealed class HonuaOgcFeaturesClient :
         => ResolveOptionalFeatureId(feature) ??
            throw new ArgumentException("OGC API Features updates require FeatureEditFeature.Id or ObjectId.");
 
+    private static string ResolveFeatureId(FeatureEditPatch patch)
+        => ResolveOptionalFeatureId(patch) ??
+           throw new ArgumentException("OGC API Features patches require FeatureEditPatch.Id or ObjectId.");
+
     private static string? ResolveOptionalFeatureId(FeatureEditFeature feature)
     {
         if (!string.IsNullOrWhiteSpace(feature.Id))
@@ -884,6 +936,16 @@ public sealed class HonuaOgcFeaturesClient :
         }
 
         return feature.ObjectId?.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static string? ResolveOptionalFeatureId(FeatureEditPatch patch)
+    {
+        if (!string.IsNullOrWhiteSpace(patch.Id))
+        {
+            return patch.Id;
+        }
+
+        return patch.ObjectId?.ToString(CultureInfo.InvariantCulture);
     }
 
     private static List<string> ResolveDeleteIds(FeatureEditRequest request)
@@ -907,11 +969,32 @@ public sealed class HonuaOgcFeaturesClient :
         };
     }
 
+    private static FeatureEditResult ToFeatureEditResult(OgcFeature response, FeatureEditPatch fallback)
+    {
+        var id = response.Id.HasValue ? JsonElementToString(response.Id.Value) : ResolveOptionalFeatureId(fallback);
+
+        return new FeatureEditResult
+        {
+            Id = id,
+            ObjectId = long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId) ? objectId : null,
+            Succeeded = true
+        };
+    }
+
     private static FeatureEditResult ToFeatureEditResult(FeatureEditFeature feature, HonuaOgcFeaturesException exception)
         => new()
         {
             Id = ResolveOptionalFeatureId(feature),
             ObjectId = feature.ObjectId,
+            Succeeded = false,
+            Error = ToFeatureEditError(exception)
+        };
+
+    private static FeatureEditResult ToFeatureEditResult(FeatureEditPatch patch, HonuaOgcFeaturesException exception)
+        => new()
+        {
+            Id = ResolveOptionalFeatureId(patch),
+            ObjectId = patch.ObjectId,
             Succeeded = false,
             Error = ToFeatureEditError(exception)
         };

--- a/src/Honua.Sdk.OgcFeatures/IHonuaOgcFeaturesPatchClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/IHonuaOgcFeaturesPatchClient.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures;
+
+/// <summary>
+/// Client interface for OGC API Features JSON Merge Patch operations.
+/// </summary>
+public interface IHonuaOgcFeaturesPatchClient
+{
+    /// <summary>
+    /// Applies an RFC 7396 JSON Merge Patch payload to a feature in a collection.
+    /// </summary>
+    /// <param name="collectionId">The collection identifier.</param>
+    /// <param name="featureId">The feature identifier.</param>
+    /// <param name="patch">JSON Merge Patch payload.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The patched feature representation returned by the server.</returns>
+    Task<OgcFeature> PatchItemAsync(string collectionId, string featureId, JsonElement patch, CancellationToken ct = default);
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -829,6 +829,7 @@ public class HonuaFeatureServerClientTests
         Assert.Equal("geoservices-featureserver", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
         Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsPatches);
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
         Assert.IsType<HonuaFeatureServerClient>(featureServerEditClient);
         Assert.Equal("geoservices-featureserver", attachmentClient.ProviderName);

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -506,6 +506,7 @@ public class HonuaGrpcClientTests
         Assert.Equal("grpc", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
         Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsPatches);
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
         Assert.Equal("grpc", attachmentClient.ProviderName);
         Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -49,14 +49,17 @@ public sealed class ClientOptionsTests
         using var provider = services.BuildServiceProvider();
         var editClient = Assert.Single(provider.GetServices<IHonuaFeatureEditClient>());
         var nativeEditClient = Assert.Single(provider.GetServices<IHonuaOgcFeaturesEditClient>());
+        var nativePatchClient = Assert.Single(provider.GetServices<IHonuaOgcFeaturesPatchClient>());
         var attachmentClient = Assert.Single(provider.GetServices<IHonuaFeatureAttachmentClient>());
 
         Assert.Equal("ogc-features", editClient.ProviderName);
         Assert.True(editClient.EditCapabilities.SupportsAdds);
         Assert.True(editClient.EditCapabilities.SupportsUpdates);
+        Assert.True(editClient.EditCapabilities.SupportsPatches);
         Assert.True(editClient.EditCapabilities.SupportsDeletes);
         Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
         Assert.IsType<HonuaOgcFeaturesClient>(nativeEditClient);
+        Assert.IsType<HonuaOgcFeaturesClient>(nativePatchClient);
         Assert.Equal("ogc-features", attachmentClient.ProviderName);
         Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);
         Assert.Contains("attachment operations", attachmentClient.AttachmentCapabilities.UnsupportedReason);

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -567,7 +567,8 @@ public class HonuaOgcFeaturesClientTests
             }
         });
 
-        var result = await client.PatchItemAsync("buildings", "building-7", patch);
+        var patchClient = (IHonuaOgcFeaturesPatchClient)client;
+        var result = await patchClient.PatchItemAsync("buildings", "building-7", patch);
 
         Assert.Equal("application/merge-patch+json", capturedMediaType);
         Assert.Contains("\"Patched\"", capturedBody);
@@ -591,17 +592,20 @@ public class HonuaOgcFeaturesClientTests
     public async Task ApplyEditsAsync_SharedAbstraction_AppliesSequentialEdits()
     {
         var call = 0;
-        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        string? capturedPatchBody = null;
+        string? capturedPatchMediaType = null;
+        var client = TestHelpers.CreateOgcFeaturesClient(async req =>
         {
             call++;
             return call switch
             {
-                1 => Task.FromResult(TestHelpers.CreateRawJsonResponse(
+                1 => TestHelpers.CreateRawJsonResponse(
                     """{ "type": "Feature", "id": "created-1", "properties": {} }""",
-                    HttpStatusCode.Created)),
-                2 => Task.FromResult(TestHelpers.CreateRawJsonResponse(
-                    """{ "type": "Feature", "id": "updated-1", "properties": {} }""")),
-                3 => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent)),
+                    HttpStatusCode.Created),
+                2 => TestHelpers.CreateRawJsonResponse(
+                    """{ "type": "Feature", "id": "updated-1", "properties": {} }"""),
+                3 => await CapturePatchAsync(req),
+                4 => new HttpResponseMessage(HttpStatusCode.NoContent),
                 _ => throw new InvalidOperationException("Unexpected edit request.")
             };
         });
@@ -630,6 +634,20 @@ public class HonuaOgcFeaturesClientTests
                     }
                 }
             ],
+            Patches =
+            [
+                new FeatureEditPatch
+                {
+                    Id = "patched-1",
+                    Patch = JsonSerializer.SerializeToElement(new
+                    {
+                        properties = new
+                        {
+                            status = "open"
+                        }
+                    })
+                }
+            ],
             DeleteIds = ["deleted-1"],
             RollbackOnFailure = false
         });
@@ -638,7 +656,19 @@ public class HonuaOgcFeaturesClientTests
         Assert.True(response.Succeeded);
         Assert.Equal("created-1", Assert.Single(response.AddResults).Id);
         Assert.Equal("updated-1", Assert.Single(response.UpdateResults).Id);
+        Assert.Equal("patched-1", Assert.Single(response.PatchResults).Id);
+        Assert.Equal("application/merge-patch+json", capturedPatchMediaType);
+        Assert.Contains("\"status\"", capturedPatchBody);
         Assert.Equal("deleted-1", Assert.Single(response.DeleteResults).Id);
+
+        async Task<HttpResponseMessage> CapturePatchAsync(HttpRequestMessage req)
+        {
+            Assert.Equal(HttpMethod.Patch, req.Method);
+            capturedPatchMediaType = req.Content?.Headers.ContentType?.MediaType;
+            capturedPatchBody = await req.Content!.ReadAsStringAsync();
+            return TestHelpers.CreateRawJsonResponse(
+                """{ "type": "Feature", "id": "patched-1", "properties": {} }""");
+        }
     }
 
     [Fact]
@@ -675,6 +705,37 @@ public class HonuaOgcFeaturesClientTests
         Assert.Equal("candidate-1", result.Id);
         Assert.Equal((int)HttpStatusCode.BadRequest, result.Error?.Code);
         Assert.Contains("outside", result.Error?.Message);
+    }
+
+    [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_MapsMalformedPatchResponseToEditResults()
+    {
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            Assert.Equal(HttpMethod.Patch, req.Method);
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(
+                "{ this is not valid JSON }"));
+        });
+
+        var response = await ((IHonuaFeatureEditClient)client).ApplyEditsAsync(new FeatureEditRequest
+        {
+            Source = new FeatureSource { CollectionId = "buildings" },
+            Patches =
+            [
+                new FeatureEditPatch
+                {
+                    Id = "patched-1",
+                    Patch = JsonSerializer.SerializeToElement(new { properties = new { name = "Patched" } })
+                }
+            ]
+        });
+
+        var result = Assert.Single(response.PatchResults);
+        Assert.False(response.Succeeded);
+        Assert.False(result.Succeeded);
+        Assert.Equal("patched-1", result.Id);
+        Assert.Equal((int)HttpStatusCode.OK, result.Error?.Code);
+        Assert.Contains("deserialize patched", result.Error?.Message);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/ClientOptionsTests.cs
@@ -53,6 +53,7 @@ public sealed class ClientOptionsTests
         Assert.Equal("wfs", editClient.ProviderName);
         Assert.False(editClient.EditCapabilities.SupportsAdds);
         Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsPatches);
         Assert.False(editClient.EditCapabilities.SupportsDeletes);
         Assert.Contains("WFS-T", editClient.EditCapabilities.UnsupportedReason);
         Assert.Equal("wfs", attachmentClient.ProviderName);

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesTests.cs
@@ -296,6 +296,7 @@ public sealed class GetFeaturesTests
         Assert.Equal("wfs", editClient.ProviderName);
         Assert.False(editClient.EditCapabilities.SupportsAdds);
         Assert.False(editClient.EditCapabilities.SupportsUpdates);
+        Assert.False(editClient.EditCapabilities.SupportsPatches);
         Assert.False(editClient.EditCapabilities.SupportsDeletes);
         Assert.False(editClient.EditCapabilities.SupportsRollbackOnFailure);
         Assert.Equal("WFS-T Transaction", editClient.EditCapabilities.NativeSurface);


### PR DESCRIPTION
## Summary
- add shared `FeatureEditPatch`, `FeatureEditRequest.Patches`, `FeatureEditResponse.PatchResults`, and `SupportsPatches` capability metadata
- wire OGC shared edits to `PATCH /items/{featureId}` with RFC 7396 `application/merge-patch+json` payloads and per-edit result mapping
- expose native patch support through a new compatibility-preserving `IHonuaOgcFeaturesPatchClient` interface
- explicitly reject shared JSON Merge Patch edits for gRPC and GeoServices FeatureServer until those transports define native support
- update edit behavior docs and provider capability tests

Closes #105

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `scripts/validate-api-compat.sh origin/trunk`