### PR TITLE
feat: add advanced editing rule contracts

### DIFF
--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -24,6 +24,7 @@ rendering stay in host applications or downstream adapter packages.
 | `Honua.Sdk.Field` | Candidate | Pure form, validation, calculated field, duplicate detection, and record workflow contracts. Browser hosts own rendering, storage, device capture, local media handling, and any map display. |
 | `Honua.Sdk.OgcFeatures` | Candidate | REST/JSON OGC API Features client over browser `HttpClient`; requires server CORS and browser-owned auth. |
 | `Honua.Sdk.Grpc` | Not supported for browser runtime | Native gRPC/HTTP2 is not a supported browser path. Treat current browser builds as compile-only. Add gRPC-Web support only after `honua-server` exposes a compatible endpoint and the SDK has a browser-specific transport plan. |
+| Advanced editing contracts | Supported | Structured domains, contingent values, attribute rules, relationship descriptors, validate-only results, and edit-session DTOs are pure contracts. Browser hosts own form UX and server adapters. |
 | Realtime feed contracts | Candidate | `IHonuaFeatureStreamClient`, normalized event envelopes, bounded buffers, and duplicate/stale sequence processors are pure contracts. Browser hosts still own the SSE/WebSocket/gRPC-Web adapter and auth/CORS behavior. |
 | Plugin contracts | Supported | `HonuaPluginManifest` parsing, validation, compatibility metadata, permissions, safe configuration envelopes, and non-UI extension declarations are pure DTO/validator contracts. Browser hosts own plugin loading, sandboxing, UI composition, and execution. |
 | Utility network trace contracts | Supported | `IHonuaUtilityNetworkTraceClient`, trace requests/results, elements, associations, terminals, barriers, and named configurations are pure contracts. Browser hosts own transport adapters and trace-result display. |
@@ -51,8 +52,8 @@ The SDK keeps a Blazor WebAssembly compile smoke in
 packages and registers the REST clients with retry disabled. That gate proves
 the packages can be consumed by a browser app without native compile-time
 dependencies. It also compile-checks pure contracts for field records, offline
-manifests, plugin manifests, realtime stream envelopes, and utility-network
-trace requests.
+manifests, advanced editing rules, plugin manifests, realtime stream envelopes,
+and utility-network trace requests.
 
 The smoke app also contains a compile-checked browser feature-map sample. It
 uses `IHonuaOgcFeaturesClient` to query a GeoJSON feature collection, uses

--- a/docs/sdk-capability-backlog.md
+++ b/docs/sdk-capability-backlog.md
@@ -584,6 +584,20 @@ Acceptance criteria:
   suggested fix text.
 - Add branch/version-aware edit sessions if Honua Server exposes versioning.
 
+SDK implementation:
+
+- `Honua.Sdk.Abstractions.Features` owns structured editing-rule metadata for
+  domains, contingent values, attribute rules, relationship classes, validation
+  results, and version-aware edit sessions.
+- `IHonuaFeatureEditingRulesClient` is optional and should be implemented only
+  by providers that expose rule discovery, validate-only, or edit-session
+  endpoints. Existing edit clients are not forced to implement these methods.
+- `FeatureEditValidationResult.FieldName` maps to SDK field-form
+  `FormField.SourceFieldName`/`FieldId`; form rendering and validation UX stay
+  in field/mobile/admin consumers.
+- Server execution, storage validation, authorization, and branch-version
+  semantics remain blocked on the linked Honua Server issues.
+
 ### P2.4 Utility network and graph workflows
 
 Outcome: connected-asset workflows have explicit API space without overloading

--- a/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureEditModels.cs
@@ -25,6 +25,21 @@ public sealed record FeatureEditCapabilities
     /// <summary>Whether the provider supports rollback-on-failure edit batches.</summary>
     public bool SupportsRollbackOnFailure { get; init; }
 
+    /// <summary>Whether structured editing-rule metadata can be discovered.</summary>
+    public bool SupportsEditingRuleMetadata { get; init; }
+
+    /// <summary>Whether edit validation can run without committing edits.</summary>
+    public bool SupportsValidateOnly { get; init; }
+
+    /// <summary>Whether contingent value metadata is advertised.</summary>
+    public bool SupportsContingentValues { get; init; }
+
+    /// <summary>Whether attribute rule metadata is advertised.</summary>
+    public bool SupportsAttributeRules { get; init; }
+
+    /// <summary>Whether branch or version-aware edit sessions are supported.</summary>
+    public bool SupportsVersionedEditSessions { get; init; }
+
     /// <summary>Native protocol surface used by the provider, when useful for diagnostics.</summary>
     public string? NativeSurface { get; init; }
 
@@ -60,6 +75,12 @@ public sealed record FeatureEditRequest
 
     /// <summary>Whether the provider should force writes that would otherwise be rejected by conflict detection.</summary>
     public bool ForceWrite { get; init; }
+
+    /// <summary>Edit session context for version-aware providers.</summary>
+    public FeatureEditSession? Session { get; init; }
+
+    /// <summary>Whether the provider should validate the edit batch without committing it.</summary>
+    public bool ValidateOnly { get; init; }
 }
 
 /// <summary>
@@ -119,9 +140,13 @@ public sealed record FeatureEditResponse
     /// <summary>Top-level error when the provider rejects the whole edit batch.</summary>
     public FeatureEditError? Error { get; init; }
 
+    /// <summary>Validation findings returned with the edit response.</summary>
+    public IReadOnlyList<FeatureEditValidationResult> ValidationResults { get; init; } = [];
+
     /// <summary>Whether the whole edit batch and all reported item results succeeded.</summary>
     public bool Succeeded =>
         Error is null &&
+        ValidationResults.All(result => !result.BlocksApply) &&
         AddResults.All(result => result.Succeeded) &&
         UpdateResults.All(result => result.Succeeded) &&
         PatchResults.All(result => result.Succeeded) &&

--- a/src/Honua.Sdk.Abstractions/Features/FeatureEditRuleModels.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureEditRuleModels.cs
@@ -1,0 +1,507 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Structured field domain type.
+/// </summary>
+public enum FeatureFieldDomainType
+{
+    /// <summary>Domain type is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Domain is a coded value list.</summary>
+    CodedValue = 1,
+
+    /// <summary>Domain is an inclusive range.</summary>
+    Range = 2,
+
+    /// <summary>Domain is inherited from a subtype or parent schema.</summary>
+    Inherited = 3
+}
+
+/// <summary>
+/// Attribute rule kind.
+/// </summary>
+public enum FeatureAttributeRuleType
+{
+    /// <summary>Rule type is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Rule calculates or derives a field value.</summary>
+    Calculation = 1,
+
+    /// <summary>Rule constrains whether an edit can be applied.</summary>
+    Constraint = 2,
+
+    /// <summary>Rule validates data quality and may produce warnings or errors.</summary>
+    Validation = 3
+}
+
+/// <summary>
+/// Edit operation that can trigger an attribute rule.
+/// </summary>
+public enum FeatureAttributeRuleTrigger
+{
+    /// <summary>Trigger is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Rule runs on insert.</summary>
+    Insert = 1,
+
+    /// <summary>Rule runs on update.</summary>
+    Update = 2,
+
+    /// <summary>Rule runs on delete.</summary>
+    Delete = 3
+}
+
+/// <summary>
+/// Relationship class cardinality.
+/// </summary>
+public enum FeatureRelationshipCardinality
+{
+    /// <summary>Cardinality is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>One origin feature can relate to one destination feature.</summary>
+    OneToOne = 1,
+
+    /// <summary>One origin feature can relate to many destination features.</summary>
+    OneToMany = 2,
+
+    /// <summary>Many origin features can relate to many destination features.</summary>
+    ManyToMany = 3
+}
+
+/// <summary>
+/// Relationship class ownership behavior.
+/// </summary>
+public enum FeatureRelationshipType
+{
+    /// <summary>Relationship type is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Simple relationship without lifecycle ownership.</summary>
+    Simple = 1,
+
+    /// <summary>Composite relationship where origin lifecycle can affect destinations.</summary>
+    Composite = 2,
+
+    /// <summary>Attachment relationship.</summary>
+    Attachment = 3
+}
+
+/// <summary>
+/// Severity for client-visible edit validation findings.
+/// </summary>
+public enum FeatureEditValidationSeverity
+{
+    /// <summary>Informational validation finding.</summary>
+    Information = 0,
+
+    /// <summary>Validation warning that may still allow the edit.</summary>
+    Warning = 1,
+
+    /// <summary>Validation error returned by a rule or provider.</summary>
+    Error = 2,
+
+    /// <summary>Validation finding that blocks applying the edit.</summary>
+    Blocking = 3
+}
+
+/// <summary>
+/// Validation mode requested before applying edits.
+/// </summary>
+public enum FeatureEditValidationMode
+{
+    /// <summary>Use provider default validation behavior.</summary>
+    ProviderDefault = 0,
+
+    /// <summary>Run only client-safe checks exposed in SDK metadata.</summary>
+    ClientSide = 1,
+
+    /// <summary>Ask the provider to validate without committing edits.</summary>
+    ServerSide = 2,
+
+    /// <summary>Run both client-safe and provider-side validation when supported.</summary>
+    ClientAndServer = 3
+}
+
+/// <summary>
+/// Structured coded domain value.
+/// </summary>
+public sealed record FeatureFieldDomainCode
+{
+    /// <summary>Stored value.</summary>
+    public required JsonElement Value { get; init; }
+
+    /// <summary>Human-readable label.</summary>
+    public string? Label { get; init; }
+
+    /// <summary>Whether this code is retired or inactive.</summary>
+    public bool Inactive { get; init; }
+}
+
+/// <summary>
+/// Structured field domain metadata.
+/// </summary>
+public sealed record FeatureFieldDomain
+{
+    /// <summary>Stable domain identifier when the provider advertises one.</summary>
+    public string? DomainId { get; init; }
+
+    /// <summary>Domain display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Field name this domain applies to, when field-specific.</summary>
+    public string? FieldName { get; init; }
+
+    /// <summary>Structured domain type.</summary>
+    public FeatureFieldDomainType Type { get; init; } = FeatureFieldDomainType.Unknown;
+
+    /// <summary>Coded values for coded-value domains.</summary>
+    public IReadOnlyList<FeatureFieldDomainCode> CodedValues { get; init; } = [];
+
+    /// <summary>Inclusive minimum for range domains.</summary>
+    public JsonElement? MinValue { get; init; }
+
+    /// <summary>Inclusive maximum for range domains.</summary>
+    public JsonElement? MaxValue { get; init; }
+
+    /// <summary>Raw provider domain payload, when useful for provider-specific adapters.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// One field value participating in a contingent value set.
+/// </summary>
+public sealed record FeatureContingentFieldValue
+{
+    /// <summary>Field name participating in the contingent value set.</summary>
+    public required string FieldName { get; init; }
+
+    /// <summary>Allowed value for the field.</summary>
+    public required JsonElement Value { get; init; }
+
+    /// <summary>Whether this value represents an explicit null allowance.</summary>
+    public bool AllowsNull { get; init; }
+}
+
+/// <summary>
+/// Contingent values across a group of fields.
+/// </summary>
+public sealed record FeatureContingentValueSet
+{
+    /// <summary>Stable contingent value identifier when the provider advertises one.</summary>
+    public string? ContingencyId { get; init; }
+
+    /// <summary>Field group or provider grouping name.</summary>
+    public string? FieldGroupName { get; init; }
+
+    /// <summary>Field/value pairs that compose this contingent value set.</summary>
+    public IReadOnlyList<FeatureContingentFieldValue> Values { get; init; } = [];
+
+    /// <summary>Whether this contingent value set is retired or inactive.</summary>
+    public bool Inactive { get; init; }
+
+    /// <summary>Raw provider contingent value payload.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// Attribute rule metadata advertised by a provider.
+/// </summary>
+public sealed record FeatureAttributeRule
+{
+    /// <summary>Stable rule identifier.</summary>
+    public required string RuleId { get; init; }
+
+    /// <summary>Rule display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Rule kind.</summary>
+    public FeatureAttributeRuleType Type { get; init; } = FeatureAttributeRuleType.Unknown;
+
+    /// <summary>Field the rule targets, when field-specific.</summary>
+    public string? FieldName { get; init; }
+
+    /// <summary>Edit triggers that run the rule.</summary>
+    public IReadOnlyList<FeatureAttributeRuleTrigger> Triggers { get; init; } = [];
+
+    /// <summary>Provider expression language, such as Arcade or CQL.</summary>
+    public string? ExpressionLanguage { get; init; }
+
+    /// <summary>Provider expression body when it is safe to expose to clients.</summary>
+    public string? Expression { get; init; }
+
+    /// <summary>Whether the rule is enabled by the provider.</summary>
+    public bool IsEnabled { get; init; } = true;
+
+    /// <summary>Whether clients should avoid evaluating the rule locally.</summary>
+    public bool ExcludeFromClientEvaluation { get; init; }
+
+    /// <summary>Provider error number or code associated with the rule.</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>Provider validation message associated with the rule.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Raw provider rule payload.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// One key pair used by a relationship class.
+/// </summary>
+public sealed record FeatureRelationshipKey
+{
+    /// <summary>Origin/source field name.</summary>
+    public required string OriginField { get; init; }
+
+    /// <summary>Destination/related field name.</summary>
+    public required string DestinationField { get; init; }
+}
+
+/// <summary>
+/// Relationship class descriptor for related feature workflows.
+/// </summary>
+public sealed record FeatureRelationshipClassDescriptor
+{
+    /// <summary>Stable relationship identifier.</summary>
+    public required string RelationshipId { get; init; }
+
+    /// <summary>Relationship display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Origin/source feature source identifiers.</summary>
+    public FeatureSource OriginSource { get; init; } = new();
+
+    /// <summary>Destination/related feature source identifiers.</summary>
+    public FeatureSource DestinationSource { get; init; } = new();
+
+    /// <summary>Relationship cardinality.</summary>
+    public FeatureRelationshipCardinality Cardinality { get; init; } = FeatureRelationshipCardinality.Unknown;
+
+    /// <summary>Relationship ownership behavior.</summary>
+    public FeatureRelationshipType Type { get; init; } = FeatureRelationshipType.Unknown;
+
+    /// <summary>Key field pairs used by the relationship.</summary>
+    public IReadOnlyList<FeatureRelationshipKey> Keys { get; init; } = [];
+
+    /// <summary>Whether related records can be queried through the provider.</summary>
+    public bool SupportsQueryRelated { get; init; }
+
+    /// <summary>Whether related records can be edited through the provider.</summary>
+    public bool SupportsEditRelated { get; init; }
+
+    /// <summary>Raw provider relationship payload.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// Versioning capabilities for edit sessions.
+/// </summary>
+public sealed record FeatureEditVersioningCapabilities
+{
+    /// <summary>Whether named versions can be targeted by edit requests.</summary>
+    public bool SupportsVersionName { get; init; }
+
+    /// <summary>Whether branch versions are supported.</summary>
+    public bool SupportsBranchVersioning { get; init; }
+
+    /// <summary>Whether edit sessions can be started and later committed or rolled back.</summary>
+    public bool SupportsEditSessions { get; init; }
+
+    /// <summary>Whether optimistic conflict detection metadata is available.</summary>
+    public bool SupportsConflictDetection { get; init; }
+
+    /// <summary>Default version name advertised by the provider.</summary>
+    public string? DefaultVersionName { get; init; }
+}
+
+/// <summary>
+/// Editing-rule metadata discovered for a source.
+/// </summary>
+public sealed record FeatureEditingRulesMetadata
+{
+    /// <summary>Source identifiers associated with the metadata.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Structured field domains advertised by the provider.</summary>
+    public IReadOnlyList<FeatureFieldDomain> FieldDomains { get; init; } = [];
+
+    /// <summary>Contingent value sets advertised by the provider.</summary>
+    public IReadOnlyList<FeatureContingentValueSet> ContingentValues { get; init; } = [];
+
+    /// <summary>Attribute rules advertised by the provider.</summary>
+    public IReadOnlyList<FeatureAttributeRule> AttributeRules { get; init; } = [];
+
+    /// <summary>Relationship class descriptors advertised by the provider.</summary>
+    public IReadOnlyList<FeatureRelationshipClassDescriptor> Relationships { get; init; } = [];
+
+    /// <summary>Versioning and edit-session capabilities advertised by the provider.</summary>
+    public FeatureEditVersioningCapabilities? Versioning { get; init; }
+
+    /// <summary>Raw provider metadata payload.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// Request for editing-rule metadata discovery.
+/// </summary>
+public sealed record FeatureEditingRulesRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Whether inactive or retired rule metadata should be included.</summary>
+    public bool IncludeInactive { get; init; }
+
+    /// <summary>Optional version name used by version-aware providers.</summary>
+    public string? VersionName { get; init; }
+}
+
+/// <summary>
+/// Branch or version-aware edit session.
+/// </summary>
+public sealed record FeatureEditSession
+{
+    /// <summary>Stable session identifier.</summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>Version name targeted by the session.</summary>
+    public string? VersionName { get; init; }
+
+    /// <summary>Branch name targeted by the session.</summary>
+    public string? BranchName { get; init; }
+
+    /// <summary>Parent version or branch name.</summary>
+    public string? ParentVersionName { get; init; }
+
+    /// <summary>Timestamp when the provider opened the session.</summary>
+    public DateTimeOffset? StartedAt { get; init; }
+
+    /// <summary>Timestamp when the provider will expire the session.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>Provider state token for optimistic concurrency or resume behavior.</summary>
+    public string? StateToken { get; init; }
+}
+
+/// <summary>
+/// Request to start a branch or version-aware edit session.
+/// </summary>
+public sealed record FeatureEditSessionStartRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Version name to target.</summary>
+    public string? VersionName { get; init; }
+
+    /// <summary>Branch name to target.</summary>
+    public string? BranchName { get; init; }
+
+    /// <summary>Parent version used when creating a new version or branch.</summary>
+    public string? ParentVersionName { get; init; }
+
+    /// <summary>Optional operator or workflow description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Whether the provider should acquire an edit lock when supported.</summary>
+    public bool AcquireLock { get; init; }
+}
+
+/// <summary>
+/// Request to complete an edit session.
+/// </summary>
+public sealed record FeatureEditSessionCompleteRequest
+{
+    /// <summary>Edit session to complete.</summary>
+    public required FeatureEditSession Session { get; init; }
+
+    /// <summary>Optional provider validation state token.</summary>
+    public string? StateToken { get; init; }
+}
+
+/// <summary>
+/// One validation finding for a feature edit.
+/// </summary>
+public sealed record FeatureEditValidationResult
+{
+    /// <summary>Field associated with the finding, when field-specific.</summary>
+    public string? FieldName { get; init; }
+
+    /// <summary>Rule identifier associated with the finding.</summary>
+    public string? RuleId { get; init; }
+
+    /// <summary>Rule display or lookup name associated with the finding.</summary>
+    public string? RuleName { get; init; }
+
+    /// <summary>Validation severity.</summary>
+    public FeatureEditValidationSeverity Severity { get; init; } = FeatureEditValidationSeverity.Error;
+
+    /// <summary>Human-readable validation message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Optional suggested fix text.</summary>
+    public string? SuggestedFix { get; init; }
+
+    /// <summary>Provider feature identifier associated with the finding.</summary>
+    public string? FeatureId { get; init; }
+
+    /// <summary>Provider object identifier associated with the finding.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Edit operation associated with the finding.</summary>
+    public string? Operation { get; init; }
+
+    /// <summary>Whether this finding blocks applying the edit.</summary>
+    public bool BlocksApply => Severity is FeatureEditValidationSeverity.Error or FeatureEditValidationSeverity.Blocking;
+}
+
+/// <summary>
+/// Request to validate edits without necessarily committing them.
+/// </summary>
+public sealed record FeatureEditValidationRequest
+{
+    /// <summary>Provider-specific source identifiers.</summary>
+    public FeatureSource Source { get; init; } = new();
+
+    /// <summary>Features to validate for add operations.</summary>
+    public IReadOnlyList<FeatureEditFeature> Adds { get; init; } = [];
+
+    /// <summary>Features to validate for update operations.</summary>
+    public IReadOnlyList<FeatureEditFeature> Updates { get; init; } = [];
+
+    /// <summary>Features to validate for patch operations.</summary>
+    public IReadOnlyList<FeatureEditPatch> Patches { get; init; } = [];
+
+    /// <summary>Edit session context for version-aware providers.</summary>
+    public FeatureEditSession? Session { get; init; }
+
+    /// <summary>Validation mode to request.</summary>
+    public FeatureEditValidationMode Mode { get; init; } = FeatureEditValidationMode.ProviderDefault;
+
+    /// <summary>Whether warnings should be returned when the provider can filter them.</summary>
+    public bool ReturnWarnings { get; init; } = true;
+}
+
+/// <summary>
+/// Response from edit validation.
+/// </summary>
+public sealed record FeatureEditValidationResponse
+{
+    /// <summary>Provider name that handled validation.</summary>
+    public string ProviderName { get; init; } = string.Empty;
+
+    /// <summary>Validation findings returned by client-side rules or the provider.</summary>
+    public IReadOnlyList<FeatureEditValidationResult> Results { get; init; } = [];
+
+    /// <summary>Whether validation returned no blocking findings.</summary>
+    public bool IsValid => Results.All(result => !result.BlocksApply);
+}

--- a/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureEditingRulesClient.cs
+++ b/src/Honua.Sdk.Abstractions/Features/IHonuaFeatureEditingRulesClient.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Features;
+
+/// <summary>
+/// Optional advanced editing-rule contract for providers that expose validation metadata and edit sessions.
+/// </summary>
+public interface IHonuaFeatureEditingRulesClient
+{
+    /// <summary>
+    /// Provider name for diagnostics and provider selection.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Provider edit capabilities exposed by this client.
+    /// </summary>
+    FeatureEditCapabilities EditCapabilities { get; }
+
+    /// <summary>
+    /// Gets structured editing-rule metadata for a source.
+    /// </summary>
+    /// <param name="request">Editing-rule metadata request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Editing-rule metadata advertised by the provider.</returns>
+    Task<FeatureEditingRulesMetadata> GetEditingRulesAsync(
+        FeatureEditingRulesRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Validates edits without necessarily committing them.
+    /// </summary>
+    /// <param name="request">Validation request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Validation findings from client-safe rules or the provider.</returns>
+    Task<FeatureEditValidationResponse> ValidateEditsAsync(
+        FeatureEditValidationRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts a branch or version-aware edit session.
+    /// </summary>
+    /// <param name="request">Edit session start request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Edit session context for subsequent validation or apply requests.</returns>
+    Task<FeatureEditSession> StartEditSessionAsync(
+        FeatureEditSessionStartRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Commits a branch or version-aware edit session.
+    /// </summary>
+    /// <param name="request">Edit session completion request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the provider commits the session.</returns>
+    Task CommitEditSessionAsync(
+        FeatureEditSessionCompleteRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Rolls back a branch or version-aware edit session.
+    /// </summary>
+    /// <param name="request">Edit session completion request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the provider rolls back the session.</returns>
+    Task RollbackEditSessionAsync(
+        FeatureEditSessionCompleteRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
+++ b/src/Honua.Sdk.Abstractions/Features/SourceDescriptor.cs
@@ -78,6 +78,9 @@ public sealed record SourceSchema
 
     /// <summary>Attachment capabilities advertised by the source.</summary>
     public FeatureAttachmentCapabilities? AttachmentCapabilities { get; init; }
+
+    /// <summary>Structured editing-rule metadata advertised by the source.</summary>
+    public FeatureEditingRulesMetadata? EditingRules { get; init; }
 }
 
 /// <summary>
@@ -108,6 +111,9 @@ public sealed record SourceField
 
     /// <summary>Provider-native field domain metadata, when advertised.</summary>
     public JsonElement? Domain { get; init; }
+
+    /// <summary>Structured field domain metadata, when advertised.</summary>
+    public FeatureFieldDomain? DomainInfo { get; init; }
 
     /// <summary>Provider-native default value, when advertised.</summary>
     public JsonElement? DefaultValue { get; init; }

--- a/tests/Honua.Sdk.Abstractions.Tests/AdvancedEditingContractTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/AdvancedEditingContractTests.cs
@@ -1,0 +1,303 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class AdvancedEditingContractTests
+{
+    [Fact]
+    public void SourceSchema_CarriesStructuredEditingRuleMetadata()
+    {
+        var domain = StatusDomain();
+        var relationship = InspectionRelationship();
+
+        var schema = new SourceSchema
+        {
+            Fields =
+            [
+                new SourceField
+                {
+                    Name = "status",
+                    Alias = "Status",
+                    Type = "esriFieldTypeString",
+                    Editable = true,
+                    Required = true,
+                    DomainInfo = domain,
+                },
+            ],
+            EditingRules = new FeatureEditingRulesMetadata
+            {
+                Source = ParksSource(),
+                FieldDomains = [domain],
+                ContingentValues =
+                [
+                    new FeatureContingentValueSet
+                    {
+                        ContingencyId = "status-condition",
+                        FieldGroupName = "status-workflow",
+                        Values =
+                        [
+                            new FeatureContingentFieldValue
+                            {
+                                FieldName = "status",
+                                Value = JsonValue("\"open\""),
+                            },
+                            new FeatureContingentFieldValue
+                            {
+                                FieldName = "condition",
+                                Value = JsonValue("\"good\""),
+                            },
+                        ],
+                    },
+                ],
+                AttributeRules =
+                [
+                    new FeatureAttributeRule
+                    {
+                        RuleId = "status-required",
+                        Name = "Status is required",
+                        Type = FeatureAttributeRuleType.Constraint,
+                        FieldName = "status",
+                        Triggers = [FeatureAttributeRuleTrigger.Insert, FeatureAttributeRuleTrigger.Update],
+                        ExpressionLanguage = "arcade",
+                        ErrorMessage = "Status is required.",
+                    },
+                ],
+                Relationships = [relationship],
+                Versioning = new FeatureEditVersioningCapabilities
+                {
+                    SupportsVersionName = true,
+                    SupportsBranchVersioning = true,
+                    SupportsEditSessions = true,
+                    DefaultVersionName = "sde.DEFAULT",
+                },
+            },
+        };
+
+        var editingRules = Assert.IsType<FeatureEditingRulesMetadata>(schema.EditingRules);
+        var versioning = Assert.IsType<FeatureEditVersioningCapabilities>(editingRules.Versioning);
+
+        Assert.Equal("status", schema.Fields[0].DomainInfo?.FieldName);
+        Assert.Equal(FeatureFieldDomainType.CodedValue, editingRules.FieldDomains[0].Type);
+        Assert.Equal("status-required", editingRules.AttributeRules[0].RuleId);
+        Assert.Equal(FeatureRelationshipCardinality.OneToMany, editingRules.Relationships[0].Cardinality);
+        Assert.True(versioning.SupportsEditSessions);
+    }
+
+    [Fact]
+    public async Task Interface_ModelsValidationAndVersionedEditSessions()
+    {
+        var client = new FakeEditingRulesClient();
+        var session = await client.StartEditSessionAsync(new FeatureEditSessionStartRequest
+        {
+            Source = ParksSource(),
+            VersionName = "field-review",
+            ParentVersionName = "sde.DEFAULT",
+            AcquireLock = true,
+        });
+        var metadata = await client.GetEditingRulesAsync(new FeatureEditingRulesRequest
+        {
+            Source = ParksSource(),
+            VersionName = session.VersionName,
+        });
+        var validation = await client.ValidateEditsAsync(new FeatureEditValidationRequest
+        {
+            Source = ParksSource(),
+            Session = session,
+            Mode = FeatureEditValidationMode.ClientAndServer,
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["status"] = JsonValue("\"retired\""),
+                    },
+                },
+            ],
+        });
+        await client.RollbackEditSessionAsync(new FeatureEditSessionCompleteRequest
+        {
+            Session = session,
+        });
+
+        Assert.Equal("fake-edit-rules", client.ProviderName);
+        Assert.True(client.EditCapabilities.SupportsEditingRuleMetadata);
+        Assert.True(client.EditCapabilities.SupportsVersionedEditSessions);
+        Assert.Equal("field-review", session.VersionName);
+        Assert.Single(metadata.FieldDomains);
+        Assert.False(validation.IsValid);
+        var finding = Assert.Single(validation.Results);
+        Assert.Equal("status", finding.FieldName);
+        Assert.Equal("status-required", finding.RuleId);
+        Assert.Equal(FeatureEditValidationSeverity.Blocking, finding.Severity);
+        Assert.Equal("Choose an active status.", finding.SuggestedFix);
+    }
+
+    [Fact]
+    public void EditResponse_TreatsBlockingValidationAsUnsuccessful()
+    {
+        var response = new FeatureEditResponse
+        {
+            ProviderName = "test",
+            AddResults =
+            [
+                new FeatureEditResult
+                {
+                    Succeeded = true,
+                },
+            ],
+            ValidationResults =
+            [
+                new FeatureEditValidationResult
+                {
+                    FieldName = "status",
+                    RuleId = "status-required",
+                    Severity = FeatureEditValidationSeverity.Blocking,
+                    Message = "Status is required.",
+                    SuggestedFix = "Choose an active status.",
+                },
+            ],
+        };
+
+        Assert.False(response.Succeeded);
+        Assert.True(response.ValidationResults[0].BlocksApply);
+    }
+
+    private static FeatureFieldDomain StatusDomain()
+        => new()
+        {
+            DomainId = "status-domain",
+            Name = "Status",
+            FieldName = "status",
+            Type = FeatureFieldDomainType.CodedValue,
+            CodedValues =
+            [
+                new FeatureFieldDomainCode
+                {
+                    Value = JsonValue("\"open\""),
+                    Label = "Open",
+                },
+                new FeatureFieldDomainCode
+                {
+                    Value = JsonValue("\"closed\""),
+                    Label = "Closed",
+                },
+            ],
+        };
+
+    private static FeatureRelationshipClassDescriptor InspectionRelationship()
+        => new()
+        {
+            RelationshipId = "parks-inspections",
+            Name = "Park inspections",
+            OriginSource = ParksSource(),
+            DestinationSource = new FeatureSource { ServiceId = "inspections", LayerId = 1 },
+            Cardinality = FeatureRelationshipCardinality.OneToMany,
+            Type = FeatureRelationshipType.Composite,
+            Keys =
+            [
+                new FeatureRelationshipKey
+                {
+                    OriginField = "globalid",
+                    DestinationField = "park_globalid",
+                },
+            ],
+            SupportsQueryRelated = true,
+            SupportsEditRelated = true,
+        };
+
+    private static FeatureSource ParksSource()
+        => new()
+        {
+            ServiceId = "parks",
+            LayerId = 0,
+        };
+
+    private static JsonElement JsonValue(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private sealed class FakeEditingRulesClient : IHonuaFeatureEditingRulesClient
+    {
+        public string ProviderName => "fake-edit-rules";
+
+        public FeatureEditCapabilities EditCapabilities { get; } = new()
+        {
+            SupportsAdds = true,
+            SupportsUpdates = true,
+            SupportsRollbackOnFailure = true,
+            SupportsEditingRuleMetadata = true,
+            SupportsValidateOnly = true,
+            SupportsContingentValues = true,
+            SupportsAttributeRules = true,
+            SupportsVersionedEditSessions = true,
+            NativeSurface = "test",
+        };
+
+        public Task<FeatureEditingRulesMetadata> GetEditingRulesAsync(
+            FeatureEditingRulesRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureEditingRulesMetadata
+            {
+                Source = request.Source,
+                FieldDomains = [StatusDomain()],
+                Relationships = [InspectionRelationship()],
+                Versioning = new FeatureEditVersioningCapabilities
+                {
+                    SupportsVersionName = true,
+                    SupportsBranchVersioning = true,
+                    SupportsEditSessions = true,
+                    DefaultVersionName = "sde.DEFAULT",
+                },
+            });
+
+        public Task<FeatureEditValidationResponse> ValidateEditsAsync(
+            FeatureEditValidationRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureEditValidationResponse
+            {
+                ProviderName = ProviderName,
+                Results =
+                [
+                    new FeatureEditValidationResult
+                    {
+                        FieldName = "status",
+                        RuleId = "status-required",
+                        RuleName = "Status is required",
+                        Severity = FeatureEditValidationSeverity.Blocking,
+                        Message = "Status value is not active.",
+                        SuggestedFix = "Choose an active status.",
+                        Operation = "add",
+                    },
+                ],
+            });
+
+        public Task<FeatureEditSession> StartEditSessionAsync(
+            FeatureEditSessionStartRequest request,
+            CancellationToken ct = default)
+            => Task.FromResult(new FeatureEditSession
+            {
+                SessionId = "session-1",
+                VersionName = request.VersionName,
+                ParentVersionName = request.ParentVersionName,
+                StartedAt = new DateTimeOffset(2026, 4, 30, 0, 0, 0, TimeSpan.Zero),
+                StateToken = "state-1",
+            });
+
+        public Task CommitEditSessionAsync(
+            FeatureEditSessionCompleteRequest request,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task RollbackEditSessionAsync(
+            FeatureEditSessionCompleteRequest request,
+            CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/Honua.Sdk.BrowserSmoke/Program.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Plugins;
 using Honua.Sdk.Abstractions.UtilityNetworks;
@@ -32,6 +33,7 @@ RegisterBrowserFeatureMapSample(builder.Services);
 RegisterFieldContracts(builder.Services);
 RegisterGeometryContracts(builder.Services);
 RegisterOfflineContracts(builder.Services);
+RegisterAdvancedEditingContracts(builder.Services);
 RegisterPluginContracts(builder.Services);
 RegisterRealtimeContracts(builder.Services);
 RegisterUtilityNetworkContracts(builder.Services);
@@ -213,6 +215,67 @@ static void RegisterOfflineContracts(IServiceCollection services)
     services.AddSingleton(new OfflineSyncEngineOptions());
 }
 
+static void RegisterAdvancedEditingContracts(IServiceCollection services)
+{
+    var domain = new FeatureFieldDomain
+    {
+        DomainId = "status-domain",
+        Name = "Status",
+        FieldName = "status",
+        Type = FeatureFieldDomainType.CodedValue,
+        CodedValues =
+        [
+            new FeatureFieldDomainCode
+            {
+                Value = JsonValue("\"open\""),
+                Label = "Open",
+            },
+        ],
+    };
+    var metadata = new FeatureEditingRulesMetadata
+    {
+        Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+        FieldDomains = [domain],
+        AttributeRules =
+        [
+            new FeatureAttributeRule
+            {
+                RuleId = "status-required",
+                Name = "Status is required",
+                Type = FeatureAttributeRuleType.Constraint,
+                FieldName = "status",
+                Triggers = [FeatureAttributeRuleTrigger.Insert, FeatureAttributeRuleTrigger.Update],
+                ErrorMessage = "Status is required.",
+            },
+        ],
+        Versioning = new FeatureEditVersioningCapabilities
+        {
+            SupportsVersionName = true,
+            SupportsEditSessions = true,
+            DefaultVersionName = "sde.DEFAULT",
+        },
+    };
+    var validation = new FeatureEditValidationResult
+    {
+        FieldName = "status",
+        RuleId = "status-required",
+        RuleName = "Status is required",
+        Severity = FeatureEditValidationSeverity.Warning,
+        Message = "Status should be reviewed.",
+        SuggestedFix = "Choose an active status.",
+    };
+
+    services.AddSingleton(domain);
+    services.AddSingleton(metadata);
+    services.AddSingleton(validation);
+    services.AddSingleton(new FeatureEditSession
+    {
+        SessionId = "browser-session",
+        VersionName = "sde.DEFAULT",
+        StartedAt = DateTimeOffset.UnixEpoch,
+    });
+}
+
 static void RegisterPluginContracts(IServiceCollection services)
 {
     var manifest = new HonuaPluginManifest
@@ -308,4 +371,10 @@ static void RegisterUtilityNetworkContracts(IServiceCollection services)
         SupportsAssociations = true,
         NativeSurface = "browser-host-adapter",
     });
+}
+
+static JsonElement JsonValue(string json)
+{
+    using var document = JsonDocument.Parse(json);
+    return document.RootElement.Clone();
 }


### PR DESCRIPTION
## Summary
- add structured advanced editing metadata contracts for domains, contingent values, attribute rules, relationship classes, and versioning
- add optional IHonuaFeatureEditingRulesClient for metadata discovery, validate-only workflows, and edit session lifecycle
- surface validation findings on edit responses and BrowserSmoke/docs while leaving server adapters and UX downstream

Closes #65

Server dependencies remain tracked in #65:
- https://github.com/honua-io/honua-server/issues/347
- https://github.com/honua-io/honua-server/issues/371

## Validation
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- git diff --check
- scripts/validate-api-compat.sh origin/trunk