### PR TITLE
feat: add host-neutral geofence evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and shared real-time feature stream contracts.
 | **Honua.Sdk.Admin** | Admin REST client -- services, layers, connections, styles, metadata |
 | **Honua.Sdk.Spec** | Spec workspace REST/SSE client -- validate, plan, apply stream, cancel |
 | **Honua.Sdk.Field** | Field form, validation, calculated field, duplicate detection, and record workflow contracts |
-| **Honua.Sdk.Geometry** | NTS/ProjNet-backed geometry conversion, spatial references, projection, and planar analysis |
+| **Honua.Sdk.Geometry** | NTS/ProjNet-backed geometry conversion, spatial references, projection, planar analysis, and geofence evaluation |
 | **Honua.Sdk.Wfs** | WFS 2.0 read/query client -- GetCapabilities, GetFeature (GeoJSON), DescribeFeatureType |
 | **Honua.Sdk.GeoServices** | GeoServices FeatureServer read/query client -- service/layer metadata, query, count, IDs, extent, statistics |
 | **Honua.Sdk.Scenes** | Scene metadata client -- list/detail/resolve scene endpoints plus offline scene package contracts |

--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -97,7 +97,7 @@ Current typed endpoint coverage is:
 | `Honua.Sdk.GeoServices` | FeatureServer service/layer metadata, query, feature by object ID, count, IDs, extent, statistics, SQL validation, raw query, auto-pagination, layer edit capabilities, and applyEdits/add/update/delete feature edits. |
 | `Honua.Sdk.Scenes` | Scene list, scene metadata detail, render endpoint resolution, access envelopes, attribution metadata, and offline scene package manifest parsing/validation. |
 | `Honua.Sdk.Field` | Provider-neutral form definitions, source-schema-to-form mapping, field validation, visibility rules, calculated fields, duplicate detection contracts, and record workflow transitions. No transport or display behavior. |
-| `Honua.Sdk.Geometry` | NTS/ProjNet-backed geometry conversion, CRS parsing/projection, and planar geometry analysis helpers. |
+| `Honua.Sdk.Geometry` | NTS/ProjNet-backed geometry conversion, CRS parsing/projection, planar geometry analysis helpers, and host-neutral geofence evaluation. |
 | `Honua.Sdk.OgcFeatures` | Landing page, conformance, collections, collection details, queryables, items, item by ID, raw item responses, next-link pagination, and create/update/patch/delete edits. |
 
 Shared read queries are available through `IHonuaFeatureQueryClient` for gRPC,
@@ -168,3 +168,12 @@ envelope operations. ProjNet projection is opt-in through
 EPSG:4326 coordinates throw by default so callers do not accidentally treat
 degrees as meters. True geodesic behavior remains separate from the planar NTS
 surface.
+
+Host-neutral geofencing also lives in `Honua.Sdk.Geometry`.
+`HonuaGeofenceEvaluator` evaluates current positions and position streams
+against NTS boundary geometries with optional planar buffers, proximity
+distances, source-query metadata, prepared geometry predicates, and per-track
+enter/exit/approach/depart state. It can also consume normalized
+`FeatureStreamEvent` sequences, rejecting duplicate or stale stream events before
+evaluation. Device sensors, background permissions, notifications, map display,
+and platform scheduling remain host-owned. See [Geofencing](geofencing.md).

--- a/docs/geofencing.md
+++ b/docs/geofencing.md
@@ -1,0 +1,77 @@
+# Geofencing
+
+`Honua.Sdk.Geometry` includes host-neutral geofence evaluation over
+NetTopologySuite geometries. The SDK handles the portable data model and
+evaluation rules; apps still own device sensor acquisition, background
+permissions, native scheduling, notifications, and UI/map display.
+
+Core types:
+
+- `HonuaGeofenceDefinition` declares a geofence ID, NTS boundary geometry,
+  optional planar buffer distance, optional proximity distance, and optional
+  `SourceDescriptor` / `SourceQuery` metadata for source-backed geofences.
+- `HonuaGeofencePosition` wraps a point sample, timestamp, and optional track ID.
+- `HonuaGeofenceEvaluator` prepares the geofence geometries and evaluates
+  current positions, synchronous position sequences, async position streams, or
+  typed feature stream events from `IHonuaFeatureStreamClient`.
+- `HonuaGeofenceEvaluationState` tracks per-geofence/per-track state so streams
+  can report enter, exit, approach, and depart transitions.
+
+Buffer and proximity distances are planar. If a geofence uses EPSG:4326
+coordinates, supply `PlanarGeometryAnalysisOptions.AnalysisSpatialReference`
+before using distance-based evaluation. This mirrors the planar analysis policy:
+the SDK will not silently treat degrees as meters.
+
+```csharp
+using Honua.Sdk.Geometry;
+using NetTopologySuite.Geometries;
+
+var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 3857);
+var fence = new HonuaGeofenceDefinition
+{
+    GeofenceId = "yard",
+    Geometry = factory.CreatePolygon(
+    [
+        new Coordinate(0, 0),
+        new Coordinate(10, 0),
+        new Coordinate(10, 10),
+        new Coordinate(0, 10),
+        new Coordinate(0, 0)
+    ]),
+    BufferDistance = 2,
+    ProximityDistance = 5
+};
+
+var evaluator = new HonuaGeofenceEvaluator([fence]);
+var state = new HonuaGeofenceEvaluationState();
+
+var result = evaluator.Evaluate(new HonuaGeofencePosition
+{
+    Location = factory.CreatePoint(new Coordinate(11, 5)),
+    TrackId = "truck-1"
+}, state).Single();
+```
+
+`HonuaGeofenceEvaluator` uses prepared NTS geometries for repeated predicate
+evaluation. Use one evaluator instance per active geofence set and reuse a
+`HonuaGeofenceEvaluationState` for each logical position stream.
+
+Feature streams can be evaluated with the SDK's normalized stream contract. The
+feature-stream overload rejects duplicate and stale sequence events by default
+through `FeatureStreamEventProcessor`; pass a shared processor when cursor state
+must survive reconnects or multiple evaluation loops.
+
+```csharp
+await foreach (var evaluation in evaluator.EvaluateFeatureStreamAsync(
+    streamClient.SubscribeAsync(subscription, ct),
+    featureEvent => HonuaGeofenceEvaluator.CreatePositionFromFeatureEvent(featureEvent),
+    state,
+    cancellationToken: ct))
+{
+    // Dispatch or persist the host-specific location event here.
+}
+```
+
+`CreatePositionFromFeatureEvent` reads GeoServices or GeoJSON point geometry
+from insert/update events. For providers that encode positions in attributes or
+custom payloads, pass a custom selector function instead.

--- a/src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj
+++ b/src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Geospatial.Grpc" Version="$(GeospatialGrpcVersion)" />
     <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="4.0.0" />

--- a/src/Honua.Sdk.Geometry/HonuaGeofenceEvaluator.cs
+++ b/src/Honua.Sdk.Geometry/HonuaGeofenceEvaluator.cs
@@ -1,0 +1,626 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Prepared;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Sdk.Geometry;
+
+/// <summary>
+/// Definition for a host-neutral geofence.
+/// </summary>
+public sealed class HonuaGeofenceDefinition
+{
+    /// <summary>
+    /// Stable geofence identifier.
+    /// </summary>
+    public required string GeofenceId { get; init; }
+
+    /// <summary>
+    /// Boundary geometry for the geofence.
+    /// </summary>
+    public required NtsGeometry Geometry { get; init; }
+
+    /// <summary>
+    /// Optional planar buffer distance added to the boundary before evaluation.
+    /// </summary>
+    public double BufferDistance { get; init; }
+
+    /// <summary>
+    /// Optional planar distance outside the boundary that reports proximity.
+    /// </summary>
+    public double? ProximityDistance { get; init; }
+
+    /// <summary>
+    /// Optional source descriptor used when the geofence came from a feature source.
+    /// </summary>
+    public SourceDescriptor? Source { get; init; }
+
+    /// <summary>
+    /// Optional source query used to retrieve or refresh source-backed geofence features.
+    /// </summary>
+    public SourceQuery? SourceQuery { get; init; }
+
+    /// <summary>
+    /// Optional application metadata carried through evaluations.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// Position sample evaluated against geofences.
+/// </summary>
+public sealed class HonuaGeofencePosition
+{
+    /// <summary>
+    /// Location point to evaluate.
+    /// </summary>
+    public required Point Location { get; init; }
+
+    /// <summary>
+    /// Optional timestamp for stream evaluation.
+    /// </summary>
+    public DateTimeOffset? Timestamp { get; init; }
+
+    /// <summary>
+    /// Optional track or device identifier. Separate tracks maintain separate transition state.
+    /// </summary>
+    public string? TrackId { get; init; }
+}
+
+/// <summary>
+/// Geofence status for a position sample.
+/// </summary>
+public enum HonuaGeofenceStatus
+{
+    /// <summary>
+    /// The position is outside the boundary and outside the proximity distance.
+    /// </summary>
+    Outside,
+
+    /// <summary>
+    /// The position is inside or on the geofence boundary.
+    /// </summary>
+    Inside,
+
+    /// <summary>
+    /// The position is outside the boundary but inside the proximity distance.
+    /// </summary>
+    Proximity,
+}
+
+/// <summary>
+/// Transition detected between previous and current geofence status.
+/// </summary>
+public enum HonuaGeofenceTransition
+{
+    /// <summary>
+    /// No transition was detected.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The position moved from outside/proximity to inside.
+    /// </summary>
+    Entered,
+
+    /// <summary>
+    /// The position moved from inside to outside/proximity.
+    /// </summary>
+    Exited,
+
+    /// <summary>
+    /// The position moved from outside to proximity.
+    /// </summary>
+    Approached,
+
+    /// <summary>
+    /// The position moved from proximity to outside.
+    /// </summary>
+    Departed,
+}
+
+/// <summary>
+/// Result of evaluating one position against one geofence.
+/// </summary>
+public sealed class HonuaGeofenceEvaluation
+{
+    /// <summary>
+    /// Geofence definition used for the evaluation.
+    /// </summary>
+    public required HonuaGeofenceDefinition Definition { get; init; }
+
+    /// <summary>
+    /// Position sample used for the evaluation.
+    /// </summary>
+    public required HonuaGeofencePosition Position { get; init; }
+
+    /// <summary>
+    /// Geofence identifier copied from <see cref="Definition"/>.
+    /// </summary>
+    public required string GeofenceId { get; init; }
+
+    /// <summary>
+    /// Evaluated geofence status.
+    /// </summary>
+    public HonuaGeofenceStatus Status { get; init; }
+
+    /// <summary>
+    /// Transition from the previous known status for this track and geofence.
+    /// </summary>
+    public HonuaGeofenceTransition Transition { get; init; }
+
+    /// <summary>
+    /// Planar distance from the position to the active geofence boundary. Inside positions return zero.
+    /// </summary>
+    public double Distance { get; init; }
+}
+
+/// <summary>
+/// Snapshot entry for geofence stream state.
+/// </summary>
+public sealed class HonuaGeofenceStateEntry
+{
+    /// <summary>
+    /// Geofence identifier.
+    /// </summary>
+    public required string GeofenceId { get; init; }
+
+    /// <summary>
+    /// Track identifier, when one was provided by the position sample.
+    /// </summary>
+    public string? TrackId { get; init; }
+
+    /// <summary>
+    /// Last known status for this track and geofence.
+    /// </summary>
+    public HonuaGeofenceStatus Status { get; init; }
+}
+
+/// <summary>
+/// Mutable transition state for geofence stream evaluation.
+/// </summary>
+public sealed class HonuaGeofenceEvaluationState
+{
+    private readonly Dictionary<StateKey, HonuaGeofenceStatus> statuses = new();
+
+    /// <summary>
+    /// Gets a snapshot of tracked geofence statuses.
+    /// </summary>
+    public IReadOnlyList<HonuaGeofenceStateEntry> Entries
+        => statuses
+            .Select(entry => new HonuaGeofenceStateEntry
+            {
+                GeofenceId = entry.Key.GeofenceId,
+                TrackId = string.IsNullOrEmpty(entry.Key.TrackId) ? null : entry.Key.TrackId,
+                Status = entry.Value
+            })
+            .ToArray();
+
+    /// <summary>
+    /// Clears all tracked state.
+    /// </summary>
+    public void Clear()
+        => statuses.Clear();
+
+    internal HonuaGeofenceTransition Update(string geofenceId, string? trackId, HonuaGeofenceStatus status)
+    {
+        var key = new StateKey(geofenceId, trackId ?? string.Empty);
+        statuses.TryGetValue(key, out var previous);
+        var hasPrevious = statuses.ContainsKey(key);
+        statuses[key] = status;
+
+        return hasPrevious
+            ? GetTransition(previous, status)
+            : GetInitialTransition(status);
+    }
+
+    private static HonuaGeofenceTransition GetInitialTransition(HonuaGeofenceStatus status)
+        => status switch
+        {
+            HonuaGeofenceStatus.Inside => HonuaGeofenceTransition.Entered,
+            HonuaGeofenceStatus.Proximity => HonuaGeofenceTransition.Approached,
+            _ => HonuaGeofenceTransition.None
+        };
+
+    private static HonuaGeofenceTransition GetTransition(
+        HonuaGeofenceStatus previous,
+        HonuaGeofenceStatus current)
+        => (previous, current) switch
+        {
+            (HonuaGeofenceStatus.Inside, HonuaGeofenceStatus.Outside) => HonuaGeofenceTransition.Exited,
+            (HonuaGeofenceStatus.Inside, HonuaGeofenceStatus.Proximity) => HonuaGeofenceTransition.Exited,
+            (HonuaGeofenceStatus.Outside, HonuaGeofenceStatus.Inside) => HonuaGeofenceTransition.Entered,
+            (HonuaGeofenceStatus.Proximity, HonuaGeofenceStatus.Inside) => HonuaGeofenceTransition.Entered,
+            (HonuaGeofenceStatus.Outside, HonuaGeofenceStatus.Proximity) => HonuaGeofenceTransition.Approached,
+            (HonuaGeofenceStatus.Proximity, HonuaGeofenceStatus.Outside) => HonuaGeofenceTransition.Departed,
+            _ => HonuaGeofenceTransition.None
+        };
+
+    private readonly record struct StateKey(string GeofenceId, string TrackId);
+}
+
+/// <summary>
+/// NTS-backed geofence evaluator for current positions and position streams.
+/// </summary>
+public sealed class HonuaGeofenceEvaluator
+{
+    private readonly PreparedGeofence[] geofences;
+    private readonly PlanarGeometryAnalysisOptions? options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaGeofenceEvaluator"/> class.
+    /// </summary>
+    /// <param name="definitions">Geofence definitions to evaluate.</param>
+    /// <param name="options">Optional projection and coordinate policy.</param>
+    public HonuaGeofenceEvaluator(
+        IEnumerable<HonuaGeofenceDefinition> definitions,
+        PlanarGeometryAnalysisOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+
+        this.options = options;
+        geofences = definitions.Select(definition => PrepareDefinition(definition, options)).ToArray();
+        if (geofences.Length == 0)
+        {
+            throw new ArgumentException("At least one geofence definition is required.", nameof(definitions));
+        }
+    }
+
+    /// <summary>
+    /// Evaluates one position against every geofence.
+    /// </summary>
+    /// <param name="position">Position to evaluate.</param>
+    /// <param name="state">Optional transition state. When omitted, transitions are <see cref="HonuaGeofenceTransition.None"/>.</param>
+    /// <returns>Evaluation results for each geofence.</returns>
+    public IReadOnlyList<HonuaGeofenceEvaluation> Evaluate(
+        HonuaGeofencePosition position,
+        HonuaGeofenceEvaluationState? state = null)
+    {
+        ArgumentNullException.ThrowIfNull(position);
+        ArgumentNullException.ThrowIfNull(position.Location);
+
+        var point = PreparePosition(position.Location);
+        var evaluations = new List<HonuaGeofenceEvaluation>(geofences.Length);
+
+        foreach (var geofence in geofences)
+        {
+            EnsureCompatibleKnownSrids(geofence.ActiveGeometry, point, options);
+
+            var inside = geofence.PreparedGeometry.Covers(point);
+            var distance = inside ? 0 : geofence.ActiveGeometry.Distance(point);
+            var status = GetStatus(inside, distance, geofence.Definition.ProximityDistance);
+            var transition = state?.Update(geofence.Definition.GeofenceId, position.TrackId, status) ??
+                HonuaGeofenceTransition.None;
+
+            evaluations.Add(new HonuaGeofenceEvaluation
+            {
+                Definition = geofence.Definition,
+                Position = position,
+                GeofenceId = geofence.Definition.GeofenceId,
+                Status = status,
+                Transition = transition,
+                Distance = distance
+            });
+        }
+
+        return evaluations;
+    }
+
+    /// <summary>
+    /// Evaluates a sequence of positions using a shared transition state.
+    /// </summary>
+    /// <param name="positions">Position sequence.</param>
+    /// <param name="state">Optional state object. A new state is created when omitted.</param>
+    /// <returns>Evaluation results in position order.</returns>
+    public IEnumerable<HonuaGeofenceEvaluation> Evaluate(
+        IEnumerable<HonuaGeofencePosition> positions,
+        HonuaGeofenceEvaluationState? state = null)
+    {
+        ArgumentNullException.ThrowIfNull(positions);
+
+        var runningState = state ?? new HonuaGeofenceEvaluationState();
+        foreach (var position in positions)
+        {
+            foreach (var evaluation in Evaluate(position, runningState))
+            {
+                yield return evaluation;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an asynchronous position stream using a shared transition state.
+    /// </summary>
+    /// <param name="positions">Asynchronous position stream.</param>
+    /// <param name="state">Optional state object. A new state is created when omitted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Evaluation results in stream order.</returns>
+    public async IAsyncEnumerable<HonuaGeofenceEvaluation> EvaluateAsync(
+        IAsyncEnumerable<HonuaGeofencePosition> positions,
+        HonuaGeofenceEvaluationState? state = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(positions);
+
+        var runningState = state ?? new HonuaGeofenceEvaluationState();
+        await foreach (var position in positions.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var evaluation in Evaluate(position, runningState))
+            {
+                yield return evaluation;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Evaluates normalized feature stream events using a shared transition state and sequence rejection.
+    /// </summary>
+    /// <param name="featureEvents">Feature stream events to evaluate.</param>
+    /// <param name="positionSelector">Maps accepted feature stream events to position samples. Return <see langword="null"/> to skip an event.</param>
+    /// <param name="state">Optional state object. A new state is created when omitted.</param>
+    /// <param name="sequenceProcessor">
+    /// Optional stream sequence processor. A new processor is created when omitted so duplicate and stale events are rejected by default.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Evaluation results in accepted stream-event order.</returns>
+    public async IAsyncEnumerable<HonuaGeofenceEvaluation> EvaluateFeatureStreamAsync(
+        IAsyncEnumerable<FeatureStreamEvent> featureEvents,
+        Func<FeatureStreamEvent, HonuaGeofencePosition?> positionSelector,
+        HonuaGeofenceEvaluationState? state = null,
+        FeatureStreamEventProcessor? sequenceProcessor = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvents);
+        ArgumentNullException.ThrowIfNull(positionSelector);
+
+        var runningState = state ?? new HonuaGeofenceEvaluationState();
+        var processor = sequenceProcessor ?? new FeatureStreamEventProcessor();
+        await foreach (var featureEvent in featureEvents.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            if (!IsPositionEvent(featureEvent))
+            {
+                continue;
+            }
+
+            var sequenceResult = processor.Process(featureEvent);
+            if (!sequenceResult.Accepted)
+            {
+                continue;
+            }
+
+            var position = positionSelector(featureEvent);
+            if (position is null)
+            {
+                continue;
+            }
+
+            foreach (var evaluation in Evaluate(position, runningState))
+            {
+                yield return evaluation;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a position sample from a point feature stream event.
+    /// </summary>
+    /// <param name="featureEvent">Feature stream event carrying point geometry.</param>
+    /// <param name="geometryFactory">Optional geometry factory used when the stream geometry omits a spatial reference.</param>
+    /// <returns>A position sample, or <see langword="null"/> when the event does not carry position geometry.</returns>
+    public static HonuaGeofencePosition? CreatePositionFromFeatureEvent(
+        FeatureStreamEvent featureEvent,
+        GeometryFactory? geometryFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(featureEvent);
+
+        if (!IsPositionEvent(featureEvent) ||
+            featureEvent.Geometry is not { } geometry ||
+            geometry.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        var point = ReadPointGeometry(geometry, geometryFactory);
+        return new HonuaGeofencePosition
+        {
+            Location = point,
+            Timestamp = featureEvent.Timestamp,
+            TrackId = featureEvent.FeatureId ?? featureEvent.ObjectId?.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
+    private static PreparedGeofence PrepareDefinition(
+        HonuaGeofenceDefinition definition,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(definition.GeofenceId);
+        ArgumentNullException.ThrowIfNull(definition.Geometry);
+        EnsureNotEmpty(definition.Geometry, nameof(definition.Geometry));
+        EnsureFinite(definition.BufferDistance, nameof(definition.BufferDistance));
+        ArgumentOutOfRangeException.ThrowIfNegative(definition.BufferDistance);
+
+        if (definition.ProximityDistance is { } proximityDistance)
+        {
+            EnsureFinite(proximityDistance, nameof(definition.ProximityDistance));
+            ArgumentOutOfRangeException.ThrowIfNegative(proximityDistance);
+        }
+
+        var requiresPlanarMeasurement = definition.BufferDistance > 0 || definition.ProximityDistance > 0;
+        var activeGeometry = ProjectForAnalysis(definition.Geometry, options);
+        EnsureMeasurementCoordinatePolicy(activeGeometry, options, requiresPlanarMeasurement);
+
+        if (definition.BufferDistance > 0)
+        {
+            activeGeometry = activeGeometry.Buffer(definition.BufferDistance);
+            EnsureNotEmpty(activeGeometry, nameof(definition.Geometry));
+        }
+
+        return new PreparedGeofence(
+            definition,
+            activeGeometry,
+            PreparedGeometryFactory.Prepare(activeGeometry));
+    }
+
+    private static HonuaGeofenceStatus GetStatus(bool inside, double distance, double? proximityDistance)
+    {
+        if (inside)
+        {
+            return HonuaGeofenceStatus.Inside;
+        }
+
+        return proximityDistance is not null && distance <= proximityDistance
+            ? HonuaGeofenceStatus.Proximity
+            : HonuaGeofenceStatus.Outside;
+    }
+
+    private Point PreparePosition(Point location)
+    {
+        EnsureNotEmpty(location, nameof(location));
+        var projected = ProjectForAnalysis(location, options);
+        return projected as Point ??
+            throw new InvalidOperationException("Projected geofence position did not remain a point geometry.");
+    }
+
+    private static bool IsPositionEvent(FeatureStreamEvent featureEvent)
+        => featureEvent.Kind is FeatureStreamEventKind.Insert or FeatureStreamEventKind.Update;
+
+    private static Point ReadPointGeometry(JsonElement geometry, GeometryFactory? geometryFactory)
+    {
+        var parsed = IsGeoJsonGeometry(geometry)
+            ? GeoJsonGeometryConverter.ReadGeometry(geometry, geometryFactory)
+            : GeoServicesGeometryConverter.ReadGeometry(geometry, geometryFactory);
+
+        return parsed as Point ??
+            throw new InvalidOperationException("Feature stream geometry must be a point for geofence position evaluation.");
+    }
+
+    private static bool IsGeoJsonGeometry(JsonElement geometry)
+        => geometry.ValueKind == JsonValueKind.Object &&
+           geometry.TryGetProperty("type", out var type) &&
+           type.ValueKind == JsonValueKind.String;
+
+    private static NtsGeometry ProjectForAnalysis(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.AnalysisSpatialReference is not { } target)
+        {
+            return geometry;
+        }
+
+        var source = ResolveSourceSpatialReference(geometry, options)
+            ?? throw new InvalidOperationException(
+                "SourceSpatialReference or geometry SRID is required when AnalysisSpatialReference is supplied.");
+
+        if (AreEquivalent(source, target))
+        {
+            return geometry;
+        }
+
+        var transformer = options.CoordinateTransformer ?? new HonuaCoordinateTransformer();
+        return transformer.Transform(geometry, source, target);
+    }
+
+    private static void EnsureCompatibleKnownSrids(
+        NtsGeometry first,
+        NtsGeometry second,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.AnalysisSpatialReference is not null ||
+            first.SRID <= 0 ||
+            second.SRID <= 0 ||
+            first.SRID == second.SRID)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Geometry SRIDs differ ({first.SRID} and {second.SRID}); supply an analysis spatial reference.");
+    }
+
+    private static void EnsureMeasurementCoordinatePolicy(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options,
+        bool requirePlanarMeasurement)
+    {
+        if (!requirePlanarMeasurement ||
+            options?.AnalysisSpatialReference is not null ||
+            options?.AllowGeographicMeasurements == true)
+        {
+            return;
+        }
+
+        var source = ResolveSourceSpatialReference(geometry, options);
+        if (source?.Wkid == 4326)
+        {
+            throw new InvalidOperationException(
+                "Planar geofence distances on EPSG:4326 coordinates are disabled by default; supply AnalysisSpatialReference for projection or set AllowGeographicMeasurements.");
+        }
+    }
+
+    private static HonuaSpatialReference? ResolveSourceSpatialReference(
+        NtsGeometry geometry,
+        PlanarGeometryAnalysisOptions? options)
+    {
+        if (options?.SourceSpatialReference is { } source)
+        {
+            return source;
+        }
+
+        return geometry.SRID > 0 ? HonuaSpatialReference.FromWkid(geometry.SRID) : null;
+    }
+
+    private static bool AreEquivalent(
+        HonuaSpatialReference first,
+        HonuaSpatialReference second)
+    {
+        if (first.Wkid is int firstWkid && second.Wkid is int secondWkid)
+        {
+            return firstWkid == secondWkid;
+        }
+
+        if (!string.IsNullOrWhiteSpace(first.Authority) &&
+            !string.IsNullOrWhiteSpace(second.Authority) &&
+            first.Code is int firstCode &&
+            second.Code is int secondCode)
+        {
+            return firstCode == secondCode &&
+                first.Authority.Equals(second.Authority, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (!string.IsNullOrWhiteSpace(first.Wkt) || !string.IsNullOrWhiteSpace(second.Wkt))
+        {
+            return string.Equals(first.Wkt, second.Wkt, StringComparison.Ordinal);
+        }
+
+        return first.Identifier.Equals(second.Identifier, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void EnsureNotEmpty(NtsGeometry geometry, string parameterName)
+    {
+        if (geometry.IsEmpty)
+        {
+            throw new ArgumentException("Geometry must not be empty.", parameterName);
+        }
+    }
+
+    private static void EnsureFinite(double value, string parameterName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Value must be finite.");
+        }
+    }
+
+    private sealed record PreparedGeofence(
+        HonuaGeofenceDefinition Definition,
+        NtsGeometry ActiveGeometry,
+        IPreparedGeometry PreparedGeometry);
+}

--- a/tests/Honua.Sdk.Geometry.Tests/Honua.Sdk.Geometry.Tests.csproj
+++ b/tests/Honua.Sdk.Geometry.Tests/Honua.Sdk.Geometry.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 

--- a/tests/Honua.Sdk.Geometry.Tests/HonuaGeofenceEvaluatorTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/HonuaGeofenceEvaluatorTests.cs
@@ -1,0 +1,315 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Geometry;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry.Tests;
+
+public sealed class HonuaGeofenceEvaluatorTests
+{
+    private static readonly GeometryFactory ProjectedFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory(srid: 3857);
+
+    private static readonly GeometryFactory Wgs84Factory =
+        NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+
+    [Fact]
+    public void Evaluate_BufferedDefinition_ReturnsInsideProximityAndOutsideStatuses()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(bufferDistance: 2, proximityDistance: 5)
+        ]);
+
+        var inside = evaluator.Evaluate(CreatePosition(11, 5)).Single();
+        var proximity = evaluator.Evaluate(CreatePosition(14, 5)).Single();
+        var outside = evaluator.Evaluate(CreatePosition(25, 5)).Single();
+
+        Assert.Equal(HonuaGeofenceStatus.Inside, inside.Status);
+        Assert.Equal(0, inside.Distance);
+        Assert.Equal(HonuaGeofenceStatus.Proximity, proximity.Status);
+        Assert.InRange(proximity.Distance, 1.9, 2.1);
+        Assert.Equal(HonuaGeofenceStatus.Outside, outside.Status);
+    }
+
+    [Fact]
+    public void Evaluate_WithState_ReturnsEnterExitAndProximityTransitions()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(proximityDistance: 5)
+        ]);
+        var state = new HonuaGeofenceEvaluationState();
+
+        var outside = evaluator.Evaluate(CreatePosition(25, 5, trackId: "truck-1"), state).Single();
+        var approach = evaluator.Evaluate(CreatePosition(14, 5, trackId: "truck-1"), state).Single();
+        var enter = evaluator.Evaluate(CreatePosition(5, 5, trackId: "truck-1"), state).Single();
+        var exit = evaluator.Evaluate(CreatePosition(25, 5, trackId: "truck-1"), state).Single();
+
+        Assert.Equal(HonuaGeofenceTransition.None, outside.Transition);
+        Assert.Equal(HonuaGeofenceTransition.Approached, approach.Transition);
+        Assert.Equal(HonuaGeofenceTransition.Entered, enter.Transition);
+        Assert.Equal(HonuaGeofenceTransition.Exited, exit.Transition);
+        Assert.Contains(state.Entries, entry =>
+            entry.GeofenceId == "yard" &&
+            entry.TrackId == "truck-1" &&
+            entry.Status == HonuaGeofenceStatus.Outside);
+    }
+
+    [Fact]
+    public void Evaluate_PositionSequence_UsesSharedTransitionState()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(proximityDistance: 5)
+        ]);
+
+        var transitions = evaluator.Evaluate(
+            [
+                CreatePosition(14, 5),
+                CreatePosition(5, 5),
+                CreatePosition(14, 5),
+                CreatePosition(25, 5)
+            ])
+            .Select(evaluation => evaluation.Transition)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                HonuaGeofenceTransition.Approached,
+                HonuaGeofenceTransition.Entered,
+                HonuaGeofenceTransition.Exited,
+                HonuaGeofenceTransition.Departed
+            ],
+            transitions);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PositionStream_UsesSharedTransitionState()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(proximityDistance: 5)
+        ]);
+
+        var results = new List<HonuaGeofenceEvaluation>();
+        await foreach (var evaluation in evaluator.EvaluateAsync(CreatePositionStream()))
+        {
+            results.Add(evaluation);
+        }
+
+        Assert.Equal(HonuaGeofenceTransition.Approached, results[0].Transition);
+        Assert.Equal(HonuaGeofenceTransition.Entered, results[1].Transition);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureStreamAsync_RejectsDuplicateAndStaleEvents()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(proximityDistance: 5)
+        ]);
+
+        var results = new List<HonuaGeofenceEvaluation>();
+        await foreach (var evaluation in evaluator.EvaluateFeatureStreamAsync(
+            CreateFeatureEventStream(
+            [
+                FeatureEvent(1, x: 14, y: 5),
+                FeatureEvent(1, x: 5, y: 5),
+                FeatureEvent(0, x: 5, y: 5),
+                FeatureEvent(2, x: 5, y: 5)
+            ]),
+            featureEvent => HonuaGeofenceEvaluator.CreatePositionFromFeatureEvent(featureEvent)))
+        {
+            results.Add(evaluation);
+        }
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(HonuaGeofenceTransition.Approached, results[0].Transition);
+        Assert.Equal(HonuaGeofenceTransition.Entered, results[1].Transition);
+    }
+
+    [Fact]
+    public void CreatePositionFromFeatureEvent_ReadsGeoJsonPoint()
+    {
+        var featureEvent = FeatureEvent(
+            sequenceNumber: 1,
+            geometry: Json("""{"type":"Point","coordinates":[14,5]}"""));
+
+        var position = HonuaGeofenceEvaluator.CreatePositionFromFeatureEvent(
+            featureEvent,
+            ProjectedFactory);
+
+        Assert.NotNull(position);
+        Assert.Equal(14, position.Location.X);
+        Assert.Equal(5, position.Location.Y);
+        Assert.Equal("truck-1", position.TrackId);
+    }
+
+    [Fact]
+    public async Task EvaluateFeatureStreamAsync_ObservesCancellation()
+    {
+        var evaluator = new HonuaGeofenceEvaluator(
+        [
+            CreateDefinition(proximityDistance: 5)
+        ]);
+        using var cts = new CancellationTokenSource();
+        await using var enumerator = evaluator.EvaluateFeatureStreamAsync(
+            CreateCancellableFeatureEventStream(cts.Token),
+            featureEvent => HonuaGeofenceEvaluator.CreatePositionFromFeatureEvent(featureEvent),
+            cancellationToken: cts.Token)
+            .GetAsyncEnumerator(cts.Token);
+
+        Assert.True(await enumerator.MoveNextAsync());
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await enumerator.MoveNextAsync().AsTask());
+    }
+
+    [Fact]
+    public void Definition_CarriesSourceQueryMetadata()
+    {
+        var definition = CreateDefinition(
+            source: new SourceDescriptor
+            {
+                Id = "yards",
+                Protocol = FeatureProtocolIds.OgcFeatures,
+                Locator = new SourceLocator { CollectionId = "yards" }
+            },
+            sourceQuery: new SourceQuery
+            {
+                Where = "status = 'active'",
+                ReturnGeometry = true
+            });
+        var evaluator = new HonuaGeofenceEvaluator([definition]);
+
+        var evaluation = evaluator.Evaluate(CreatePosition(5, 5)).Single();
+
+        Assert.Equal("yards", evaluation.Definition.Source?.Id);
+        Assert.Equal("status = 'active'", evaluation.Definition.SourceQuery?.Where);
+    }
+
+    [Fact]
+    public void Evaluate_ProjectsWgs84GeofenceBeforeBufferedEvaluation()
+    {
+        var definition = new HonuaGeofenceDefinition
+        {
+            GeofenceId = "honolulu",
+            Geometry = Wgs84Factory.CreatePoint(new Coordinate(-157.8583, 21.3069)),
+            BufferDistance = 250
+        };
+        var evaluator = new HonuaGeofenceEvaluator([definition], new PlanarGeometryAnalysisOptions
+        {
+            AnalysisSpatialReference = HonuaSpatialReference.WebMercator
+        });
+
+        var evaluation = evaluator.Evaluate(new HonuaGeofencePosition
+        {
+            Location = Wgs84Factory.CreatePoint(new Coordinate(-157.8583, 21.3079))
+        }).Single();
+
+        Assert.Equal(HonuaGeofenceStatus.Inside, evaluation.Status);
+    }
+
+    [Fact]
+    public void Evaluate_RejectsGeographicDistanceWithoutProjection()
+    {
+        var definition = new HonuaGeofenceDefinition
+        {
+            GeofenceId = "honolulu",
+            Geometry = Wgs84Factory.CreatePoint(new Coordinate(-157.8583, 21.3069)),
+            BufferDistance = 250
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new HonuaGeofenceEvaluator([definition]));
+
+        Assert.Contains("EPSG:4326", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static HonuaGeofenceDefinition CreateDefinition(
+        double bufferDistance = 0,
+        double? proximityDistance = null,
+        SourceDescriptor? source = null,
+        SourceQuery? sourceQuery = null)
+        => new()
+        {
+            GeofenceId = "yard",
+            Geometry = ProjectedFactory.CreatePolygon(
+            [
+                new Coordinate(0, 0),
+                new Coordinate(10, 0),
+                new Coordinate(10, 10),
+                new Coordinate(0, 10),
+                new Coordinate(0, 0)
+            ]),
+            BufferDistance = bufferDistance,
+            ProximityDistance = proximityDistance,
+            Source = source,
+            SourceQuery = sourceQuery,
+            Metadata = new Dictionary<string, string> { ["kind"] = "operations-yard" }
+        };
+
+    private static HonuaGeofencePosition CreatePosition(double x, double y, string? trackId = null)
+        => new()
+        {
+            Location = ProjectedFactory.CreatePoint(new Coordinate(x, y)),
+            TrackId = trackId,
+            Timestamp = new DateTimeOffset(2026, 4, 30, 12, 0, 0, TimeSpan.Zero)
+        };
+
+    private static async IAsyncEnumerable<HonuaGeofencePosition> CreatePositionStream()
+    {
+        yield return CreatePosition(14, 5);
+        await Task.Yield();
+        yield return CreatePosition(5, 5);
+    }
+
+    private static async IAsyncEnumerable<FeatureStreamEvent> CreateFeatureEventStream(
+        IEnumerable<FeatureStreamEvent> events)
+    {
+        foreach (var featureEvent in events)
+        {
+            yield return featureEvent;
+            await Task.Yield();
+        }
+    }
+
+    private static async IAsyncEnumerable<FeatureStreamEvent> CreateCancellableFeatureEventStream(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return FeatureEvent(1, x: 14, y: 5);
+        await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+    }
+
+    private static FeatureStreamEvent FeatureEvent(long sequenceNumber, double x, double y)
+        => FeatureEvent(sequenceNumber, Json($$"""
+            {
+              "x": {{x}},
+              "y": {{y}},
+              "spatialReference": { "wkid": 3857 }
+            }
+            """));
+
+    private static FeatureStreamEvent FeatureEvent(long sequenceNumber, JsonElement geometry)
+        => new()
+        {
+            SubscriptionId = "positions",
+            Source = new FeatureSource { ServiceId = "fleet", LayerId = 0 },
+            Kind = FeatureStreamEventKind.Update,
+            FeatureId = "truck-1",
+            Timestamp = new DateTimeOffset(2026, 4, 30, 12, 0, 0, TimeSpan.Zero),
+            SequenceNumber = sequenceNumber,
+            Geometry = geometry
+        };
+
+    private static JsonElement Json(string value)
+    {
+        using var document = JsonDocument.Parse(value);
+        return document.RootElement.Clone();
+    }
+}


### PR DESCRIPTION
## Summary
- add `Honua.Sdk.Geometry` geofence definitions, transition state, and NTS prepared-geometry evaluation
- support current positions, synchronous/asynchronous position streams, and normalized `FeatureStreamEvent` streams
- reject duplicate/stale feature stream events through `FeatureStreamEventProcessor`, with GeoServices/GeoJSON point selectors for stream-backed positions
- document the SDK/host boundary for geofencing and location events

Closes #64.

## Validation
- `dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test Honua.Sdk.sln --configuration Release --no-restore`
- `dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore`
- `git diff --check`
- `scripts/validate-api-compat.sh origin/trunk`

## Notes
- server stream/outbox dependencies remain tracked in honua-server#339 and honua-server#692
- mobile duplicate model removal remains the companion consumption task in honua-mobile#51