### PR TITLE
feat: add utility network trace contracts

### DIFF
--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -26,6 +26,7 @@ rendering stay in host applications or downstream adapter packages.
 | `Honua.Sdk.Grpc` | Not supported for browser runtime | Native gRPC/HTTP2 is not a supported browser path. Treat current browser builds as compile-only. Add gRPC-Web support only after `honua-server` exposes a compatible endpoint and the SDK has a browser-specific transport plan. |
 | Realtime feed contracts | Candidate | `IHonuaFeatureStreamClient`, normalized event envelopes, bounded buffers, and duplicate/stale sequence processors are pure contracts. Browser hosts still own the SSE/WebSocket/gRPC-Web adapter and auth/CORS behavior. |
 | Plugin contracts | Supported | `HonuaPluginManifest` parsing, validation, compatibility metadata, permissions, safe configuration envelopes, and non-UI extension declarations are pure DTO/validator contracts. Browser hosts own plugin loading, sandboxing, UI composition, and execution. |
+| Utility network trace contracts | Supported | `IHonuaUtilityNetworkTraceClient`, trace requests/results, elements, associations, terminals, barriers, and named configurations are pure contracts. Browser hosts own transport adapters and trace-result display. |
 | Display/maps | Out of SDK core | MapLibre/deck.gl, Cesium, Mapsui, renderer caches, controls, and AR/VR anchors belong in viewer/mobile/admin apps or display adapter packages. SDK packages should hand back portable data/contracts. |
 
 ## Explicit Browser Exclusions
@@ -50,7 +51,8 @@ The SDK keeps a Blazor WebAssembly compile smoke in
 packages and registers the REST clients with retry disabled. That gate proves
 the packages can be consumed by a browser app without native compile-time
 dependencies. It also compile-checks pure contracts for field records, offline
-manifests, plugin manifests, and realtime stream envelopes.
+manifests, plugin manifests, realtime stream envelopes, and utility-network
+trace requests.
 
 The smoke app also contains a compile-checked browser feature-map sample. It
 uses `IHonuaOgcFeaturesClient` to query a GeoJSON feature collection, uses

--- a/docs/sdk-capability-backlog.md
+++ b/docs/sdk-capability-backlog.md
@@ -597,6 +597,18 @@ Acceptance criteria:
   workflows if supported by the server.
 - Treat display of trace results as a downstream viewer concern.
 
+SDK implementation:
+
+- `Honua.Sdk.Abstractions.UtilityNetworks` owns the provider-neutral contract
+  surface: trace capabilities, source identifiers, elements, associations,
+  terminals, starting points, barriers, trace configuration queries, named trace
+  configurations, and trace results.
+- `IHonuaUtilityNetworkTraceClient` defines connected, upstream, downstream,
+  and subnetwork trace methods. Concrete server adapters should implement that
+  interface only when Honua Server exposes the corresponding endpoint.
+- Map display, trace highlighting, graph diagrams, and viewer state stay in
+  mobile/admin/viewer repos or display adapter packages.
+
 ### P2.5 Raster, elevation, and enrichment data clients
 
 Outcome: future data APIs have a clear home without becoming display features.

--- a/src/Honua.Sdk.Abstractions/UtilityNetworks/IHonuaUtilityNetworkTraceClient.cs
+++ b/src/Honua.Sdk.Abstractions/UtilityNetworks/IHonuaUtilityNetworkTraceClient.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.UtilityNetworks;
+
+/// <summary>
+/// Provider-neutral utility-network trace client contract.
+/// </summary>
+public interface IHonuaUtilityNetworkTraceClient
+{
+    /// <summary>Stable provider name for diagnostics and adapter selection.</summary>
+    string ProviderName { get; }
+
+    /// <summary>Provider capabilities for utility-network trace operations.</summary>
+    UtilityNetworkTraceCapabilities TraceCapabilities { get; }
+
+    /// <summary>
+    /// Lists named trace configurations advertised by the provider.
+    /// </summary>
+    /// <param name="request">Trace configuration query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Named trace configurations that can be referenced by trace requests.</returns>
+    Task<IReadOnlyList<UtilityNetworkNamedTraceConfiguration>> GetTraceConfigurationsAsync(
+        UtilityNetworkTraceConfigurationQuery request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Traces all elements connected to the request's starting points.
+    /// </summary>
+    /// <param name="request">Trace request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Trace result data for downstream workflow or display adapters.</returns>
+    Task<UtilityNetworkTraceResult> TraceConnectedAsync(
+        UtilityNetworkTraceRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Traces upstream from the request's starting points.
+    /// </summary>
+    /// <param name="request">Trace request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Trace result data for downstream workflow or display adapters.</returns>
+    Task<UtilityNetworkTraceResult> TraceUpstreamAsync(
+        UtilityNetworkTraceRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Traces downstream from the request's starting points.
+    /// </summary>
+    /// <param name="request">Trace request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Trace result data for downstream workflow or display adapters.</returns>
+    Task<UtilityNetworkTraceResult> TraceDownstreamAsync(
+        UtilityNetworkTraceRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Traces the subnetwork reachable from the request's starting points.
+    /// </summary>
+    /// <param name="request">Trace request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Trace result data for downstream workflow or display adapters.</returns>
+    Task<UtilityNetworkTraceResult> TraceSubnetworkAsync(
+        UtilityNetworkTraceRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/UtilityNetworks/UtilityNetworkModels.cs
+++ b/src/Honua.Sdk.Abstractions/UtilityNetworks/UtilityNetworkModels.cs
@@ -1,0 +1,589 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.UtilityNetworks;
+
+/// <summary>
+/// Utility-network trace workflow kind.
+/// </summary>
+public enum UtilityNetworkTraceType
+{
+    /// <summary>Trace type is not specified or is provider-defined.</summary>
+    Unspecified = 0,
+
+    /// <summary>Connected trace workflow.</summary>
+    Connected = 1,
+
+    /// <summary>Upstream trace workflow.</summary>
+    Upstream = 2,
+
+    /// <summary>Downstream trace workflow.</summary>
+    Downstream = 3,
+
+    /// <summary>Subnetwork trace workflow.</summary>
+    Subnetwork = 4,
+
+    /// <summary>Provider-specific trace workflow not covered by the canonical values.</summary>
+    Custom = 5
+}
+
+/// <summary>
+/// Utility-network element category.
+/// </summary>
+public enum UtilityNetworkElementKind
+{
+    /// <summary>Element kind is unknown.</summary>
+    Unknown = 0,
+
+    /// <summary>Junction or point-like network element.</summary>
+    Junction = 1,
+
+    /// <summary>Edge or line-like network element.</summary>
+    Edge = 2,
+
+    /// <summary>Device element.</summary>
+    Device = 3,
+
+    /// <summary>Line element.</summary>
+    Line = 4,
+
+    /// <summary>Assembly element.</summary>
+    Assembly = 5,
+
+    /// <summary>Container element.</summary>
+    Container = 6,
+
+    /// <summary>Structure junction element.</summary>
+    StructureJunction = 7,
+
+    /// <summary>Structure line element.</summary>
+    StructureLine = 8,
+
+    /// <summary>Subnetwork controller or subnetwork summary element.</summary>
+    Subnetwork = 9
+}
+
+/// <summary>
+/// Utility-network association category.
+/// </summary>
+public enum UtilityNetworkAssociationKind
+{
+    /// <summary>Association kind is unknown.</summary>
+    Unknown = 0,
+
+    /// <summary>Connectivity association between two elements.</summary>
+    Connectivity = 1,
+
+    /// <summary>Containment association between a container and content.</summary>
+    Containment = 2,
+
+    /// <summary>Structural attachment association.</summary>
+    StructuralAttachment = 3
+}
+
+/// <summary>
+/// Utility-network trace barrier category.
+/// </summary>
+public enum UtilityNetworkTraceBarrierKind
+{
+    /// <summary>Barrier kind is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Barrier stops traversal at a specific element.</summary>
+    Traversability = 1,
+
+    /// <summary>Barrier filters results without necessarily stopping traversal.</summary>
+    Filter = 2,
+
+    /// <summary>Barrier is created from a provider-side condition or function.</summary>
+    Function = 3
+}
+
+/// <summary>
+/// Utility-network trace condition operator.
+/// </summary>
+public enum UtilityNetworkTraceConditionOperator
+{
+    /// <summary>Operator is not specified.</summary>
+    Unspecified = 0,
+
+    /// <summary>Left value equals the right value.</summary>
+    Equal = 1,
+
+    /// <summary>Left value does not equal the right value.</summary>
+    NotEqual = 2,
+
+    /// <summary>Left value is greater than the right value.</summary>
+    GreaterThan = 3,
+
+    /// <summary>Left value is greater than or equal to the right value.</summary>
+    GreaterThanOrEqual = 4,
+
+    /// <summary>Left value is less than the right value.</summary>
+    LessThan = 5,
+
+    /// <summary>Left value is less than or equal to the right value.</summary>
+    LessThanOrEqual = 6,
+
+    /// <summary>Left value is included in a provider-defined set.</summary>
+    IncludesAny = 7,
+
+    /// <summary>Left value excludes a provider-defined set.</summary>
+    ExcludesAll = 8
+}
+
+/// <summary>
+/// Utility-network trace message severity.
+/// </summary>
+public enum UtilityNetworkTraceMessageSeverity
+{
+    /// <summary>Informational trace message.</summary>
+    Information = 0,
+
+    /// <summary>Trace warning that does not block the result.</summary>
+    Warning = 1,
+
+    /// <summary>Trace error reported by the provider.</summary>
+    Error = 2
+}
+
+/// <summary>
+/// Utility-network source identifiers used by trace requests.
+/// </summary>
+public sealed record UtilityNetworkSource
+{
+    /// <summary>Honua service identifier or provider network service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Provider network identifier.</summary>
+    public string? NetworkId { get; init; }
+
+    /// <summary>Provider network display or lookup name.</summary>
+    public string? NetworkName { get; init; }
+
+    /// <summary>Optional branch or version name used by version-aware providers.</summary>
+    public string? VersionName { get; init; }
+
+    /// <summary>Additional provider-neutral feature source identifiers.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+}
+
+/// <summary>
+/// Provider utility-network trace capabilities.
+/// </summary>
+public sealed record UtilityNetworkTraceCapabilities
+{
+    /// <summary>Whether connected traces are supported.</summary>
+    public bool SupportsConnectedTrace { get; init; }
+
+    /// <summary>Whether upstream traces are supported.</summary>
+    public bool SupportsUpstreamTrace { get; init; }
+
+    /// <summary>Whether downstream traces are supported.</summary>
+    public bool SupportsDownstreamTrace { get; init; }
+
+    /// <summary>Whether subnetwork traces are supported.</summary>
+    public bool SupportsSubnetworkTrace { get; init; }
+
+    /// <summary>Whether named trace configurations can be discovered or referenced.</summary>
+    public bool SupportsNamedTraceConfigurations { get; init; }
+
+    /// <summary>Whether terminal-specific starting points and barriers are supported.</summary>
+    public bool SupportsTerminals { get; init; }
+
+    /// <summary>Whether association details can be returned.</summary>
+    public bool SupportsAssociations { get; init; }
+
+    /// <summary>Whether barriers can be sent with trace requests.</summary>
+    public bool SupportsBarriers { get; init; }
+
+    /// <summary>Whether provider result payloads can include geometry data.</summary>
+    public bool SupportsResultGeometry { get; init; }
+
+    /// <summary>Native provider surface backing the implementation.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason the capability set is unavailable, when applicable.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Lightweight reference to a utility-network element.
+/// </summary>
+public sealed record UtilityNetworkElementReference
+{
+    /// <summary>Stable provider or SDK element identifier.</summary>
+    public required string ElementId { get; init; }
+
+    /// <summary>Provider network source identifier.</summary>
+    public string? NetworkSourceId { get; init; }
+
+    /// <summary>Provider network source name.</summary>
+    public string? NetworkSourceName { get; init; }
+
+    /// <summary>Feature object identifier when the element maps to a feature row.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Feature global identifier when the element maps to a feature row.</summary>
+    public string? GlobalId { get; init; }
+
+    /// <summary>Terminal identifier used for terminal-specific traces.</summary>
+    public string? TerminalId { get; init; }
+
+    /// <summary>Provider-neutral feature source identifiers for the referenced element.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+}
+
+/// <summary>
+/// Utility-network element returned by a trace result.
+/// </summary>
+public sealed record UtilityNetworkElement
+{
+    /// <summary>Stable provider or SDK element identifier.</summary>
+    public required string ElementId { get; init; }
+
+    /// <summary>Element category.</summary>
+    public UtilityNetworkElementKind Kind { get; init; } = UtilityNetworkElementKind.Unknown;
+
+    /// <summary>Provider network source identifier.</summary>
+    public string? NetworkSourceId { get; init; }
+
+    /// <summary>Provider network source name.</summary>
+    public string? NetworkSourceName { get; init; }
+
+    /// <summary>Feature object identifier when the element maps to a feature row.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Feature global identifier when the element maps to a feature row.</summary>
+    public string? GlobalId { get; init; }
+
+    /// <summary>Asset group code or name advertised by the provider.</summary>
+    public string? AssetGroup { get; init; }
+
+    /// <summary>Asset type code or name advertised by the provider.</summary>
+    public string? AssetType { get; init; }
+
+    /// <summary>Terminal identifier used when the trace result is terminal-specific.</summary>
+    public string? TerminalId { get; init; }
+
+    /// <summary>Terminal display or lookup name used when the trace result is terminal-specific.</summary>
+    public string? TerminalName { get; init; }
+
+    /// <summary>Provider-neutral feature source identifiers for this element.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+
+    /// <summary>Optional geometry data returned by the provider. Rendering is owned by downstream viewers.</summary>
+    public JsonElement? Geometry { get; init; }
+
+    /// <summary>Provider or SDK attributes associated with the element.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Terminal metadata for utility-network elements.
+/// </summary>
+public sealed record UtilityNetworkTerminal
+{
+    /// <summary>Stable terminal identifier.</summary>
+    public required string TerminalId { get; init; }
+
+    /// <summary>Terminal display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Element that owns the terminal, when known.</summary>
+    public UtilityNetworkElementReference? Element { get; init; }
+
+    /// <summary>Whether this terminal is the provider default for the owning element.</summary>
+    public bool IsDefault { get; init; }
+
+    /// <summary>Provider or SDK attributes associated with the terminal.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Association between two utility-network elements.
+/// </summary>
+public sealed record UtilityNetworkAssociation
+{
+    /// <summary>Stable association identifier.</summary>
+    public required string AssociationId { get; init; }
+
+    /// <summary>Association category.</summary>
+    public UtilityNetworkAssociationKind Kind { get; init; } = UtilityNetworkAssociationKind.Unknown;
+
+    /// <summary>First endpoint of the association.</summary>
+    public required UtilityNetworkElementReference FromElement { get; init; }
+
+    /// <summary>Second endpoint of the association.</summary>
+    public required UtilityNetworkElementReference ToElement { get; init; }
+
+    /// <summary>Provider or SDK attributes associated with the association.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Utility-network trace condition used by configuration and barrier rules.
+/// </summary>
+public sealed record UtilityNetworkTraceCondition
+{
+    /// <summary>Provider network attribute, category, or function name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Condition comparison operator.</summary>
+    public UtilityNetworkTraceConditionOperator Operator { get; init; } = UtilityNetworkTraceConditionOperator.Unspecified;
+
+    /// <summary>Comparison value, when the provider condition requires one.</summary>
+    public JsonElement? Value { get; init; }
+
+    /// <summary>Whether the condition should be negated.</summary>
+    public bool Negate { get; init; }
+}
+
+/// <summary>
+/// Inline trace configuration shared by all utility-network trace workflows.
+/// </summary>
+public sealed record UtilityNetworkTraceConfiguration
+{
+    /// <summary>Trace workflow kind represented by the configuration.</summary>
+    public UtilityNetworkTraceType TraceType { get; init; } = UtilityNetworkTraceType.Unspecified;
+
+    /// <summary>Provider domain network name.</summary>
+    public string? DomainNetwork { get; init; }
+
+    /// <summary>Provider source tier name.</summary>
+    public string? Tier { get; init; }
+
+    /// <summary>Provider target tier name used by tier-aware traces.</summary>
+    public string? TargetTier { get; init; }
+
+    /// <summary>Subnetwork name used by subnetwork traces.</summary>
+    public string? SubnetworkName { get; init; }
+
+    /// <summary>Traversal conditions applied by the provider.</summary>
+    public IReadOnlyList<UtilityNetworkTraceCondition> TraversabilityConditions { get; init; } = [];
+
+    /// <summary>Filter conditions applied to returned results.</summary>
+    public IReadOnlyList<UtilityNetworkTraceCondition> FilterConditions { get; init; } = [];
+
+    /// <summary>Network attribute names requested in the trace result.</summary>
+    public IReadOnlyList<string> OutputNetworkAttributes { get; init; } = [];
+
+    /// <summary>Whether container elements should be included when the provider supports them.</summary>
+    public bool IncludeContainers { get; init; }
+
+    /// <summary>Whether contained content should be included when the provider supports it.</summary>
+    public bool IncludeContent { get; init; }
+
+    /// <summary>Whether structure elements should be included when the provider supports them.</summary>
+    public bool IncludeStructures { get; init; }
+
+    /// <summary>Whether the provider should validate network topology consistency before tracing.</summary>
+    public bool ValidateConsistency { get; init; }
+
+    /// <summary>Additional provider parameters for server-specific trace extensions.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? ProviderParameters { get; init; }
+}
+
+/// <summary>
+/// Named trace configuration advertised by a utility-network provider.
+/// </summary>
+public sealed record UtilityNetworkNamedTraceConfiguration
+{
+    /// <summary>Stable configuration identifier.</summary>
+    public required string ConfigurationId { get; init; }
+
+    /// <summary>Configuration display or lookup name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Configuration description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Trace workflow kind represented by this named configuration.</summary>
+    public UtilityNetworkTraceType TraceType { get; init; } = UtilityNetworkTraceType.Unspecified;
+
+    /// <summary>Inline configuration details, when the provider exposes them.</summary>
+    public UtilityNetworkTraceConfiguration? Configuration { get; init; }
+
+    /// <summary>Whether this is the provider default for its trace workflow or tier.</summary>
+    public bool IsDefault { get; init; }
+
+    /// <summary>Provider or SDK metadata associated with the named configuration.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Metadata { get; init; }
+}
+
+/// <summary>
+/// Query used to discover named utility-network trace configurations.
+/// </summary>
+public sealed record UtilityNetworkTraceConfigurationQuery
+{
+    /// <summary>Utility-network source identifiers.</summary>
+    public UtilityNetworkSource Source { get; init; } = new();
+
+    /// <summary>Optional trace workflow kind filter.</summary>
+    public UtilityNetworkTraceType? TraceType { get; init; }
+
+    /// <summary>Optional provider domain network name filter.</summary>
+    public string? DomainNetwork { get; init; }
+
+    /// <summary>Optional provider tier name filter.</summary>
+    public string? Tier { get; init; }
+
+    /// <summary>Whether inactive or hidden provider configurations should be included.</summary>
+    public bool IncludeInactive { get; init; }
+}
+
+/// <summary>
+/// Starting point for a utility-network trace.
+/// </summary>
+public sealed record UtilityNetworkTraceStartingPoint
+{
+    /// <summary>Trace starting element.</summary>
+    public required UtilityNetworkElementReference Element { get; init; }
+
+    /// <summary>Optional terminal identifier overriding the element reference terminal.</summary>
+    public string? TerminalId { get; init; }
+
+    /// <summary>Optional percentage along an edge element.</summary>
+    public double? PercentAlong { get; init; }
+
+    /// <summary>Provider or SDK attributes associated with the starting point.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Barrier used by a utility-network trace.
+/// </summary>
+public sealed record UtilityNetworkTraceBarrier
+{
+    /// <summary>Barrier element.</summary>
+    public required UtilityNetworkElementReference Element { get; init; }
+
+    /// <summary>Barrier category.</summary>
+    public UtilityNetworkTraceBarrierKind Kind { get; init; } = UtilityNetworkTraceBarrierKind.Traversability;
+
+    /// <summary>Optional terminal identifier overriding the element reference terminal.</summary>
+    public string? TerminalId { get; init; }
+
+    /// <summary>Optional percentage along an edge element.</summary>
+    public double? PercentAlong { get; init; }
+
+    /// <summary>Provider or SDK attributes associated with the barrier.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Utility-network trace request shared by connected, upstream, downstream, and subnetwork traces.
+/// </summary>
+public sealed record UtilityNetworkTraceRequest
+{
+    /// <summary>Utility-network source identifiers.</summary>
+    public UtilityNetworkSource Source { get; init; } = new();
+
+    /// <summary>Trace starting points.</summary>
+    public required IReadOnlyList<UtilityNetworkTraceStartingPoint> StartingPoints { get; init; }
+
+    /// <summary>Named provider trace configuration identifier.</summary>
+    public string? NamedConfigurationId { get; init; }
+
+    /// <summary>Inline trace configuration for providers that support caller-supplied settings.</summary>
+    public UtilityNetworkTraceConfiguration? Configuration { get; init; }
+
+    /// <summary>Trace barriers.</summary>
+    public IReadOnlyList<UtilityNetworkTraceBarrier> Barriers { get; init; } = [];
+
+    /// <summary>Whether trace result elements should be returned.</summary>
+    public bool ReturnElements { get; init; } = true;
+
+    /// <summary>Whether trace result associations should be returned.</summary>
+    public bool ReturnAssociations { get; init; } = true;
+
+    /// <summary>Whether trace result terminals should be returned.</summary>
+    public bool ReturnTerminals { get; init; } = true;
+
+    /// <summary>Whether provider geometry data should be returned for trace result elements.</summary>
+    public bool ReturnGeometry { get; init; }
+
+    /// <summary>Additional provider parameters for server-specific trace extensions.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? ProviderParameters { get; init; }
+}
+
+/// <summary>
+/// Subnetwork summary returned by a utility-network trace.
+/// </summary>
+public sealed record UtilityNetworkSubnetworkResult
+{
+    /// <summary>Subnetwork display or lookup name.</summary>
+    public required string SubnetworkName { get; init; }
+
+    /// <summary>Provider domain network name.</summary>
+    public string? DomainNetwork { get; init; }
+
+    /// <summary>Provider tier name.</summary>
+    public string? Tier { get; init; }
+
+    /// <summary>Subnetwork controller elements returned by the provider.</summary>
+    public IReadOnlyList<UtilityNetworkElementReference> Controllers { get; init; } = [];
+
+    /// <summary>Provider or SDK attributes associated with the subnetwork.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Provider message returned with a utility-network trace result.
+/// </summary>
+public sealed record UtilityNetworkTraceMessage
+{
+    /// <summary>Message severity.</summary>
+    public UtilityNetworkTraceMessageSeverity Severity { get; init; } = UtilityNetworkTraceMessageSeverity.Information;
+
+    /// <summary>Provider or SDK message code.</summary>
+    public string? Code { get; init; }
+
+    /// <summary>Human-readable message text.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Element associated with the message, when applicable.</summary>
+    public UtilityNetworkElementReference? Element { get; init; }
+}
+
+/// <summary>
+/// Utility-network trace result data. Display and map rendering are downstream responsibilities.
+/// </summary>
+public sealed record UtilityNetworkTraceResult
+{
+    /// <summary>Trace workflow kind that produced this result.</summary>
+    public UtilityNetworkTraceType TraceType { get; init; } = UtilityNetworkTraceType.Unspecified;
+
+    /// <summary>Provider trace identifier.</summary>
+    public string? TraceId { get; init; }
+
+    /// <summary>Named configuration identifier used by the trace, when applicable.</summary>
+    public string? ConfigurationId { get; init; }
+
+    /// <summary>Whether the provider completed the trace successfully.</summary>
+    public bool Succeeded { get; init; }
+
+    /// <summary>Elements returned by the trace.</summary>
+    public IReadOnlyList<UtilityNetworkElement> Elements { get; init; } = [];
+
+    /// <summary>Associations returned by the trace.</summary>
+    public IReadOnlyList<UtilityNetworkAssociation> Associations { get; init; } = [];
+
+    /// <summary>Terminals returned by the trace.</summary>
+    public IReadOnlyList<UtilityNetworkTerminal> Terminals { get; init; } = [];
+
+    /// <summary>Subnetwork summaries returned by the trace.</summary>
+    public IReadOnlyList<UtilityNetworkSubnetworkResult> Subnetworks { get; init; } = [];
+
+    /// <summary>Provider messages returned with the trace.</summary>
+    public IReadOnlyList<UtilityNetworkTraceMessage> Messages { get; init; } = [];
+
+    /// <summary>Provider or SDK scalar outputs associated with the trace.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Outputs { get; init; }
+
+    /// <summary>Raw provider response, when the implementation exposes one.</summary>
+    public JsonElement? RawResponse { get; init; }
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/UtilityNetworkContractTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/UtilityNetworkContractTests.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Abstractions.UtilityNetworks;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class UtilityNetworkContractTests
+{
+    [Fact]
+    public void TraceRequest_ModelsNamedConfigurationsTerminalsAndBarriers()
+    {
+        var startingElement = ElementReference("switch-1", terminalId: "load");
+        var barrierElement = ElementReference("fuse-9");
+
+        var request = new UtilityNetworkTraceRequest
+        {
+            Source = new UtilityNetworkSource
+            {
+                ServiceId = "electric",
+                NetworkId = "distribution",
+                VersionName = "sde.DEFAULT",
+                FeatureSource = new FeatureSource { ServiceId = "electric", LayerId = 0 },
+            },
+            NamedConfigurationId = "primary-upstream",
+            StartingPoints =
+            [
+                new UtilityNetworkTraceStartingPoint
+                {
+                    Element = startingElement,
+                    TerminalId = "load",
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["phase"] = JsonValue("\"A\""),
+                    },
+                },
+            ],
+            Barriers =
+            [
+                new UtilityNetworkTraceBarrier
+                {
+                    Element = barrierElement,
+                    Kind = UtilityNetworkTraceBarrierKind.Filter,
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["reason"] = JsonValue("\"open-switch\""),
+                    },
+                },
+            ],
+            Configuration = new UtilityNetworkTraceConfiguration
+            {
+                TraceType = UtilityNetworkTraceType.Upstream,
+                DomainNetwork = "ElectricDistribution",
+                Tier = "MediumVoltage",
+                ValidateConsistency = true,
+                TraversabilityConditions =
+                [
+                    new UtilityNetworkTraceCondition
+                    {
+                        Name = "phase",
+                        Operator = UtilityNetworkTraceConditionOperator.Equal,
+                        Value = JsonValue("\"A\""),
+                    },
+                ],
+                OutputNetworkAttributes = ["phase", "status"],
+            },
+            ReturnGeometry = true,
+        };
+
+        Assert.Equal("primary-upstream", request.NamedConfigurationId);
+        Assert.Equal("load", request.StartingPoints[0].TerminalId);
+        Assert.Equal(UtilityNetworkTraceBarrierKind.Filter, request.Barriers[0].Kind);
+        var configuration = Assert.IsType<UtilityNetworkTraceConfiguration>(request.Configuration);
+        Assert.Equal("MediumVoltage", configuration.Tier);
+        Assert.True(configuration.ValidateConsistency);
+        Assert.True(request.ReturnAssociations);
+        Assert.True(request.ReturnGeometry);
+    }
+
+    [Fact]
+    public async Task Interface_ModelsTraceWorkflowsAndResultData()
+    {
+        var client = new FakeUtilityNetworkTraceClient();
+        var request = new UtilityNetworkTraceRequest
+        {
+            Source = new UtilityNetworkSource
+            {
+                ServiceId = "electric",
+                NetworkId = "distribution",
+            },
+            NamedConfigurationId = "primary-upstream",
+            StartingPoints =
+            [
+                new UtilityNetworkTraceStartingPoint
+                {
+                    Element = ElementReference("switch-1", terminalId: "load"),
+                },
+            ],
+        };
+
+        var configurations = await client.GetTraceConfigurationsAsync(new UtilityNetworkTraceConfigurationQuery
+        {
+            Source = request.Source,
+            TraceType = UtilityNetworkTraceType.Upstream,
+            DomainNetwork = "ElectricDistribution",
+            Tier = "MediumVoltage",
+        });
+        var connected = await client.TraceConnectedAsync(request);
+        var upstream = await client.TraceUpstreamAsync(request);
+        var downstream = await client.TraceDownstreamAsync(request);
+        var subnetwork = await client.TraceSubnetworkAsync(request);
+
+        Assert.Equal("fake-utility-network", client.ProviderName);
+        Assert.True(client.TraceCapabilities.SupportsNamedTraceConfigurations);
+        Assert.True(client.TraceCapabilities.SupportsTerminals);
+        Assert.Single(configurations);
+        Assert.Equal("primary-upstream", configurations[0].ConfigurationId);
+        Assert.Equal(UtilityNetworkTraceType.Connected, connected.TraceType);
+        Assert.Equal(UtilityNetworkTraceType.Upstream, upstream.TraceType);
+        Assert.Equal(UtilityNetworkTraceType.Downstream, downstream.TraceType);
+        Assert.Equal(UtilityNetworkTraceType.Subnetwork, subnetwork.TraceType);
+        Assert.True(upstream.Succeeded);
+        Assert.Single(upstream.Elements);
+        Assert.Single(upstream.Associations);
+        Assert.Single(upstream.Terminals);
+        Assert.Single(subnetwork.Subnetworks);
+        Assert.Equal("ElectricDistribution", subnetwork.Subnetworks[0].DomainNetwork);
+    }
+
+    private static UtilityNetworkElementReference ElementReference(string elementId, string? terminalId = null)
+        => new()
+        {
+            ElementId = elementId,
+            NetworkSourceId = "devices",
+            NetworkSourceName = "Electric Device",
+            GlobalId = $"{elementId}-global",
+            TerminalId = terminalId,
+            FeatureSource = new FeatureSource { ServiceId = "electric", LayerId = 0 },
+        };
+
+    private static JsonElement JsonValue(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static UtilityNetworkTraceResult Result(UtilityNetworkTraceType traceType)
+    {
+        var from = ElementReference("switch-1", terminalId: "load");
+        var to = ElementReference("transformer-1", terminalId: "source");
+
+        return new UtilityNetworkTraceResult
+        {
+            TraceType = traceType,
+            TraceId = $"trace-{traceType}",
+            ConfigurationId = "primary-upstream",
+            Succeeded = true,
+            Elements =
+            [
+                new UtilityNetworkElement
+                {
+                    ElementId = from.ElementId,
+                    Kind = UtilityNetworkElementKind.Device,
+                    NetworkSourceId = from.NetworkSourceId,
+                    NetworkSourceName = from.NetworkSourceName,
+                    GlobalId = from.GlobalId,
+                    TerminalId = from.TerminalId,
+                    TerminalName = "Load",
+                    FeatureSource = from.FeatureSource,
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["phase"] = JsonValue("\"A\""),
+                    },
+                },
+            ],
+            Associations =
+            [
+                new UtilityNetworkAssociation
+                {
+                    AssociationId = "assoc-1",
+                    Kind = UtilityNetworkAssociationKind.Connectivity,
+                    FromElement = from,
+                    ToElement = to,
+                },
+            ],
+            Terminals =
+            [
+                new UtilityNetworkTerminal
+                {
+                    TerminalId = "load",
+                    Name = "Load",
+                    Element = from,
+                    IsDefault = true,
+                },
+            ],
+            Subnetworks =
+            [
+                new UtilityNetworkSubnetworkResult
+                {
+                    SubnetworkName = "Feeder-1",
+                    DomainNetwork = "ElectricDistribution",
+                    Tier = "MediumVoltage",
+                    Controllers = [to],
+                },
+            ],
+            Messages =
+            [
+                new UtilityNetworkTraceMessage
+                {
+                    Message = "Trace completed.",
+                },
+            ],
+        };
+    }
+
+    private sealed class FakeUtilityNetworkTraceClient : IHonuaUtilityNetworkTraceClient
+    {
+        public string ProviderName => "fake-utility-network";
+
+        public UtilityNetworkTraceCapabilities TraceCapabilities { get; } = new()
+        {
+            SupportsConnectedTrace = true,
+            SupportsUpstreamTrace = true,
+            SupportsDownstreamTrace = true,
+            SupportsSubnetworkTrace = true,
+            SupportsNamedTraceConfigurations = true,
+            SupportsTerminals = true,
+            SupportsAssociations = true,
+            SupportsBarriers = true,
+            SupportsResultGeometry = true,
+            NativeSurface = "test",
+        };
+
+        public Task<IReadOnlyList<UtilityNetworkNamedTraceConfiguration>> GetTraceConfigurationsAsync(
+            UtilityNetworkTraceConfigurationQuery request,
+            CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<UtilityNetworkNamedTraceConfiguration>>(
+            [
+                new UtilityNetworkNamedTraceConfiguration
+                {
+                    ConfigurationId = "primary-upstream",
+                    Name = "Primary upstream",
+                    TraceType = UtilityNetworkTraceType.Upstream,
+                    IsDefault = true,
+                    Configuration = new UtilityNetworkTraceConfiguration
+                    {
+                        TraceType = UtilityNetworkTraceType.Upstream,
+                        DomainNetwork = request.DomainNetwork,
+                        Tier = request.Tier,
+                    },
+                },
+            ]);
+
+        public Task<UtilityNetworkTraceResult> TraceConnectedAsync(
+            UtilityNetworkTraceRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(Result(UtilityNetworkTraceType.Connected));
+
+        public Task<UtilityNetworkTraceResult> TraceUpstreamAsync(
+            UtilityNetworkTraceRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(Result(UtilityNetworkTraceType.Upstream));
+
+        public Task<UtilityNetworkTraceResult> TraceDownstreamAsync(
+            UtilityNetworkTraceRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(Result(UtilityNetworkTraceType.Downstream));
+
+        public Task<UtilityNetworkTraceResult> TraceSubnetworkAsync(
+            UtilityNetworkTraceRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(Result(UtilityNetworkTraceType.Subnetwork));
+    }
+}

--- a/tests/Honua.Sdk.BrowserSmoke/Program.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/Program.cs
@@ -1,5 +1,6 @@
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Plugins;
+using Honua.Sdk.Abstractions.UtilityNetworks;
 using Honua.Sdk.Admin;
 using Honua.Sdk.Admin.Geocoding;
 using Honua.Sdk.Admin.Extensions;
@@ -33,6 +34,7 @@ RegisterGeometryContracts(builder.Services);
 RegisterOfflineContracts(builder.Services);
 RegisterPluginContracts(builder.Services);
 RegisterRealtimeContracts(builder.Services);
+RegisterUtilityNetworkContracts(builder.Services);
 
 var host = builder.Build();
 _ = host.Services.GetRequiredService<BrowserFeatureMapSample>();
@@ -254,4 +256,56 @@ static void RegisterRealtimeContracts(IServiceCollection services)
     });
     services.AddSingleton(featureEvent);
     services.AddSingleton(processor.Process(featureEvent));
+}
+
+static void RegisterUtilityNetworkContracts(IServiceCollection services)
+{
+    var source = new UtilityNetworkSource
+    {
+        ServiceId = "electric",
+        NetworkId = "distribution",
+        NetworkName = "Electric Distribution",
+    };
+    var startingPoint = new UtilityNetworkTraceStartingPoint
+    {
+        Element = new UtilityNetworkElementReference
+        {
+            ElementId = "switch-1",
+            NetworkSourceId = "devices",
+            NetworkSourceName = "Electric Device",
+            TerminalId = "load",
+        },
+    };
+    var namedConfiguration = new UtilityNetworkNamedTraceConfiguration
+    {
+        ConfigurationId = "primary-upstream",
+        Name = "Primary upstream",
+        TraceType = UtilityNetworkTraceType.Upstream,
+        Configuration = new UtilityNetworkTraceConfiguration
+        {
+            TraceType = UtilityNetworkTraceType.Upstream,
+            DomainNetwork = "ElectricDistribution",
+            Tier = "MediumVoltage",
+            OutputNetworkAttributes = ["phase", "status"],
+        },
+    };
+    var traceRequest = new UtilityNetworkTraceRequest
+    {
+        Source = source,
+        NamedConfigurationId = namedConfiguration.ConfigurationId,
+        StartingPoints = [startingPoint],
+        ReturnGeometry = true,
+    };
+
+    services.AddSingleton(source);
+    services.AddSingleton(namedConfiguration);
+    services.AddSingleton(traceRequest);
+    services.AddSingleton(new UtilityNetworkTraceCapabilities
+    {
+        SupportsUpstreamTrace = true,
+        SupportsNamedTraceConfigurations = true,
+        SupportsTerminals = true,
+        SupportsAssociations = true,
+        NativeSurface = "browser-host-adapter",
+    });
 }


### PR DESCRIPTION
## Summary
- add provider-neutral utility-network trace contracts for elements, associations, terminals, barriers, named configurations, and trace results
- define IHonuaUtilityNetworkTraceClient methods for connected, upstream, downstream, and subnetwork workflows
- extend BrowserSmoke/docs to keep the surface browser-safe and explicitly leave display/rendering downstream

Closes #66

## Validation
- dotnet build src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet build tests/Honua.Sdk.BrowserSmoke/Honua.Sdk.BrowserSmoke.csproj --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- git diff --check
- scripts/validate-api-compat.sh origin/trunk