### PR TITLE
feat: add raster elevation enrichment contracts

### DIFF
--- a/docs/browser-wasm-support.md
+++ b/docs/browser-wasm-support.md
@@ -28,6 +28,7 @@ rendering stay in host applications or downstream adapter packages.
 | Realtime feed contracts | Candidate | `IHonuaFeatureStreamClient`, normalized event envelopes, bounded buffers, and duplicate/stale sequence processors are pure contracts. Browser hosts still own the SSE/WebSocket/gRPC-Web adapter and auth/CORS behavior. |
 | Plugin contracts | Supported | `HonuaPluginManifest` parsing, validation, compatibility metadata, permissions, safe configuration envelopes, and non-UI extension declarations are pure DTO/validator contracts. Browser hosts own plugin loading, sandboxing, UI composition, and execution. |
 | Utility network trace contracts | Supported | `IHonuaUtilityNetworkTraceClient`, trace requests/results, elements, associations, terminals, barriers, and named configurations are pure contracts. Browser hosts own transport adapters and trace-result display. |
+| Raster/elevation/enrichment contracts | Supported | `IHonuaRasterDataClient`, `IHonuaElevationDataClient`, and `IHonuaEnrichmentDataClient` expose portable data requests/results only. Browser hosts own transport adapters, CORS/auth, map display, terrain rendering, hillshade, and thematic styling. |
 | Display/maps | Out of SDK core | MapLibre/deck.gl, Cesium, Mapsui, renderer caches, controls, and AR/VR anchors belong in viewer/mobile/admin apps or display adapter packages. SDK packages should hand back portable data/contracts. |
 
 ## Explicit Browser Exclusions
@@ -53,7 +54,7 @@ packages and registers the REST clients with retry disabled. That gate proves
 the packages can be consumed by a browser app without native compile-time
 dependencies. It also compile-checks pure contracts for field records, offline
 manifests, advanced editing rules, plugin manifests, realtime stream envelopes,
-and utility-network trace requests.
+utility-network trace requests, and raster/elevation/enrichment data requests.
 
 The smoke app also contains a compile-checked browser feature-map sample. It
 uses `IHonuaOgcFeaturesClient` to query a GeoJSON feature collection, uses
@@ -61,6 +62,11 @@ uses `IHonuaOgcFeaturesClient` to query a GeoJSON feature collection, uses
 injected `IBrowserGeoJsonDisplayAdapter`. The adapter is intentionally a no-op
 in this repository: MapLibre/deck.gl, Cesium, Mapsui, canvas/WebGL lifecycle,
 and picking controls remain in viewer packages or host apps.
+
+Raster, elevation, and enrichment contracts are compile-checked in the same
+smoke app as DTOs and provider interfaces. Live service calls remain dependent
+on Honua Server endpoints, browser CORS/auth configuration, and a host-provided
+transport adapter.
 
 Live runtime validation still belongs to the consuming app or a follow-up SDK
 sample wired to a test Honua deployment:

--- a/docs/sdk-capability-backlog.md
+++ b/docs/sdk-capability-backlog.md
@@ -644,6 +644,21 @@ Server dependencies:
 - https://github.com/honua-io/honua-server/issues/839
 - https://github.com/honua-io/honua-server/issues/840
 
+SDK implementation notes:
+
+- `Honua.Sdk.Abstractions.Data` owns provider-neutral contracts for raster
+  metadata, raster coverage statistics, elevation sampling, and enrichment
+  metadata/results.
+- `IHonuaRasterDataClient`, `IHonuaElevationDataClient`, and
+  `IHonuaEnrichmentDataClient` are optional service contracts. Concrete
+  adapters should implement them only after the corresponding Honua Server
+  endpoints are available.
+- The SDK returns portable values, extents, sample points, raw provider payloads,
+  and diagnostics. It does not render images, terrain, hillshade, map layers, or
+  thematic styling.
+- Server execution, persistence, authorization, large-raster streaming, and
+  tenant catalog semantics remain blocked on the linked Honua Server issues.
+
 ### P2.6 Non-UI plugin contracts
 
 Outcome: plugin extension contracts that are not UI/runtime-specific can be

--- a/src/Honua.Sdk.Abstractions/Data/ElevationDataModels.cs
+++ b/src/Honua.Sdk.Abstractions/Data/ElevationDataModels.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Capabilities advertised by an elevation data provider.
+/// </summary>
+public sealed record ElevationDataCapabilities
+{
+    /// <summary>Whether point elevation sampling is supported.</summary>
+    public bool SupportsPointSampling { get; init; }
+
+    /// <summary>Whether multiple points can be sampled in one request.</summary>
+    public bool SupportsBatchSampling { get; init; }
+
+    /// <summary>Whether elevation profiles can be sampled along a line geometry.</summary>
+    public bool SupportsProfileSampling { get; init; }
+
+    /// <summary>Whether output units can be requested.</summary>
+    public bool SupportsOutputUnits { get; init; }
+
+    /// <summary>Whether vertical datum selection is supported.</summary>
+    public bool SupportsVerticalDatum { get; init; }
+
+    /// <summary>Whether sample resolution metadata can be returned.</summary>
+    public bool SupportsResolutionMetadata { get; init; }
+
+    /// <summary>Native provider surface backing the implementation.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason the capability set is unavailable, when applicable.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Elevation sampling request for points or provider-supported profile geometry.
+/// </summary>
+public sealed record ElevationSamplingRequest
+{
+    /// <summary>Provider-specific elevation source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Point samples to request.</summary>
+    public IReadOnlyList<SpatialDataPoint> Points { get; init; } = [];
+
+    /// <summary>Optional line geometry for profile sampling using provider JSON geometry.</summary>
+    public JsonElement? PathGeometry { get; init; }
+
+    /// <summary>Coordinate reference system for <see cref="PathGeometry"/> when not embedded in the geometry.</summary>
+    public string? PathCrs { get; init; }
+
+    /// <summary>Requested sample spacing for profile sampling.</summary>
+    public double? SampleDistance { get; init; }
+
+    /// <summary>Requested output elevation unit.</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>Requested output vertical datum.</summary>
+    public string? VerticalDatum { get; init; }
+
+    /// <summary>Whether no-data samples should be included instead of filtered.</summary>
+    public bool IncludeNoData { get; init; }
+
+    /// <summary>Optional provider selector, such as a raster item filter or terrain version.</summary>
+    public JsonElement? Selector { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Elevation sample returned by a provider.
+/// </summary>
+public sealed record ElevationSample
+{
+    /// <summary>Point associated with the sample.</summary>
+    public required SpatialDataPoint Location { get; init; }
+
+    /// <summary>Elevation value in <see cref="Unit"/>, or null for no-data samples.</summary>
+    public double? Elevation { get; init; }
+
+    /// <summary>Elevation unit for this sample.</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>Vertical datum used by this sample.</summary>
+    public string? VerticalDatum { get; init; }
+
+    /// <summary>Distance along a sampled profile, when applicable.</summary>
+    public double? DistanceAlong { get; init; }
+
+    /// <summary>Resolution or cell size used to produce the sample.</summary>
+    public double? Resolution { get; init; }
+
+    /// <summary>Whether this sample represents provider no-data.</summary>
+    public bool IsNoData { get; init; }
+
+    /// <summary>Additional provider sample attributes.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Elevation sampling response.
+/// </summary>
+public sealed record ElevationSamplingResponse
+{
+    /// <summary>Source that produced the response.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Returned elevation samples.</summary>
+    public IReadOnlyList<ElevationSample> Samples { get; init; } = [];
+
+    /// <summary>Provider messages.</summary>
+    public IReadOnlyList<SpatialDataMessage> Messages { get; init; } = [];
+
+    /// <summary>Raw provider response payload.</summary>
+    public JsonElement? RawResponse { get; init; }
+
+    /// <summary>Whether the response does not contain provider errors.</summary>
+    public bool Succeeded => !Messages.Any(static message => message.Severity == SpatialDataMessageSeverity.Error);
+}

--- a/src/Honua.Sdk.Abstractions/Data/EnrichmentDataModels.cs
+++ b/src/Honua.Sdk.Abstractions/Data/EnrichmentDataModels.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Capabilities advertised by an enrichment data provider.
+/// </summary>
+public sealed record EnrichmentDataCapabilities
+{
+    /// <summary>Whether enrichment variable metadata can be discovered.</summary>
+    public bool SupportsMetadata { get; init; }
+
+    /// <summary>Whether enrichment can run against caller-provided geometry.</summary>
+    public bool SupportsGeometryEnrichment { get; init; }
+
+    /// <summary>Whether enrichment can run against feature identifiers.</summary>
+    public bool SupportsFeatureEnrichment { get; init; }
+
+    /// <summary>Whether batch enrichment is supported.</summary>
+    public bool SupportsBatchEnrichment { get; init; }
+
+    /// <summary>Whether demographic or business-analysis variables are available.</summary>
+    public bool SupportsDemographicVariables { get; init; }
+
+    /// <summary>Whether custom or tenant-defined variables are available.</summary>
+    public bool SupportsCustomVariables { get; init; }
+
+    /// <summary>Native provider surface backing the implementation.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason the capability set is unavailable, when applicable.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Enrichment attribute or variable definition.
+/// </summary>
+public sealed record EnrichmentAttributeDefinition
+{
+    /// <summary>Stable attribute or variable id.</summary>
+    public required string AttributeId { get; init; }
+
+    /// <summary>Display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Attribute category, such as demographics or parcel context.</summary>
+    public string? Category { get; init; }
+
+    /// <summary>Portable value type.</summary>
+    public SpatialDataValueType ValueType { get; init; } = SpatialDataValueType.Unknown;
+
+    /// <summary>Measurement unit for the attribute value.</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>Provider description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Provider aggregation or apportionment method.</summary>
+    public string? AggregationMethod { get; init; }
+
+    /// <summary>Raw provider metadata for this attribute.</summary>
+    public JsonElement? Raw { get; init; }
+}
+
+/// <summary>
+/// Request for enrichment metadata.
+/// </summary>
+public sealed record EnrichmentMetadataRequest
+{
+    /// <summary>Provider-specific enrichment source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Optional variable set or enrichment catalog identifier.</summary>
+    public string? VariableSetId { get; init; }
+
+    /// <summary>Optional categories to include.</summary>
+    public IReadOnlyList<string>? Categories { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Enrichment metadata returned by a provider.
+/// </summary>
+public sealed record EnrichmentMetadata
+{
+    /// <summary>Source that produced the metadata.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Attributes or variables available for enrichment.</summary>
+    public IReadOnlyList<EnrichmentAttributeDefinition> Attributes { get; init; } = [];
+
+    /// <summary>Advertised attribute categories.</summary>
+    public IReadOnlyList<string> Categories { get; init; } = [];
+
+    /// <summary>Raw provider metadata payload.</summary>
+    public JsonElement? RawMetadata { get; init; }
+}
+
+/// <summary>
+/// Enrichment request for feature identifiers, geometry, or an area of interest.
+/// </summary>
+public sealed record EnrichmentRequest
+{
+    /// <summary>Provider-specific enrichment source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Attributes or variables requested from the provider.</summary>
+    public IReadOnlyList<string> AttributeIds { get; init; } = [];
+
+    /// <summary>Feature source to enrich when feature identifiers are supplied.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+
+    /// <summary>String feature identifiers to enrich.</summary>
+    public IReadOnlyList<string>? FeatureIds { get; init; }
+
+    /// <summary>Numeric object identifiers to enrich.</summary>
+    public IReadOnlyList<long>? ObjectIds { get; init; }
+
+    /// <summary>Provider JSON geometry to enrich.</summary>
+    public JsonElement? Geometry { get; init; }
+
+    /// <summary>Geometry shape type for <see cref="Geometry"/>.</summary>
+    public FeatureSpatialGeometryType GeometryType { get; init; } = FeatureSpatialGeometryType.Unspecified;
+
+    /// <summary>Coordinate reference system for <see cref="Geometry"/> when not embedded in the geometry.</summary>
+    public string? GeometryCrs { get; init; }
+
+    /// <summary>Bounding extent to enrich or use as an area hint.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Optional area-of-interest geometry filter.</summary>
+    public FeatureSpatialFilter? AreaOfInterest { get; init; }
+
+    /// <summary>Provider or CQL filter applied before enrichment.</summary>
+    public string? Filter { get; init; }
+
+    /// <summary>Filter language for <see cref="Filter"/>.</summary>
+    public FeatureFilterLanguage FilterLanguage { get; init; } = FeatureFilterLanguage.ProviderDefault;
+
+    /// <summary>Whether geometry should be returned with enriched records.</summary>
+    public bool ReturnGeometry { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Enriched record returned by a provider.
+/// </summary>
+public sealed record EnrichmentRecord
+{
+    /// <summary>Record identifier, when returned by the provider.</summary>
+    public string? RecordId { get; init; }
+
+    /// <summary>Feature source associated with this record, when known.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+
+    /// <summary>Returned geometry, when requested and supported.</summary>
+    public JsonElement? Geometry { get; init; }
+
+    /// <summary>Enriched attribute values keyed by attribute id.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Attributes { get; init; } = new Dictionary<string, JsonElement>();
+
+    /// <summary>Provider messages specific to this record.</summary>
+    public IReadOnlyList<SpatialDataMessage> Messages { get; init; } = [];
+}
+
+/// <summary>
+/// Enrichment response returned by a provider.
+/// </summary>
+public sealed record EnrichmentResponse
+{
+    /// <summary>Source that produced the response.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Returned enrichment records.</summary>
+    public IReadOnlyList<EnrichmentRecord> Records { get; init; } = [];
+
+    /// <summary>Attribute definitions associated with returned values, when available.</summary>
+    public IReadOnlyList<EnrichmentAttributeDefinition> Attributes { get; init; } = [];
+
+    /// <summary>Provider messages.</summary>
+    public IReadOnlyList<SpatialDataMessage> Messages { get; init; } = [];
+
+    /// <summary>Raw provider response payload.</summary>
+    public JsonElement? RawResponse { get; init; }
+
+    /// <summary>Whether the response and all returned records do not contain provider errors.</summary>
+    public bool Succeeded =>
+        !Messages.Any(static message => message.Severity == SpatialDataMessageSeverity.Error) &&
+        !Records.Any(static record => record.Messages.Any(static message => message.Severity == SpatialDataMessageSeverity.Error));
+}

--- a/src/Honua.Sdk.Abstractions/Data/IHonuaElevationDataClient.cs
+++ b/src/Honua.Sdk.Abstractions/Data/IHonuaElevationDataClient.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Provider-neutral elevation data client contract.
+/// </summary>
+public interface IHonuaElevationDataClient
+{
+    /// <summary>Stable provider name for diagnostics and adapter selection.</summary>
+    string ProviderName { get; }
+
+    /// <summary>Provider capabilities for elevation operations.</summary>
+    ElevationDataCapabilities ElevationCapabilities { get; }
+
+    /// <summary>
+    /// Samples elevation at points or along a provider-supported profile geometry.
+    /// </summary>
+    /// <param name="request">Elevation sampling request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Elevation sampling response.</returns>
+    Task<ElevationSamplingResponse> SampleElevationAsync(ElevationSamplingRequest request, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Data/IHonuaEnrichmentDataClient.cs
+++ b/src/Honua.Sdk.Abstractions/Data/IHonuaEnrichmentDataClient.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Provider-neutral enrichment data client contract.
+/// </summary>
+public interface IHonuaEnrichmentDataClient
+{
+    /// <summary>Stable provider name for diagnostics and adapter selection.</summary>
+    string ProviderName { get; }
+
+    /// <summary>Provider capabilities for enrichment operations.</summary>
+    EnrichmentDataCapabilities EnrichmentCapabilities { get; }
+
+    /// <summary>
+    /// Gets available enrichment attributes or variable metadata.
+    /// </summary>
+    /// <param name="request">Metadata discovery request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Enrichment metadata.</returns>
+    Task<EnrichmentMetadata> GetEnrichmentMetadataAsync(EnrichmentMetadataRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Enriches feature identifiers, geometry, or an area of interest with requested attributes.
+    /// </summary>
+    /// <param name="request">Enrichment request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Enrichment response.</returns>
+    Task<EnrichmentResponse> EnrichAsync(EnrichmentRequest request, CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Data/IHonuaRasterDataClient.cs
+++ b/src/Honua.Sdk.Abstractions/Data/IHonuaRasterDataClient.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Provider-neutral raster data client contract.
+/// </summary>
+public interface IHonuaRasterDataClient
+{
+    /// <summary>Stable provider name for diagnostics and adapter selection.</summary>
+    string ProviderName { get; }
+
+    /// <summary>Provider capabilities for raster data operations.</summary>
+    RasterDataCapabilities RasterCapabilities { get; }
+
+    /// <summary>
+    /// Gets raster dataset metadata.
+    /// </summary>
+    /// <param name="request">Metadata discovery request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Raster dataset metadata.</returns>
+    Task<RasterDatasetMetadata> GetRasterMetadataAsync(RasterMetadataRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Computes raster coverage statistics for an extent or area of interest.
+    /// </summary>
+    /// <param name="request">Coverage statistics request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Raster coverage statistics response.</returns>
+    Task<RasterCoverageStatisticsResponse> GetCoverageStatisticsAsync(
+        RasterCoverageStatisticsRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Abstractions/Data/RasterDataModels.cs
+++ b/src/Honua.Sdk.Abstractions/Data/RasterDataModels.cs
@@ -1,0 +1,331 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Portable raster pixel storage type.
+/// </summary>
+public enum RasterPixelType
+{
+    /// <summary>Pixel type is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Unsigned 8-bit integer.</summary>
+    UnsignedByte = 1,
+
+    /// <summary>Signed 8-bit integer.</summary>
+    SignedByte = 2,
+
+    /// <summary>Unsigned 16-bit integer.</summary>
+    UnsignedShort = 3,
+
+    /// <summary>Signed 16-bit integer.</summary>
+    SignedShort = 4,
+
+    /// <summary>Unsigned 32-bit integer.</summary>
+    UnsignedInteger = 5,
+
+    /// <summary>Signed 32-bit integer.</summary>
+    SignedInteger = 6,
+
+    /// <summary>32-bit floating-point value.</summary>
+    SinglePrecision = 7,
+
+    /// <summary>64-bit floating-point value.</summary>
+    DoublePrecision = 8,
+
+    /// <summary>64-bit complex value.</summary>
+    ComplexSinglePrecision = 9,
+
+    /// <summary>128-bit complex value.</summary>
+    ComplexDoublePrecision = 10
+}
+
+/// <summary>
+/// Raster sampling or aggregation resampling method.
+/// </summary>
+public enum RasterResamplingMethod
+{
+    /// <summary>Use the provider default.</summary>
+    ProviderDefault = 0,
+
+    /// <summary>Nearest-neighbor sampling.</summary>
+    Nearest = 1,
+
+    /// <summary>Bilinear interpolation.</summary>
+    Bilinear = 2,
+
+    /// <summary>Cubic interpolation.</summary>
+    Cubic = 3,
+
+    /// <summary>Majority value for categorical rasters.</summary>
+    Majority = 4,
+
+    /// <summary>Average of contributing cells.</summary>
+    Average = 5
+}
+
+/// <summary>
+/// Capabilities advertised by a raster data provider.
+/// </summary>
+public sealed record RasterDataCapabilities
+{
+    /// <summary>Whether raster dataset metadata can be discovered.</summary>
+    public bool SupportsMetadata { get; init; }
+
+    /// <summary>Whether band-level metadata can be returned.</summary>
+    public bool SupportsBandMetadata { get; init; }
+
+    /// <summary>Whether raster coverage statistics can be computed.</summary>
+    public bool SupportsCoverageStatistics { get; init; }
+
+    /// <summary>Whether histogram metadata can be returned.</summary>
+    public bool SupportsHistograms { get; init; }
+
+    /// <summary>Whether provider mosaic rules or raster item filters can be supplied.</summary>
+    public bool SupportsMosaicRules { get; init; }
+
+    /// <summary>Whether temporal slices can be requested.</summary>
+    public bool SupportsTimeSlices { get; init; }
+
+    /// <summary>Whether no-data masks or no-data counts can be returned.</summary>
+    public bool SupportsNoDataMasks { get; init; }
+
+    /// <summary>Native provider surface backing the implementation.</summary>
+    public string? NativeSurface { get; init; }
+
+    /// <summary>Reason the capability set is unavailable, when applicable.</summary>
+    public string? UnsupportedReason { get; init; }
+}
+
+/// <summary>
+/// Request for raster dataset metadata.
+/// </summary>
+public sealed record RasterMetadataRequest
+{
+    /// <summary>Provider-specific raster source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Whether band metadata should be included when the provider supports it.</summary>
+    public bool IncludeBands { get; init; } = true;
+
+    /// <summary>Whether statistics should be included when the provider supports them.</summary>
+    public bool IncludeStatistics { get; init; }
+
+    /// <summary>Whether histograms should be included when the provider supports them.</summary>
+    public bool IncludeHistograms { get; init; }
+
+    /// <summary>Optional provider mosaic rule, raster item filter, or version selector.</summary>
+    public JsonElement? Selector { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Metadata for a raster band.
+/// </summary>
+public sealed record RasterBandMetadata
+{
+    /// <summary>Zero- or one-based band index as advertised by the provider.</summary>
+    public required int BandIndex { get; init; }
+
+    /// <summary>Band display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Band description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Portable pixel type, when known.</summary>
+    public RasterPixelType PixelType { get; init; } = RasterPixelType.Unknown;
+
+    /// <summary>Provider-native data type string.</summary>
+    public string? DataType { get; init; }
+
+    /// <summary>Measurement unit for band values.</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>No-data value for this band, when a scalar no-data value is available.</summary>
+    public double? NoDataValue { get; init; }
+
+    /// <summary>Minimum advertised value.</summary>
+    public double? Minimum { get; init; }
+
+    /// <summary>Maximum advertised value.</summary>
+    public double? Maximum { get; init; }
+
+    /// <summary>Mean advertised value.</summary>
+    public double? Mean { get; init; }
+
+    /// <summary>Standard deviation advertised by the provider.</summary>
+    public double? StandardDeviation { get; init; }
+
+    /// <summary>Additional band attributes.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+}
+
+/// <summary>
+/// Raster dataset metadata returned by a provider.
+/// </summary>
+public sealed record RasterDatasetMetadata
+{
+    /// <summary>Source that produced the metadata.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Stable dataset identifier.</summary>
+    public required string DatasetId { get; init; }
+
+    /// <summary>Dataset display or lookup name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Dataset description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>Dataset coordinate reference system identifier.</summary>
+    public string? SpatialReference { get; init; }
+
+    /// <summary>Dataset extent, when advertised.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Cell width in dataset units.</summary>
+    public double? CellSizeX { get; init; }
+
+    /// <summary>Cell height in dataset units.</summary>
+    public double? CellSizeY { get; init; }
+
+    /// <summary>Raster width in cells.</summary>
+    public int? Width { get; init; }
+
+    /// <summary>Raster height in cells.</summary>
+    public int? Height { get; init; }
+
+    /// <summary>Dataset pixel type, when a single type applies.</summary>
+    public RasterPixelType PixelType { get; init; } = RasterPixelType.Unknown;
+
+    /// <summary>Advertised band metadata.</summary>
+    public IReadOnlyList<RasterBandMetadata> Bands { get; init; } = [];
+
+    /// <summary>Provider capabilities or named operations available for this dataset.</summary>
+    public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+    /// <summary>Raw provider metadata payload.</summary>
+    public JsonElement? RawMetadata { get; init; }
+}
+
+/// <summary>
+/// Request for raster coverage statistics.
+/// </summary>
+public sealed record RasterCoverageStatisticsRequest
+{
+    /// <summary>Provider-specific raster source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Band indexes to include. Empty or null means provider default.</summary>
+    public IReadOnlyList<int>? BandIndexes { get; init; }
+
+    /// <summary>Bounding extent for statistics.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Optional area-of-interest geometry filter.</summary>
+    public FeatureSpatialFilter? AreaOfInterest { get; init; }
+
+    /// <summary>Provider or CQL filter applied before statistics are computed.</summary>
+    public string? Filter { get; init; }
+
+    /// <summary>Filter language for <see cref="Filter"/>.</summary>
+    public FeatureFilterLanguage FilterLanguage { get; init; } = FeatureFilterLanguage.ProviderDefault;
+
+    /// <summary>Requested statistic functions. Empty or null means provider default.</summary>
+    public IReadOnlyList<SpatialDataStatisticType>? StatisticTypes { get; init; }
+
+    /// <summary>Percentile values to compute, expressed in the range 0-100.</summary>
+    public IReadOnlyList<double>? Percentiles { get; init; }
+
+    /// <summary>Requested output cell size or aggregation resolution.</summary>
+    public double? CellSize { get; init; }
+
+    /// <summary>Resampling method for providers that aggregate or sample cells.</summary>
+    public RasterResamplingMethod ResamplingMethod { get; init; } = RasterResamplingMethod.ProviderDefault;
+
+    /// <summary>Optional provider mosaic rule, raster item filter, or version selector.</summary>
+    public JsonElement? Selector { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Statistics for one raster band over a requested coverage area.
+/// </summary>
+public sealed record RasterBandStatistics
+{
+    /// <summary>Band index associated with these statistics.</summary>
+    public required int BandIndex { get; init; }
+
+    /// <summary>Count of included cells.</summary>
+    public long? Count { get; init; }
+
+    /// <summary>Count of no-data cells.</summary>
+    public long? NoDataCount { get; init; }
+
+    /// <summary>Minimum value.</summary>
+    public double? Minimum { get; init; }
+
+    /// <summary>Maximum value.</summary>
+    public double? Maximum { get; init; }
+
+    /// <summary>Mean value.</summary>
+    public double? Mean { get; init; }
+
+    /// <summary>Median value.</summary>
+    public double? Median { get; init; }
+
+    /// <summary>Standard deviation.</summary>
+    public double? StandardDeviation { get; init; }
+
+    /// <summary>Variance.</summary>
+    public double? Variance { get; init; }
+
+    /// <summary>Sum of values.</summary>
+    public double? Sum { get; init; }
+
+    /// <summary>Percentile values keyed by requested percentile label.</summary>
+    public IReadOnlyDictionary<string, double>? Percentiles { get; init; }
+
+    /// <summary>Additional provider statistics.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? AdditionalStatistics { get; init; }
+}
+
+/// <summary>
+/// Raster coverage statistics response.
+/// </summary>
+public sealed record RasterCoverageStatisticsResponse
+{
+    /// <summary>Source that produced the response.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Statistics grouped by band.</summary>
+    public IReadOnlyList<RasterBandStatistics> Bands { get; init; } = [];
+
+    /// <summary>Extent used by the provider for the statistics.</summary>
+    public FeatureBoundingBox? Extent { get; init; }
+
+    /// <summary>Cell size or aggregation resolution used by the provider.</summary>
+    public double? CellSize { get; init; }
+
+    /// <summary>Measurement unit for returned values when one unit applies.</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>Provider messages.</summary>
+    public IReadOnlyList<SpatialDataMessage> Messages { get; init; } = [];
+
+    /// <summary>Raw provider response payload.</summary>
+    public JsonElement? RawResponse { get; init; }
+
+    /// <summary>Whether the response does not contain provider errors.</summary>
+    public bool Succeeded => !Messages.Any(static message => message.Severity == SpatialDataMessageSeverity.Error);
+}

--- a/src/Honua.Sdk.Abstractions/Data/SpatialDataModels.cs
+++ b/src/Honua.Sdk.Abstractions/Data/SpatialDataModels.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Data;
+
+/// <summary>
+/// Severity for provider messages returned by spatial data services.
+/// </summary>
+public enum SpatialDataMessageSeverity
+{
+    /// <summary>Informational message.</summary>
+    Information = 0,
+
+    /// <summary>Warning that does not necessarily block the result.</summary>
+    Warning = 1,
+
+    /// <summary>Error reported by the provider.</summary>
+    Error = 2
+}
+
+/// <summary>
+/// Portable scalar value kind used by raster and enrichment metadata.
+/// </summary>
+public enum SpatialDataValueType
+{
+    /// <summary>Value type is unknown or provider-defined.</summary>
+    Unknown = 0,
+
+    /// <summary>Integral numeric value.</summary>
+    IntegralNumber = 1,
+
+    /// <summary>Floating-point numeric value.</summary>
+    FloatingNumber = 2,
+
+    /// <summary>Fixed-precision decimal value.</summary>
+    FixedPrecisionNumber = 3,
+
+    /// <summary>Boolean value.</summary>
+    BooleanValue = 4,
+
+    /// <summary>String value.</summary>
+    Text = 5,
+
+    /// <summary>Date or timestamp value.</summary>
+    Timestamp = 6,
+
+    /// <summary>Geometry value.</summary>
+    Geometry = 7,
+
+    /// <summary>Provider JSON object or array.</summary>
+    Json = 8
+}
+
+/// <summary>
+/// Statistic function requested from raster coverage or enrichment services.
+/// </summary>
+public enum SpatialDataStatisticType
+{
+    /// <summary>Statistic type is not specified.</summary>
+    Unspecified = 0,
+
+    /// <summary>Count of included cells or records.</summary>
+    Count = 1,
+
+    /// <summary>Count of excluded no-data cells.</summary>
+    NoDataCount = 2,
+
+    /// <summary>Sum of values.</summary>
+    Sum = 3,
+
+    /// <summary>Minimum value.</summary>
+    Min = 4,
+
+    /// <summary>Maximum value.</summary>
+    Max = 5,
+
+    /// <summary>Mean or average value.</summary>
+    Mean = 6,
+
+    /// <summary>Median value.</summary>
+    Median = 7,
+
+    /// <summary>Standard deviation.</summary>
+    StandardDeviation = 8,
+
+    /// <summary>Variance.</summary>
+    Variance = 9,
+
+    /// <summary>Requested percentile value.</summary>
+    Percentile = 10,
+
+    /// <summary>Area represented by included cells or features.</summary>
+    Area = 11
+}
+
+/// <summary>
+/// Provider-neutral source identifiers for raster, elevation, and enrichment data.
+/// </summary>
+public sealed record SpatialDataSource
+{
+    /// <summary>Honua service identifier or provider service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Provider dataset identifier.</summary>
+    public string? DatasetId { get; init; }
+
+    /// <summary>Layer identifier when the provider exposes data through a layer endpoint.</summary>
+    public int? LayerId { get; init; }
+
+    /// <summary>Raster identifier when a service contains multiple rasters or mosaic items.</summary>
+    public string? RasterId { get; init; }
+
+    /// <summary>OGC collection identifier for coverage or enrichment services.</summary>
+    public string? CollectionId { get; init; }
+
+    /// <summary>Optional provider version, branch, or workspace name.</summary>
+    public string? VersionName { get; init; }
+
+    /// <summary>Optional feature source associated with the data service.</summary>
+    public FeatureSource? FeatureSource { get; init; }
+}
+
+/// <summary>
+/// Point coordinate used by data sampling requests.
+/// </summary>
+public sealed record SpatialDataPoint
+{
+    /// <summary>X coordinate, normally longitude or projected easting.</summary>
+    public required double X { get; init; }
+
+    /// <summary>Y coordinate, normally latitude or projected northing.</summary>
+    public required double Y { get; init; }
+
+    /// <summary>Optional Z coordinate supplied by the caller or provider.</summary>
+    public double? Z { get; init; }
+
+    /// <summary>Optional coordinate reference system identifier.</summary>
+    public string? Crs { get; init; }
+
+    /// <summary>Optional caller-stable point id for correlating batch responses.</summary>
+    public string? PointId { get; init; }
+
+    /// <summary>Additional provider-neutral point attributes.</summary>
+    public IReadOnlyDictionary<string, JsonElement>? Attributes { get; init; }
+
+    /// <summary>
+    /// Creates a point from longitude/latitude ordered values.
+    /// </summary>
+    /// <param name="longitude">Longitude in decimal degrees.</param>
+    /// <param name="latitude">Latitude in decimal degrees.</param>
+    /// <param name="pointId">Optional caller-stable point id.</param>
+    /// <returns>A WGS84 point.</returns>
+    public static SpatialDataPoint FromLongitudeLatitude(double longitude, double latitude, string? pointId = null) => new()
+    {
+        X = longitude,
+        Y = latitude,
+        Crs = "EPSG:4326",
+        PointId = pointId,
+    };
+
+    /// <summary>
+    /// Creates a point from latitude/longitude ordered values, which is common for GPS APIs.
+    /// </summary>
+    /// <param name="latitude">Latitude in decimal degrees.</param>
+    /// <param name="longitude">Longitude in decimal degrees.</param>
+    /// <param name="pointId">Optional caller-stable point id.</param>
+    /// <returns>A WGS84 point.</returns>
+    public static SpatialDataPoint FromLatitudeLongitude(double latitude, double longitude, string? pointId = null)
+        => FromLongitudeLatitude(longitude, latitude, pointId);
+}
+
+/// <summary>
+/// Provider message returned with spatial data responses.
+/// </summary>
+public sealed record SpatialDataMessage
+{
+    /// <summary>Message severity.</summary>
+    public SpatialDataMessageSeverity Severity { get; init; }
+
+    /// <summary>Provider or SDK message code.</summary>
+    public string? Code { get; init; }
+
+    /// <summary>Human-readable message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Field, attribute, or request member associated with the message.</summary>
+    public string? FieldName { get; init; }
+
+    /// <summary>Optional suggested remediation text.</summary>
+    public string? SuggestedFix { get; init; }
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/RasterElevationEnrichmentContractTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/RasterElevationEnrichmentContractTests.cs
@@ -1,0 +1,405 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Data;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class RasterElevationEnrichmentContractTests
+{
+    [Fact]
+    public void RasterMetadata_ModelsBandsExtentsAndCoverageStatistics()
+    {
+        var source = RasterSource();
+        var metadata = new RasterDatasetMetadata
+        {
+            Source = source,
+            DatasetId = "landcover-2025",
+            Name = "Landcover 2025",
+            SpatialReference = "EPSG:3857",
+            Extent = new FeatureBoundingBox
+            {
+                MinX = -158.25,
+                MinY = 21.20,
+                MaxX = -157.60,
+                MaxY = 21.75,
+                Crs = "EPSG:4326",
+            },
+            CellSizeX = 10,
+            CellSizeY = 10,
+            Width = 4096,
+            Height = 2048,
+            PixelType = RasterPixelType.UnsignedShort,
+            Bands =
+            [
+                new RasterBandMetadata
+                {
+                    BandIndex = 1,
+                    Name = "Class",
+                    PixelType = RasterPixelType.UnsignedShort,
+                    Unit = "class",
+                    NoDataValue = 0,
+                    Minimum = 1,
+                    Maximum = 12,
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["colorTable"] = JsonValue("[1,2,3]"),
+                    },
+                },
+            ],
+            Capabilities = ["metadata", "statistics"],
+            RawMetadata = JsonValue("""{"dataset":"landcover-2025"}"""),
+        };
+
+        var request = new RasterCoverageStatisticsRequest
+        {
+            Source = source,
+            BandIndexes = [1],
+            Extent = metadata.Extent,
+            StatisticTypes =
+            [
+                SpatialDataStatisticType.Count,
+                SpatialDataStatisticType.Mean,
+                SpatialDataStatisticType.Percentile,
+            ],
+            Percentiles = [50, 95],
+            ResamplingMethod = RasterResamplingMethod.Nearest,
+        };
+        var response = new RasterCoverageStatisticsResponse
+        {
+            Source = source,
+            Extent = request.Extent,
+            Bands =
+            [
+                new RasterBandStatistics
+                {
+                    BandIndex = 1,
+                    Count = 2048,
+                    NoDataCount = 3,
+                    Minimum = 1,
+                    Maximum = 12,
+                    Mean = 4.25,
+                    Percentiles = new Dictionary<string, double>
+                    {
+                        ["p50"] = 4,
+                        ["p95"] = 11,
+                    },
+                },
+            ],
+        };
+
+        Assert.Equal("landcover-2025", metadata.DatasetId);
+        Assert.Equal(RasterPixelType.UnsignedShort, metadata.Bands[0].PixelType);
+        Assert.Equal(RasterResamplingMethod.Nearest, request.ResamplingMethod);
+        Assert.True(response.Succeeded);
+        Assert.Equal(2048, response.Bands[0].Count);
+        Assert.Equal(11, response.Bands[0].Percentiles?["p95"]);
+    }
+
+    [Fact]
+    public void ElevationSampling_ModelsPointAndProfileSamples()
+    {
+        var point = SpatialDataPoint.FromLatitudeLongitude(21.3045, -157.8557, "honolulu");
+        var request = new ElevationSamplingRequest
+        {
+            Source = new SpatialDataSource
+            {
+                ServiceId = "terrain",
+                DatasetId = "dem-1m",
+            },
+            Points = [point],
+            PathGeometry = JsonValue("""{"paths":[[[-157.9,21.3],[-157.8,21.35]]]}"""),
+            PathCrs = "EPSG:4326",
+            SampleDistance = 25,
+            Unit = "meters",
+            VerticalDatum = "EGM96",
+            IncludeNoData = true,
+        };
+        var response = new ElevationSamplingResponse
+        {
+            Source = request.Source,
+            Samples =
+            [
+                new ElevationSample
+                {
+                    Location = point,
+                    Elevation = 5.8,
+                    Unit = request.Unit,
+                    VerticalDatum = request.VerticalDatum,
+                    DistanceAlong = 0,
+                    Resolution = 1,
+                },
+            ],
+        };
+
+        Assert.Equal("EPSG:4326", point.Crs);
+        Assert.Equal(-157.8557, point.X);
+        Assert.Equal(21.3045, point.Y);
+        Assert.Equal(25, request.SampleDistance);
+        Assert.True(response.Succeeded);
+        Assert.Equal(5.8, response.Samples[0].Elevation);
+    }
+
+    [Fact]
+    public void Enrichment_ModelsMetadataAttributesAndBlockingMessages()
+    {
+        var population = new EnrichmentAttributeDefinition
+        {
+            AttributeId = "population_total",
+            Name = "Total population",
+            Category = "demographics",
+            ValueType = SpatialDataValueType.IntegralNumber,
+            Unit = "people",
+            AggregationMethod = "apportioned",
+        };
+        var metadata = new EnrichmentMetadata
+        {
+            Source = new SpatialDataSource
+            {
+                ServiceId = "enrichment",
+                DatasetId = "acs",
+            },
+            Attributes = [population],
+            Categories = ["demographics"],
+        };
+        var request = new EnrichmentRequest
+        {
+            Source = metadata.Source,
+            AttributeIds = [population.AttributeId],
+            Geometry = JsonValue("""{"rings":[[[-158,21],[-157,21],[-157,22],[-158,21]]]}"""),
+            GeometryType = FeatureSpatialGeometryType.Polygon,
+            GeometryCrs = "EPSG:4326",
+            ReturnGeometry = false,
+        };
+        var response = new EnrichmentResponse
+        {
+            Source = metadata.Source,
+            Attributes = [population],
+            Records =
+            [
+                new EnrichmentRecord
+                {
+                    RecordId = "aoI-1",
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        [population.AttributeId] = JsonValue("973000"),
+                    },
+                },
+            ],
+        };
+        var failed = response with
+        {
+            Messages =
+            [
+                new SpatialDataMessage
+                {
+                    Severity = SpatialDataMessageSeverity.Error,
+                    Code = "missing-variable",
+                    Message = "Requested enrichment variable is not available.",
+                    SuggestedFix = "Refresh enrichment metadata.",
+                },
+            ],
+        };
+
+        Assert.Single(metadata.Attributes);
+        Assert.Equal(FeatureSpatialGeometryType.Polygon, request.GeometryType);
+        Assert.True(response.Succeeded);
+        Assert.False(failed.Succeeded);
+        Assert.Equal(973000, response.Records[0].Attributes[population.AttributeId].GetInt32());
+    }
+
+    [Fact]
+    public async Task Interfaces_ModelProviderCapabilitiesAndWorkflows()
+    {
+        var client = new FakeSpatialDataClient();
+
+        var metadata = await client.GetRasterMetadataAsync(new RasterMetadataRequest
+        {
+            Source = RasterSource(),
+            IncludeBands = true,
+        });
+        var statistics = await client.GetCoverageStatisticsAsync(new RasterCoverageStatisticsRequest
+        {
+            Source = RasterSource(),
+            BandIndexes = [1],
+        });
+        var elevation = await client.SampleElevationAsync(new ElevationSamplingRequest
+        {
+            Source = new SpatialDataSource { ServiceId = "terrain" },
+            Points = [SpatialDataPoint.FromLongitudeLatitude(-157.8557, 21.3045, "honolulu")],
+        });
+        var enrichmentMetadata = await client.GetEnrichmentMetadataAsync(new EnrichmentMetadataRequest
+        {
+            Source = new SpatialDataSource { ServiceId = "enrichment" },
+        });
+        var enrichment = await client.EnrichAsync(new EnrichmentRequest
+        {
+            Source = enrichmentMetadata.Source,
+            AttributeIds = ["population_total"],
+            FeatureSource = new FeatureSource { ServiceId = "parcels", LayerId = 0 },
+            ObjectIds = [42],
+        });
+
+        Assert.Equal("fake-spatial-data", client.ProviderName);
+        Assert.True(client.RasterCapabilities.SupportsCoverageStatistics);
+        Assert.True(client.ElevationCapabilities.SupportsProfileSampling);
+        Assert.True(client.EnrichmentCapabilities.SupportsFeatureEnrichment);
+        Assert.Equal("landcover-2025", metadata.DatasetId);
+        Assert.True(statistics.Succeeded);
+        Assert.Single(elevation.Samples);
+        Assert.Single(enrichmentMetadata.Attributes);
+        Assert.True(enrichment.Succeeded);
+    }
+
+    private static SpatialDataSource RasterSource()
+        => new()
+        {
+            ServiceId = "imagery",
+            DatasetId = "landcover-2025",
+            RasterId = "mosaic-1",
+        };
+
+    private static JsonElement JsonValue(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private sealed class FakeSpatialDataClient :
+        IHonuaRasterDataClient,
+        IHonuaElevationDataClient,
+        IHonuaEnrichmentDataClient
+    {
+        public string ProviderName => "fake-spatial-data";
+
+        public RasterDataCapabilities RasterCapabilities { get; } = new()
+        {
+            SupportsMetadata = true,
+            SupportsBandMetadata = true,
+            SupportsCoverageStatistics = true,
+            SupportsNoDataMasks = true,
+            NativeSurface = "honua-server-raster",
+        };
+
+        public ElevationDataCapabilities ElevationCapabilities { get; } = new()
+        {
+            SupportsPointSampling = true,
+            SupportsBatchSampling = true,
+            SupportsProfileSampling = true,
+            SupportsOutputUnits = true,
+            SupportsVerticalDatum = true,
+            NativeSurface = "honua-server-elevation",
+        };
+
+        public EnrichmentDataCapabilities EnrichmentCapabilities { get; } = new()
+        {
+            SupportsMetadata = true,
+            SupportsFeatureEnrichment = true,
+            SupportsGeometryEnrichment = true,
+            SupportsBatchEnrichment = true,
+            SupportsDemographicVariables = true,
+            NativeSurface = "honua-server-enrichment",
+        };
+
+        public Task<RasterDatasetMetadata> GetRasterMetadataAsync(RasterMetadataRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new RasterDatasetMetadata
+            {
+                Source = request.Source,
+                DatasetId = request.Source.DatasetId ?? "landcover-2025",
+                Bands =
+                [
+                    new RasterBandMetadata
+                    {
+                        BandIndex = 1,
+                        Name = "Class",
+                        PixelType = RasterPixelType.UnsignedShort,
+                    },
+                ],
+                Capabilities = ["metadata", "statistics"],
+            });
+        }
+
+        public Task<RasterCoverageStatisticsResponse> GetCoverageStatisticsAsync(
+            RasterCoverageStatisticsRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new RasterCoverageStatisticsResponse
+            {
+                Source = request.Source,
+                Bands =
+                [
+                    new RasterBandStatistics
+                    {
+                        BandIndex = request.BandIndexes?[0] ?? 1,
+                        Count = 12,
+                        Minimum = 1,
+                        Maximum = 9,
+                        Mean = 4.5,
+                    },
+                ],
+            });
+        }
+
+        public Task<ElevationSamplingResponse> SampleElevationAsync(ElevationSamplingRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new ElevationSamplingResponse
+            {
+                Source = request.Source,
+                Samples = request.Points.Select(static point => new ElevationSample
+                {
+                    Location = point,
+                    Elevation = 5.8,
+                    Unit = "meters",
+                    VerticalDatum = "EGM96",
+                }).ToList(),
+            });
+        }
+
+        public Task<EnrichmentMetadata> GetEnrichmentMetadataAsync(EnrichmentMetadataRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new EnrichmentMetadata
+            {
+                Source = request.Source,
+                Categories = ["demographics"],
+                Attributes =
+                [
+                    new EnrichmentAttributeDefinition
+                    {
+                        AttributeId = "population_total",
+                        Name = "Total population",
+                        Category = "demographics",
+                        ValueType = SpatialDataValueType.IntegralNumber,
+                    },
+                ],
+            });
+        }
+
+        public Task<EnrichmentResponse> EnrichAsync(EnrichmentRequest request, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(new EnrichmentResponse
+            {
+                Source = request.Source,
+                Records =
+                [
+                    new EnrichmentRecord
+                    {
+                        RecordId = request.ObjectIds?[0].ToString(System.Globalization.CultureInfo.InvariantCulture),
+                        FeatureSource = request.FeatureSource,
+                        Attributes = new Dictionary<string, JsonElement>
+                        {
+                            ["population_total"] = JsonValue("973000"),
+                        },
+                    },
+                ],
+            });
+        }
+    }
+}

--- a/tests/Honua.Sdk.BrowserSmoke/Program.cs
+++ b/tests/Honua.Sdk.BrowserSmoke/Program.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Honua.Sdk.Abstractions.Data;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Plugins;
 using Honua.Sdk.Abstractions.UtilityNetworks;
@@ -34,6 +35,7 @@ RegisterFieldContracts(builder.Services);
 RegisterGeometryContracts(builder.Services);
 RegisterOfflineContracts(builder.Services);
 RegisterAdvancedEditingContracts(builder.Services);
+RegisterSpatialDataContracts(builder.Services);
 RegisterPluginContracts(builder.Services);
 RegisterRealtimeContracts(builder.Services);
 RegisterUtilityNetworkContracts(builder.Services);
@@ -273,6 +275,111 @@ static void RegisterAdvancedEditingContracts(IServiceCollection services)
         SessionId = "browser-session",
         VersionName = "sde.DEFAULT",
         StartedAt = DateTimeOffset.UnixEpoch,
+    });
+}
+
+static void RegisterSpatialDataContracts(IServiceCollection services)
+{
+    var source = new SpatialDataSource
+    {
+        ServiceId = "imagery",
+        DatasetId = "landcover-2025",
+        RasterId = "mosaic-1",
+    };
+    var band = new RasterBandMetadata
+    {
+        BandIndex = 1,
+        Name = "Class",
+        PixelType = RasterPixelType.UnsignedShort,
+        Unit = "class",
+    };
+    var metadata = new RasterDatasetMetadata
+    {
+        Source = source,
+        DatasetId = "landcover-2025",
+        SpatialReference = "EPSG:4326",
+        Extent = new FeatureBoundingBox
+        {
+            MinX = -158.25,
+            MinY = 21.20,
+            MaxX = -157.60,
+            MaxY = 21.75,
+            Crs = "EPSG:4326",
+        },
+        Bands = [band],
+        Capabilities = ["metadata", "statistics"],
+    };
+    var elevationRequest = new ElevationSamplingRequest
+    {
+        Source = new SpatialDataSource
+        {
+            ServiceId = "terrain",
+            DatasetId = "dem-1m",
+        },
+        Points = [SpatialDataPoint.FromLongitudeLatitude(-157.8557, 21.3045, "honolulu")],
+        Unit = "meters",
+    };
+    var enrichmentAttribute = new EnrichmentAttributeDefinition
+    {
+        AttributeId = "population_total",
+        Name = "Total population",
+        Category = "demographics",
+        ValueType = SpatialDataValueType.IntegralNumber,
+    };
+
+    services.AddSingleton(source);
+    services.AddSingleton(band);
+    services.AddSingleton(metadata);
+    services.AddSingleton(new RasterDataCapabilities
+    {
+        SupportsMetadata = true,
+        SupportsBandMetadata = true,
+        SupportsCoverageStatistics = true,
+        NativeSurface = "browser-host-adapter",
+    });
+    services.AddSingleton(new RasterCoverageStatisticsRequest
+    {
+        Source = source,
+        BandIndexes = [1],
+        StatisticTypes = [SpatialDataStatisticType.Count, SpatialDataStatisticType.Mean],
+    });
+    services.AddSingleton(elevationRequest);
+    services.AddSingleton(new ElevationSamplingResponse
+    {
+        Source = elevationRequest.Source,
+        Samples =
+        [
+            new ElevationSample
+            {
+                Location = elevationRequest.Points[0],
+                Elevation = 5.8,
+                Unit = "meters",
+            },
+        ],
+    });
+    services.AddSingleton(new ElevationDataCapabilities
+    {
+        SupportsPointSampling = true,
+        SupportsBatchSampling = true,
+        NativeSurface = "browser-host-adapter",
+    });
+    services.AddSingleton(enrichmentAttribute);
+    services.AddSingleton(new EnrichmentMetadata
+    {
+        Source = new SpatialDataSource
+        {
+            ServiceId = "enrichment",
+            DatasetId = "acs",
+        },
+        Attributes = [enrichmentAttribute],
+        Categories = ["demographics"],
+    });
+    services.AddSingleton(new EnrichmentDataCapabilities
+    {
+        SupportsMetadata = true,
+        SupportsGeometryEnrichment = true,
+        SupportsFeatureEnrichment = true,
+        NativeSurface = "browser-host-adapter",
     });
 }
 


### PR DESCRIPTION
## Summary
- add provider-neutral data contracts for raster metadata, coverage statistics, elevation sampling, and enrichment metadata/results
- add optional IHonuaRasterDataClient, IHonuaElevationDataClient, and IHonuaEnrichmentDataClient interfaces without choosing server routes or display/rendering behavior
- extend BrowserSmoke/docs so these contracts remain browser-safe DTO/interface surfaces while server adapters stay blocked on linked Honua Server work

Closes #67

Server dependencies remain tracked in #67:
- https://github.com/honua-io/honua-server/issues/521
- https://github.com/honua-io/honua-server/issues/522
- https://github.com/honua-io/honua-server/issues/381
- https://github.com/honua-io/honua-server/issues/374
- https://github.com/honua-io/honua-server/issues/839
- https://github.com/honua-io/honua-server/issues/840

## Validation
- dotnet format Honua.Sdk.sln --verify-no-changes --verbosity minimal --no-restore
- dotnet build Honua.Sdk.sln --configuration Release --no-restore /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true
- dotnet test Honua.Sdk.sln --configuration Release --no-restore
- git diff --check
- git diff --cached --check
- scripts/validate-api-compat.sh origin/trunk