### PR TITLE
feat: add planar geometry analysis helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and shared real-time feature stream contracts.
 | **Honua.Sdk.Admin** | Admin REST client -- services, layers, connections, styles, metadata |
 | **Honua.Sdk.Spec** | Spec workspace REST/SSE client -- validate, plan, apply stream, cancel |
 | **Honua.Sdk.Field** | Field form, validation, calculated field, duplicate detection, and record workflow contracts |
+| **Honua.Sdk.Geometry** | NTS/ProjNet-backed geometry conversion, spatial references, projection, and planar analysis |
 | **Honua.Sdk.Wfs** | WFS 2.0 read/query client -- GetCapabilities, GetFeature (GeoJSON), DescribeFeatureType |
 | **Honua.Sdk.GeoServices** | GeoServices FeatureServer read/query client -- service/layer metadata, query, count, IDs, extent, statistics |
 | **Honua.Sdk.Scenes** | Scene metadata client -- list/detail/resolve scene endpoints plus offline scene package contracts |
@@ -40,6 +41,7 @@ dotnet add package Honua.Sdk.Grpc --prerelease
 dotnet add package Honua.Sdk.Admin --prerelease
 dotnet add package Honua.Sdk.Spec --prerelease
 dotnet add package Honua.Sdk.Field --prerelease
+dotnet add package Honua.Sdk.Geometry --prerelease
 dotnet add package Honua.Sdk.Wfs --prerelease
 dotnet add package Honua.Sdk.GeoServices --prerelease
 dotnet add package Honua.Sdk.Scenes --prerelease

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -96,6 +96,7 @@ Current typed endpoint coverage is:
 | `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, auto-pagination, layer edit capabilities, and applyEdits/add/update/delete feature edits. |
 | `Honua.Sdk.Scenes` | Scene list, scene metadata detail, render endpoint resolution, access envelopes, attribution metadata, and offline scene package manifest parsing/validation. |
 | `Honua.Sdk.Field` | Provider-neutral form definitions, source-schema-to-form mapping, field validation, visibility rules, calculated fields, duplicate detection contracts, and record workflow transitions. No transport or display behavior. |
+| `Honua.Sdk.Geometry` | NTS/ProjNet-backed geometry conversion, CRS parsing/projection, and planar geometry analysis helpers. |
 | `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, next-link pagination, and create/update/patch/delete edits. |
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
@@ -149,3 +150,12 @@ maps time filters to `datetime` and rejects provider-neutral statistics,
 group-by, having, and explicit geometry spatial filters. WFS rejects
 provider-neutral time, statistics, and explicit geometry spatial-filter facets
 until there is a dedicated shared mapping.
+
+Local geometry analysis lives in `Honua.Sdk.Geometry`. `HonuaPlanarGeometryAnalyzer`
+wraps NetTopologySuite for planar distance, area, length, centroid, buffer,
+simplify, intersection, containment, overlap, nearest point, nearest vertex, and
+envelope operations. ProjNet projection is opt-in through
+`PlanarGeometryAnalysisOptions.AnalysisSpatialReference`; planar measurements on
+EPSG:4326 coordinates throw by default so callers do not accidentally treat
+degrees as meters. True geodesic behavior remains separate from the planar NTS
+surface.

--- a/docs/geometry-analysis.md
+++ b/docs/geometry-analysis.md
@@ -1,0 +1,37 @@
+# Geometry Analysis
+
+`Honua.Sdk.Geometry` exposes local geometry helpers backed by
+NetTopologySuite and ProjNet. Honua-specific code stays limited to adapters,
+projection policy, and diagnostics.
+
+## Planar Analysis
+
+Use `HonuaPlanarGeometryAnalyzer` for planar NTS operations:
+
+- distance, length, and area measurements;
+- centroid, buffer, simplify, intersection, and envelope operations;
+- containment, cover, intersection, and overlap predicates;
+- nearest point pair and nearest vertex lookups.
+
+Measurements are returned in the active coordinate units. If a geometry is in
+EPSG:4326, measurement methods throw by default because planar degree
+measurements are usually wrong. Supply `AnalysisSpatialReference` to project
+with ProjNet before analysis.
+
+```csharp
+var length = HonuaPlanarGeometryAnalyzer.MeasureLength(line, new PlanarGeometryAnalysisOptions
+{
+    AnalysisSpatialReference = HonuaSpatialReference.WebMercator
+});
+```
+
+Constructive operations that receive an analysis spatial reference return
+geometries in that analysis coordinate space. Transform them back with
+`HonuaCoordinateTransformer` when the caller needs source coordinates.
+
+## Geodesic Behavior
+
+The SDK does not pretend that NTS planar math is geodesic math. True geodesic
+operations should come from a dedicated geodesy implementation or a server-side
+analysis endpoint. Until that exists in the SDK, use the planar analyzer only
+when the coordinate space is appropriate for the operation.

--- a/src/Honua.Sdk.Geometry/HonuaPlanarGeometryAnalyzer.cs
+++ b/src/Honua.Sdk.Geometry/HonuaPlanarGeometryAnalyzer.cs
@@ -1,0 +1,439 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Distance;
+using NetTopologySuite.Simplify;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// NTS-backed planar geometry analysis helpers.
+/// </summary>
+public static class HonuaPlanarGeometryAnalyzer
+{
+    /// <summary>
+    /// Measures the planar distance between two geometries.
+    /// </summary>
+    /// <param name="first">The first geometry.</param>
+    /// <param name="second">The second geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The planar distance in the active analysis coordinate units.</returns>
+    public static double MeasureDistance(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedFirst, preparedSecond) = PrepareBinary(first, second, options, requirePlanarMeasurement: true);
+        return preparedFirst.Distance(preparedSecond);
+    }
+
+    /// <summary>
+    /// Measures the planar length of a geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry to measure.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The planar length in the active analysis coordinate units.</returns>
+    public static double MeasureLength(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: true);
+        return prepared.Length;
+    }
+
+    /// <summary>
+    /// Measures the planar area of a geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry to measure.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The planar area in squared active analysis coordinate units.</returns>
+    public static double MeasureArea(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: true);
+        return prepared.Area;
+    }
+
+    /// <summary>
+    /// Gets the planar centroid of a geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry to analyze.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The centroid point in the active analysis coordinate space.</returns>
+    public static Point GetCentroid(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: false);
+        return prepared.Centroid;
+    }
+
+    /// <summary>
+    /// Buffers a geometry with the NTS planar buffer operation.
+    /// </summary>
+    /// <param name="geometry">The geometry to buffer.</param>
+    /// <param name="distance">The buffer distance in the active analysis coordinate units.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The buffered geometry in the active analysis coordinate space.</returns>
+    public static NtsGeometry Buffer(
+        NtsGeometry geometry,
+        double distance,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        EnsureFinite(distance, nameof(distance));
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: true);
+        return prepared.Buffer(distance);
+    }
+
+    /// <summary>
+    /// Simplifies a geometry with NTS topology-preserving simplification.
+    /// </summary>
+    /// <param name="geometry">The geometry to simplify.</param>
+    /// <param name="distanceTolerance">The simplification tolerance in the active analysis coordinate units.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The simplified geometry in the active analysis coordinate space.</returns>
+    public static NtsGeometry Simplify(
+        NtsGeometry geometry,
+        double distanceTolerance,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        EnsureFinite(distanceTolerance, nameof(distanceTolerance));
+        ArgumentOutOfRangeException.ThrowIfNegative(distanceTolerance);
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: true);
+        return TopologyPreservingSimplifier.Simplify(prepared, distanceTolerance);
+    }
+
+    /// <summary>
+    /// Intersects two geometries with the NTS planar overlay operation.
+    /// </summary>
+    /// <param name="first">The first geometry.</param>
+    /// <param name="second">The second geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The intersection geometry in the active analysis coordinate space.</returns>
+    public static NtsGeometry Intersect(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedFirst, preparedSecond) = PrepareBinary(first, second, options, requirePlanarMeasurement: false);
+        return preparedFirst.Intersection(preparedSecond);
+    }
+
+    /// <summary>
+    /// Determines whether one geometry contains another in planar coordinates.
+    /// </summary>
+    /// <param name="container">The possible containing geometry.</param>
+    /// <param name="candidate">The candidate contained geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>True when the container contains the candidate.</returns>
+    public static bool Contains(
+        NtsGeometry container,
+        NtsGeometry candidate,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedContainer, preparedCandidate) = PrepareBinary(
+            container,
+            candidate,
+            options,
+            requirePlanarMeasurement: false);
+        return preparedContainer.Contains(preparedCandidate);
+    }
+
+    /// <summary>
+    /// Determines whether one geometry covers another in planar coordinates.
+    /// </summary>
+    /// <param name="container">The possible covering geometry.</param>
+    /// <param name="candidate">The candidate covered geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>True when the container covers the candidate.</returns>
+    public static bool Covers(
+        NtsGeometry container,
+        NtsGeometry candidate,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedContainer, preparedCandidate) = PrepareBinary(
+            container,
+            candidate,
+            options,
+            requirePlanarMeasurement: false);
+        return preparedContainer.Covers(preparedCandidate);
+    }
+
+    /// <summary>
+    /// Determines whether two geometries intersect in planar coordinates.
+    /// </summary>
+    /// <param name="first">The first geometry.</param>
+    /// <param name="second">The second geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>True when the geometries intersect.</returns>
+    public static bool Intersects(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedFirst, preparedSecond) = PrepareBinary(first, second, options, requirePlanarMeasurement: false);
+        return preparedFirst.Intersects(preparedSecond);
+    }
+
+    /// <summary>
+    /// Determines whether two geometries overlap in planar coordinates.
+    /// </summary>
+    /// <param name="first">The first geometry.</param>
+    /// <param name="second">The second geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>True when the geometries overlap.</returns>
+    public static bool Overlaps(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedFirst, preparedSecond) = PrepareBinary(first, second, options, requirePlanarMeasurement: false);
+        return preparedFirst.Overlaps(preparedSecond);
+    }
+
+    /// <summary>
+    /// Gets the envelope of a geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry to analyze.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The envelope in the active analysis coordinate space.</returns>
+    public static Envelope GetEnvelope(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: false);
+        return new Envelope(prepared.EnvelopeInternal);
+    }
+
+    /// <summary>
+    /// Gets the envelope geometry of a geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry to analyze.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The envelope geometry in the active analysis coordinate space.</returns>
+    public static NtsGeometry GetEnvelopeGeometry(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var prepared = PrepareUnary(geometry, options, requirePlanarMeasurement: false);
+        return prepared.Envelope;
+    }
+
+    /// <summary>
+    /// Finds the nearest points between two geometries.
+    /// </summary>
+    /// <param name="first">The first geometry.</param>
+    /// <param name="second">The second geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The nearest point pair in the active analysis coordinate space.</returns>
+    public static NearestGeometryPointPair FindNearestPoints(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedFirst, preparedSecond) = PrepareBinary(first, second, options, requirePlanarMeasurement: true);
+        EnsureNotEmpty(preparedFirst, nameof(first));
+        EnsureNotEmpty(preparedSecond, nameof(second));
+
+        var coordinates = DistanceOp.NearestPoints(preparedFirst, preparedSecond);
+        var firstPoint = preparedFirst.Factory.CreatePoint(coordinates[0].Copy());
+        var secondPoint = preparedSecond.Factory.CreatePoint(coordinates[1].Copy());
+
+        return new NearestGeometryPointPair
+        {
+            FirstPoint = firstPoint,
+            SecondPoint = secondPoint,
+            Distance = firstPoint.Distance(secondPoint)
+        };
+    }
+
+    /// <summary>
+    /// Finds the nearest vertex in a geometry to a target geometry.
+    /// </summary>
+    /// <param name="geometry">The geometry whose vertices are searched.</param>
+    /// <param name="target">The target geometry.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    /// <returns>The nearest vertex in the active analysis coordinate space.</returns>
+    public static NearestGeometryVertex FindNearestVertex(
+        NtsGeometry geometry,
+        NtsGeometry target,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        var (preparedGeometry, preparedTarget) = PrepareBinary(geometry, target, options, requirePlanarMeasurement: true);
+        EnsureNotEmpty(preparedGeometry, nameof(geometry));
+        EnsureNotEmpty(preparedTarget, nameof(target));
+
+        var coordinates = preparedGeometry.Coordinates;
+        if (coordinates.Length == 0)
+        {
+            throw new ArgumentException("Geometry does not contain any coordinates.", nameof(geometry));
+        }
+
+        var nearestIndex = 0;
+        var nearestPoint = preparedGeometry.Factory.CreatePoint(coordinates[0].Copy());
+        var nearestDistance = nearestPoint.Distance(preparedTarget);
+
+        for (var index = 1; index < coordinates.Length; index++)
+        {
+            var point = preparedGeometry.Factory.CreatePoint(coordinates[index].Copy());
+            var distance = point.Distance(preparedTarget);
+            if (distance < nearestDistance)
+            {
+                nearestIndex = index;
+                nearestPoint = point;
+                nearestDistance = distance;
+            }
+        }
+
+        return new NearestGeometryVertex
+        {
+            Vertex = nearestPoint,
+            CoordinateIndex = nearestIndex,
+            Distance = nearestDistance
+        };
+    }
+
+    private static NtsGeometry PrepareUnary(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options,
+        bool requirePlanarMeasurement)
+    {
+        ArgumentNullException.ThrowIfNull(geometry);
+        var prepared = ProjectForAnalysis(geometry, options);
+        EnsureMeasurementCoordinatePolicy(prepared, options, requirePlanarMeasurement);
+        return prepared;
+    }
+
+    private static (NtsGeometry First, NtsGeometry Second) PrepareBinary(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options,
+        bool requirePlanarMeasurement)
+    {
+        ArgumentNullException.ThrowIfNull(first);
+        ArgumentNullException.ThrowIfNull(second);
+        EnsureCompatibleKnownSrids(first, second, options);
+
+        var preparedFirst = ProjectForAnalysis(first, options);
+        var preparedSecond = ProjectForAnalysis(second, options);
+        EnsureMeasurementCoordinatePolicy(preparedFirst, options, requirePlanarMeasurement);
+        EnsureMeasurementCoordinatePolicy(preparedSecond, options, requirePlanarMeasurement);
+        return (preparedFirst, preparedSecond);
+    }
+
+    private static NtsGeometry ProjectForAnalysis(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.AnalysisSpatialReference is not { } target)
+        {
+            return geometry;
+        }
+
+        var source = ResolveSourceSpatialReference(geometry, options)
+            ?? throw new InvalidOperationException(
+                "SourceSpatialReference or geometry SRID is required when AnalysisSpatialReference is supplied.");
+
+        if (AreEquivalent(source, target))
+        {
+            return geometry;
+        }
+
+        var transformer = options.CoordinateTransformer ?? new HonuaCoordinateTransformer();
+        return transformer.Transform(geometry, source, target);
+    }
+
+    private static void EnsureCompatibleKnownSrids(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.AnalysisSpatialReference is not null ||
+            first.SRID <= 0 ||
+            second.SRID <= 0 ||
+            first.SRID == second.SRID)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Geometry SRIDs differ ({first.SRID} and {second.SRID}); supply an analysis spatial reference.");
+    }
+
+    private static void EnsureMeasurementCoordinatePolicy(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options,
+        bool requirePlanarMeasurement)
+    {
+        if (!requirePlanarMeasurement ||
+            options?.AnalysisSpatialReference is not null ||
+            options?.AllowGeographicMeasurements == true)
+        {
+            return;
+        }
+
+        var source = ResolveSourceSpatialReference(geometry, options);
+        if (source?.Wkid == 4326)
+        {
+            throw new InvalidOperationException(
+                "Planar measurements on EPSG:4326 coordinates are disabled by default; supply AnalysisSpatialReference for projection or set AllowGeographicMeasurements.");
+        }
+    }
+
+    private static HonuaSpatialReference? ResolveSourceSpatialReference(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.SourceSpatialReference is { } source)
+        {
+            return source;
+        }
+
+        return geometry.SRID > 0 ? HonuaSpatialReference.FromWkid(geometry.SRID) : null;
+    }
+
+    private static bool AreEquivalent(
+        HonuaSpatialReference first,
+        HonuaSpatialReference second)
+    {
+        if (first.Wkid is int firstWkid && second.Wkid is int secondWkid)
+        {
+            return firstWkid == secondWkid;
+        }
+
+        if (!string.IsNullOrWhiteSpace(first.Authority) &&
+            !string.IsNullOrWhiteSpace(second.Authority) &&
+            first.Code is int firstCode &&
+            second.Code is int secondCode)
+        {
+            return firstCode == secondCode &&
+                first.Authority.Equals(second.Authority, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!string.IsNullOrWhiteSpace(first.Wkt) || !string.IsNullOrWhiteSpace(second.Wkt))
+        {
+            return string.Equals(first.Wkt, second.Wkt, StringComparison.Ordinal);
+        }
+
+        return first.Identifier.Equals(second.Identifier, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void EnsureNotEmpty(NtsGeometry geometry, string parameterName)
+    {
+        if (geometry.IsEmpty)
+        {
+            throw new ArgumentException("Geometry must not be empty.", parameterName);
+        }
+    }
+
+    private static void EnsureFinite(double value, string parameterName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite.");
+        }
+    }
+}

--- a/src/Honua.Sdk.Geometry/NearestGeometryPointPair.cs
+++ b/src/Honua.Sdk.Geometry/NearestGeometryPointPair.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// Nearest point pair between two geometries in planar analysis coordinates.
+/// </summary>
+public sealed record NearestGeometryPointPair
+{
+    /// <summary>
+    /// Gets the nearest point on the first geometry.
+    /// </summary>
+    public required Point FirstPoint { get; init; }
+
+    /// <summary>
+    /// Gets the nearest point on the second geometry.
+    /// </summary>
+    public required Point SecondPoint { get; init; }
+
+    /// <summary>
+    /// Gets the planar distance between the two points.
+    /// </summary>
+    public double Distance { get; init; }
+}

--- a/src/Honua.Sdk.Geometry/NearestGeometryVertex.cs
+++ b/src/Honua.Sdk.Geometry/NearestGeometryVertex.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// Nearest vertex result for a geometry in planar analysis coordinates.
+/// </summary>
+public sealed record NearestGeometryVertex
+{
+    /// <summary>
+    /// Gets the nearest vertex as a point.
+    /// </summary>
+    public required Point Vertex { get; init; }
+
+    /// <summary>
+    /// Gets the zero-based coordinate index in the analyzed geometry coordinate sequence.
+    /// </summary>
+    public int CoordinateIndex { get; init; }
+
+    /// <summary>
+    /// Gets the planar distance from the vertex to the target geometry.
+    /// </summary>
+    public double Distance { get; init; }
+}

--- a/src/Honua.Sdk.Geometry/PlanarGeometryAnalysisOptions.cs
+++ b/src/Honua.Sdk.Geometry/PlanarGeometryAnalysisOptions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// Options that control planar geometry analysis coordinate handling.
+/// </summary>
+public sealed record PlanarGeometryAnalysisOptions
+{
+    /// <summary>
+    /// Gets the source spatial reference for geometries that do not carry an SRID.
+    /// </summary>
+    public HonuaSpatialReference? SourceSpatialReference { get; init; }
+
+    /// <summary>
+    /// Gets the projected spatial reference used before planar analysis.
+    /// </summary>
+    public HonuaSpatialReference? AnalysisSpatialReference { get; init; }
+
+    /// <summary>
+    /// Gets the coordinate transformer used when <see cref="AnalysisSpatialReference"/> is supplied.
+    /// </summary>
+    public HonuaCoordinateTransformer? CoordinateTransformer { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether measurement operations may use geographic coordinates directly.
+    /// </summary>
+    public bool AllowGeographicMeasurements { get; init; }
+}

--- a/tests/Honua.Sdk.Geometry.Tests/HonuaPlanarGeometryAnalyzerTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/HonuaPlanarGeometryAnalyzerTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry;
+using NetTopologySuite.Geometries;
+using ProjNet.CoordinateSystems;
+
+namespace Honua.Sdk.Geometry.Tests;
+
+public class HonuaPlanarGeometryAnalyzerTests
+{
+    private static readonly GeometryFactory ProjectedFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory(srid: 3857);
+
+    private static readonly GeometryFactory Wgs84Factory =
+        NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+
+    [Fact]
+    public void MeasureDistance_UsesNtsPlanarDistance()
+    {
+        var first = ProjectedFactory.CreatePoint(new Coordinate(0, 0));
+        var second = ProjectedFactory.CreatePoint(new Coordinate(3, 4));
+
+        var distance = HonuaPlanarGeometryAnalyzer.MeasureDistance(first, second);
+
+        Assert.Equal(5, distance);
+    }
+
+    [Fact]
+    public void MeasureArea_RejectsWgs84WithoutProjection()
+    {
+        var polygon = Wgs84Factory.CreatePolygon(
+        [
+            new Coordinate(-158.0, 21.0),
+            new Coordinate(-157.0, 21.0),
+            new Coordinate(-157.0, 22.0),
+            new Coordinate(-158.0, 22.0),
+            new Coordinate(-158.0, 21.0)
+        ]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => HonuaPlanarGeometryAnalyzer.MeasureArea(polygon));
+
+        Assert.Contains("EPSG:4326", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MeasureLength_ProjectsBeforePlanarAnalysis()
+    {
+        var line = Wgs84Factory.CreateLineString(
+        [
+            new Coordinate(-157.8583, 21.3069),
+            new Coordinate(-157.8583, 21.3169)
+        ]);
+
+        var length = HonuaPlanarGeometryAnalyzer.MeasureLength(line, new PlanarGeometryAnalysisOptions
+        {
+            AnalysisSpatialReference = HonuaSpatialReference.WebMercator
+        });
+
+        Assert.InRange(length, 1_100, 1_250);
+    }
+
+    [Fact]
+    public void Buffer_Simplify_AndCentroid_ReturnProjectedAnalysisGeometry()
+    {
+        var line = ProjectedFactory.CreateLineString(
+        [
+            new Coordinate(0, 0),
+            new Coordinate(5, 0),
+            new Coordinate(10, 0)
+        ]);
+
+        var buffer = HonuaPlanarGeometryAnalyzer.Buffer(line, 1);
+        var simplified = HonuaPlanarGeometryAnalyzer.Simplify(line, 2);
+        var centroid = HonuaPlanarGeometryAnalyzer.GetCentroid(buffer);
+
+        Assert.True(buffer.Area > 0);
+        Assert.Equal(2, simplified.NumPoints);
+        Assert.InRange(centroid.X, 4.9, 5.1);
+    }
+
+    [Fact]
+    public void TopologyOperations_UseNtsPredicatesAndOverlay()
+    {
+        var container = ProjectedFactory.CreatePolygon(
+        [
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10),
+            new Coordinate(0, 10),
+            new Coordinate(0, 0)
+        ]);
+        var overlapping = ProjectedFactory.CreatePolygon(
+        [
+            new Coordinate(5, 5),
+            new Coordinate(15, 5),
+            new Coordinate(15, 15),
+            new Coordinate(5, 15),
+            new Coordinate(5, 5)
+        ]);
+        var inside = ProjectedFactory.CreatePoint(new Coordinate(2, 2));
+
+        var intersection = HonuaPlanarGeometryAnalyzer.Intersect(container, overlapping);
+
+        Assert.True(HonuaPlanarGeometryAnalyzer.Contains(container, inside));
+        Assert.True(HonuaPlanarGeometryAnalyzer.Covers(container, inside));
+        Assert.True(HonuaPlanarGeometryAnalyzer.Intersects(container, overlapping));
+        Assert.True(HonuaPlanarGeometryAnalyzer.Overlaps(container, overlapping));
+        Assert.Equal(25, intersection.Area);
+    }
+
+    [Fact]
+    public void EnvelopeOperations_ReturnEnvelopeAndGeometry()
+    {
+        var geometry = ProjectedFactory.CreateMultiPointFromCoords(
+        [
+            new Coordinate(1, 2),
+            new Coordinate(5, 8)
+        ]);
+
+        var envelope = HonuaPlanarGeometryAnalyzer.GetEnvelope(geometry);
+        var envelopeGeometry = HonuaPlanarGeometryAnalyzer.GetEnvelopeGeometry(geometry);
+
+        Assert.Equal(1, envelope.MinX);
+        Assert.Equal(8, envelope.MaxY);
+        Assert.Equal("Polygon", envelopeGeometry.GeometryType);
+    }
+
+    [Fact]
+    public void NearestOperations_ReturnNearestPointPairAndVertex()
+    {
+        var line = ProjectedFactory.CreateLineString(
+        [
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10)
+        ]);
+        var target = ProjectedFactory.CreatePoint(new Coordinate(7, 2));
+
+        var nearestPoints = HonuaPlanarGeometryAnalyzer.FindNearestPoints(line, target);
+        var nearestVertex = HonuaPlanarGeometryAnalyzer.FindNearestVertex(line, target);
+
+        Assert.Equal(7, nearestPoints.FirstPoint.X);
+        Assert.Equal(0, nearestPoints.FirstPoint.Y);
+        Assert.Equal(2, nearestPoints.Distance);
+        Assert.Equal(1, nearestVertex.CoordinateIndex);
+        Assert.Equal(10, nearestVertex.Vertex.X);
+        Assert.InRange(nearestVertex.Distance, 3.60, 3.61);
+    }
+
+    [Fact]
+    public void BinaryAnalysis_RejectsDifferentKnownSridsWithoutAnalysisReference()
+    {
+        var first = ProjectedFactory.CreatePoint(new Coordinate(0, 0));
+        var second = Wgs84Factory.CreatePoint(new Coordinate(0, 0));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => HonuaPlanarGeometryAnalyzer.Intersects(first, second));
+
+        Assert.Contains("SRIDs differ", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BinaryAnalysis_RejectsDifferentKnownSridsEvenWhenSourceReferenceIsProvided()
+    {
+        var first = ProjectedFactory.CreatePoint(new Coordinate(0, 0));
+        var second = Wgs84Factory.CreatePoint(new Coordinate(0, 0));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => HonuaPlanarGeometryAnalyzer.Intersects(first, second, new PlanarGeometryAnalysisOptions
+            {
+                SourceSpatialReference = HonuaSpatialReference.WebMercator
+            }));
+
+        Assert.Contains("SRIDs differ", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnalysisProjection_DistinguishesDifferentWktSpatialReferences()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory();
+        var line = factory.CreateLineString(
+        [
+            new Coordinate(-157.8583, 21.3069),
+            new Coordinate(-157.8583, 21.3169)
+        ]);
+
+        var length = HonuaPlanarGeometryAnalyzer.MeasureLength(line, new PlanarGeometryAnalysisOptions
+        {
+            SourceSpatialReference = HonuaSpatialReference.FromWkt(GeographicCoordinateSystem.WGS84.WKT),
+            AnalysisSpatialReference = HonuaSpatialReference.FromWkt(ProjectedCoordinateSystem.WebMercator.WKT)
+        });
+
+        Assert.InRange(length, 1_100, 1_250);
+    }
+}


### PR DESCRIPTION
## Summary
- add `HonuaPlanarGeometryAnalyzer` over NetTopologySuite for planar distance, length, area, centroid, buffer, simplify, intersection, containment/cover/intersection/overlap predicates, envelopes, nearest point pairs, and nearest vertices
- add `PlanarGeometryAnalysisOptions` so callers can project with ProjNet before planar analysis and avoid accidental WGS84 degree measurements
- add nearest point/vertex result contracts, geometry analysis docs, and README/client behavior coverage

Closes #63

## Notes
- This keeps true geodesic behavior explicitly separate from the NTS planar surface.
- Existing `HonuaCoordinateTransformer` remains the ProjNet path for projected analysis coordinates.

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `scripts/validate-api-compat.sh origin/trunk`