### PR TITLE
feat: add .NET demo suite scaffold

### DIFF
--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.BrowserSmoke", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.BrowserSmoke.Tests", "tests\Honua.Sdk.BrowserSmoke.Tests\Honua.Sdk.BrowserSmoke.Tests.csproj", "{67A5782D-9FA6-4074-95C2-0C1C26DC38CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecPlanApplyConsole", "examples\SpecPlanApplyConsole\SpecPlanApplyConsole.csproj", "{8A2D1437-243E-4D8A-9470-537ED2DA0772}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -425,6 +427,18 @@ Global
 		{67A5782D-9FA6-4074-95C2-0C1C26DC38CD}.Release|x64.Build.0 = Release|Any CPU
 		{67A5782D-9FA6-4074-95C2-0C1C26DC38CD}.Release|x86.ActiveCfg = Release|Any CPU
 		{67A5782D-9FA6-4074-95C2-0C1C26DC38CD}.Release|x86.Build.0 = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|x64.Build.0 = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -459,5 +473,6 @@ Global
 		{3F802AFE-2C9A-43A0-BEE5-E6AAEAF1E2A1} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{D9183C7D-D3A5-4C7C-80DB-E722C405F0C8} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{67A5782D-9FA6-4074-95C2-0C1C26DC38CD} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
+		{8A2D1437-243E-4D8A-9470-537ED2DA0772} = {4E4E4E4E-4E4E-4E4E-4E4E-4E4E4E4E4E4E}
 	EndGlobalSection
 EndGlobal

--- a/docs/demo-suite.md
+++ b/docs/demo-suite.md
@@ -1,0 +1,76 @@
+# .NET Demo Suite
+
+Issue `honua-sdk-dotnet#128` tracks a .NET-first demo suite that shows how the
+SDK packages fit operator, automation, worker, routing, geofence, and offline
+contract workflows.
+
+## Current Suite
+
+| Workflow | Owner package(s) | Demo asset | Notes |
+|----------|------------------|------------|-------|
+| Operator/admin bootstrap | `Honua.Sdk.Admin`, `Honua.Sdk.Grpc` | `examples/AdminBootstrapConsole` | Canonical sample. It should stay focused on compatibility, connection reuse, layer publish, protocol enablement, and bounded gRPC verification. |
+| Spec plan/apply | `Honua.Sdk.Spec` | `examples/SpecPlanApplyConsole` | Runnable scaffold. Uses a deterministic in-process Spec API by default and can target a real Honua Server with env vars. |
+| Realtime worker | `Honua.Sdk.Abstractions` | Planned `examples/RealtimeWorker` | Blocked on concrete server realtime transport. The first worker should process `FeatureStreamEvent` envelopes through SDK buffering with simulated insert/update/delete events as a fallback. |
+| Routing/geofence | `Honua.Sdk.Abstractions`, `Honua.Sdk.GeoServices`, `Honua.Sdk.Geometry` | Planned `examples/RoutingGeofenceConsole` | Routing needs a configured GeoServices/NAServer endpoint; geofence evaluation can be deterministic with local NTS geometry fixtures. |
+| Mobile offline boundary | `Honua.Sdk.Offline.Abstractions`, `Honua.Sdk.Offline` | Docs and contract tests | SDK owns portable offline manifests, journals, checkpoints, conflicts, adapters, planners, and `OfflineSyncEngine`. `honua-mobile` owns native GeoPackage storage and mobile runtime. |
+
+## Cloud Configuration
+
+Use environment variables for live deployments:
+
+```bash
+export HONUA_SPEC_MODE=server
+export HONUA_SPEC_SERVER_URL=https://your-honua.example
+export HONUA_SPEC_API_KEY=
+export HONUA_SPEC_BEARER_TOKEN=
+```
+
+Samples must not require checked-in credentials. API keys and bearer tokens may
+be sent to HTTPS targets or loopback HTTP used for local development. Non-local
+plain HTTP should remain a configuration error for authenticated samples.
+
+## Realtime Worker Plan
+
+The realtime worker demo should wait for server realtime support before
+claiming live coverage. Until then, the scaffold should:
+
+- Use `IHonuaFeatureStreamClient`-shaped code and SDK stream envelopes.
+- Feed deterministic simulated events through `FeatureStreamEventProcessor`.
+- Show reconnect cursor handling and duplicate/stale event rejection.
+- Keep host behavior limited to console logging or an in-memory projection.
+- Avoid server, mobile, browser, map-display, and notification concerns.
+
+Live validation should be added once Honua Server exposes the negotiated
+subscription endpoint and authentication requirements.
+
+## Routing And Geofence Plan
+
+The routing/geofence demo should be split so one half is deterministic and one
+half is live-configured:
+
+- Geofence: build NTS polygons and position samples in a projected spatial
+  reference, evaluate enter/exit/approach/depart transitions, and print a
+  stable event table.
+- Routing: register `IHonuaRoutingClient` through `Honua.Sdk.GeoServices` and
+  solve a small route only when a configured NAServer-compatible service is
+  available.
+- Validation: always run geofence evaluation locally; skip or clearly fail the
+  routing live path when the route service variables are absent.
+
+## Mobile Offline Boundary
+
+Offline is not missing from .NET. The SDK owns the portable contract and sync
+engine layer:
+
+- `Honua.Sdk.Offline.Abstractions` owns manifests, source descriptors, sync
+  state, checkpoints, retry cursors, change journal entries, conflict records,
+  and storage adapter contracts.
+- `Honua.Sdk.Offline` owns the provider-neutral planner and
+  `Honua.Sdk.Offline.OfflineSyncEngine`.
+- `honua-mobile` owns device reachability, background execution, native
+  SQLite/GeoPackage placement and lifecycle, mobile storage adapters, map
+  display, and user-facing conflict workflows.
+
+The .NET demo suite should show the portable contracts and deterministic sync
+adapter behavior. It should link to mobile docs for native runtime validation
+instead of presenting GeoPackage support as absent from the platform.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# Honua .NET SDK Examples
+
+This directory carries the .NET demo suite for SDK-owned workflows. Samples are
+kept language-fit for .NET console, worker, and service-host scenarios and do
+not replace mobile, server, or admin UI demos.
+
+## Demo Suite
+
+| Demo | Status | Capability | Validation |
+|------|--------|------------|------------|
+| [AdminBootstrapConsole](AdminBootstrapConsole/) | Canonical runnable sample | Operator/admin bootstrap, PostGIS table discovery, layer publish, protocol enablement, bounded gRPC verification | `dotnet run --project examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj` against local Honua Server |
+| [SpecPlanApplyConsole](SpecPlanApplyConsole/) | Lightweight runnable scaffold | Spec document construction, plan request, apply SSE stream consumption, deterministic simulated apply fallback | `dotnet run --project examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj` |
+| Realtime worker | Planned | `IHonuaFeatureStreamClient` subscription processing, reconnect/buffer behavior, duplicate/stale sequence handling | Gated on Honua Server realtime transport support; use deterministic simulated stream events until server endpoints are ready |
+| Routing/geofence | Planned | `IHonuaRoutingClient` route solve plus `HonuaGeofenceEvaluator` enter/exit/approach/depart transitions | Routing requires configured GeoServices/NAServer; geofence evaluation can run offline with NTS fixtures |
+| Mobile offline boundary | Documented | Portable offline manifests, journals, checkpoints, conflicts, and `Honua.Sdk.Offline.OfflineSyncEngine` contracts | Contract tests in `tests/Honua.Sdk.Offline.Tests`; native GeoPackage/runtime validation remains in `honua-mobile` |
+
+## Cloud Configuration
+
+Samples use environment variables instead of checked-in secrets:
+
+- `HONUA_*_SERVER_URL` or sample-specific server URL variables for the target
+  Honua deployment.
+- `HONUA_*_API_KEY` for API-key auth when enabled.
+- `HONUA_*_BEARER_TOKEN` for OAuth/OIDC or service-account bearer tokens.
+- Loopback HTTP is allowed for local development. Non-local authenticated
+  targets should use HTTPS.
+
+Each sample README lists its exact variable names and whether it can run without
+a live Honua Server.
+
+## Validation Policy
+
+- Prefer deterministic local scaffolds for CI-friendly demos.
+- Keep `AdminBootstrapConsole` canonical for operator bootstrap and avoid
+  broadening it into unrelated workflows.
+- For server-gated capabilities, document the live path and keep a simulated
+  event or fixture fallback so the SDK usage remains runnable.
+- Keep native mobile runtime, GeoPackage file lifecycle, background scheduling,
+  device permissions, and map display out of this repo's examples.
+
+See [../docs/demo-suite.md](../docs/demo-suite.md) for the issue #128 rollout
+plan and remaining work.

--- a/examples/SpecPlanApplyConsole/Program.cs
+++ b/examples/SpecPlanApplyConsole/Program.cs
@@ -1,0 +1,264 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Honua.Sdk.Spec;
+using Honua.Sdk.Spec.Models;
+
+var mode = Environment.GetEnvironmentVariable("HONUA_SPEC_MODE") ?? "simulated";
+var useServer = string.Equals(mode, "server", StringComparison.OrdinalIgnoreCase);
+var baseAddress = new Uri(Environment.GetEnvironmentVariable("HONUA_SPEC_SERVER_URL") ?? "https://localhost:5001");
+var apiKey = Environment.GetEnvironmentVariable("HONUA_SPEC_API_KEY");
+var bearerToken = Environment.GetEnvironmentVariable("HONUA_SPEC_BEARER_TOKEN");
+
+if (useServer && HasCredentials(apiKey, bearerToken) && RequiresHttpsForAuthentication(baseAddress))
+{
+    Console.Error.WriteLine("Authenticated Spec requests require HTTPS, except loopback HTTP for local development.");
+    return 2;
+}
+
+using HttpMessageHandler transportHandler = useServer ? new HttpClientHandler() : new SimulatedSpecHandler();
+using var authHandler = new DemoAuthHandler(apiKey, bearerToken, transportHandler);
+using var http = new HttpClient(authHandler, disposeHandler: false)
+{
+    BaseAddress = baseAddress
+};
+
+var client = new HonuaSpecClient(http);
+var document = CreateDocument();
+
+Console.WriteLine($"Mode: {(useServer ? "server" : "simulated")}");
+Console.WriteLine($"Spec: {document.SpecId}");
+Console.WriteLine();
+
+try
+{
+    var plan = await client.PlanAsync(document);
+    PrintPlan(plan);
+
+    await using var apply = await client.ApplyAsync(document);
+    await PrintApplyAsync(apply);
+    return 0;
+}
+catch (HonuaSpecException ex)
+{
+    Console.Error.WriteLine($"Spec request failed: {(int)ex.StatusCode} {ex.Message}");
+    return 3;
+}
+
+static SpecDocumentRequest CreateDocument() => new()
+{
+    GrammarVersion = "2026.1",
+    ProcessFamilyVersion = "2026.1",
+    SpecId = "dotnet-demo-suite",
+    CacheMode = SpecCacheMode.ReadWrite,
+    MaxConcurrency = 2,
+    Nodes =
+    [
+        new SpecNodeRequest
+        {
+            Id = "source-permits",
+            Kind = SpecResourceKind.Dataset,
+            SourcePins = new Dictionary<string, string>
+            {
+                ["provider"] = "honua",
+                ["collection"] = "permits"
+            },
+            CanonicalFragment = "dataset:permits"
+        },
+        new SpecNodeRequest
+        {
+            Id = "active-permits",
+            Kind = SpecResourceKind.Compute,
+            Op = "filter",
+            Inputs = new Dictionary<string, string>
+            {
+                ["source"] = "source-permits"
+            },
+            Parameters = new Dictionary<string, string>
+            {
+                ["where"] = "status = 'active'"
+            },
+            CanonicalFragment = "filter:status-active"
+        },
+        new SpecNodeRequest
+        {
+            Id = "operator-summary",
+            Kind = SpecResourceKind.Report,
+            Op = "summarize",
+            Inputs = new Dictionary<string, string>
+            {
+                ["source"] = "active-permits"
+            },
+            Parameters = new Dictionary<string, string>
+            {
+                ["groupBy"] = "district"
+            },
+            CanonicalFragment = "summarize:district"
+        }
+    ]
+};
+
+static void PrintPlan(SpecPlanResponse plan)
+{
+    Console.WriteLine($"Plan: {plan.PlanId}");
+    foreach (var node in plan.Nodes)
+    {
+        var dependencies = node.DependsOn.Count == 0 ? "(none)" : string.Join(", ", node.DependsOn);
+        Console.WriteLine($"  {node.NodeId} [{node.Kind}] deps={dependencies} hash={node.ContentHash}");
+    }
+
+    if (plan.Warnings.Count > 0)
+    {
+        Console.WriteLine("Warnings:");
+        foreach (var warning in plan.Warnings)
+        {
+            Console.WriteLine($"  {warning.Code}: {warning.Message}");
+        }
+    }
+
+    Console.WriteLine();
+}
+
+static async Task PrintApplyAsync(SpecApplyStream apply)
+{
+    Console.WriteLine($"Apply: {apply.ApplyToken ?? "(server did not return a token header)"}");
+    SpecApplySummary? summary = null;
+
+    await foreach (var evt in apply.Events)
+    {
+        var node = string.IsNullOrWhiteSpace(evt.NodeId) ? string.Empty : $" {evt.NodeId}";
+        Console.WriteLine($"  #{evt.Sequence} {evt.Kind}{node}");
+        summary = evt.Summary ?? summary;
+    }
+
+    if (summary is not null)
+    {
+        Console.WriteLine();
+        Console.WriteLine(
+            $"Summary: total={summary.TotalNodes} ran={summary.RanNodes} cached={summary.CachedNodes} failed={summary.FailedNodes}");
+    }
+}
+
+static bool HasCredentials(string? apiKey, string? bearerToken) =>
+    !string.IsNullOrWhiteSpace(apiKey) || !string.IsNullOrWhiteSpace(bearerToken);
+
+static bool RequiresHttpsForAuthentication(Uri uri)
+{
+    if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+    {
+        return false;
+    }
+
+    return !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+        (!uri.IsLoopback && !string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
+}
+
+internal sealed class DemoAuthHandler : DelegatingHandler
+{
+    private readonly string? _apiKey;
+    private readonly string? _bearerToken;
+
+    public DemoAuthHandler(string? apiKey, string? bearerToken, HttpMessageHandler innerHandler)
+        : base(innerHandler)
+    {
+        _apiKey = apiKey;
+        _bearerToken = bearerToken;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+        {
+            request.Headers.TryAddWithoutValidation("X-API-Key", _apiKey);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_bearerToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _bearerToken);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}
+
+internal sealed class SimulatedSpecHandler : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var path = request.RequestUri?.AbsolutePath;
+        return Task.FromResult(path switch
+        {
+            "/v1/spec/plan" => JsonResponse(PlanJson()),
+            "/v1/spec/apply" => SseResponse(ApplyEvents()),
+            _ => JsonResponse(
+                """
+                {"type":"about:blank","title":"Not found","status":404,"detail":"Simulated endpoint not found.","code":"not_found"}
+                """,
+                HttpStatusCode.NotFound)
+        });
+    }
+
+    private static HttpResponseMessage JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK) => new(statusCode)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+    };
+
+    private static HttpResponseMessage SseResponse(string events)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(events, Encoding.UTF8, "text/event-stream")
+        };
+        response.Headers.TryAddWithoutValidation("X-Spec-Apply-Token", "apply-dotnet-demo-suite");
+        return response;
+    }
+
+    private static string PlanJson() =>
+        """
+        {
+          "planId": "plan-dotnet-demo-suite",
+          "grammarVersion": "2026.1",
+          "processFamilyVersion": "2026.1",
+          "nodes": [
+            {
+              "nodeId": "source-permits",
+              "kind": "Dataset",
+              "dependsOn": [],
+              "contentHash": "sha256:source-permits",
+              "cost": { "estimatedRows": 1200, "estimatedBytes": 256000, "estimatedDurationMs": 0 }
+            },
+            {
+              "nodeId": "active-permits",
+              "kind": "Compute",
+              "op": "filter",
+              "dependsOn": [ "source-permits" ],
+              "contentHash": "sha256:active-permits",
+              "cost": { "estimatedRows": 420, "estimatedBytes": 86000, "estimatedDurationMs": 125 }
+            },
+            {
+              "nodeId": "operator-summary",
+              "kind": "Report",
+              "op": "summarize",
+              "dependsOn": [ "active-permits" ],
+              "contentHash": "sha256:operator-summary",
+              "cost": { "estimatedRows": 12, "estimatedBytes": 4096, "estimatedDurationMs": 75 }
+            }
+          ],
+          "warnings": []
+        }
+        """;
+
+    private static string ApplyEvents() =>
+        """
+        data: {"sequence":1,"kind":"ApplyStarted","applyToken":"apply-dotnet-demo-suite","timestamp":"2026-05-03T12:00:00Z"}
+
+        data: {"sequence":2,"kind":"Cached","applyToken":"apply-dotnet-demo-suite","nodeId":"source-permits","contentHash":"sha256:source-permits","timestamp":"2026-05-03T12:00:01Z"}
+
+        data: {"sequence":3,"kind":"Running","applyToken":"apply-dotnet-demo-suite","nodeId":"active-permits","timestamp":"2026-05-03T12:00:02Z"}
+
+        data: {"sequence":4,"kind":"Succeeded","applyToken":"apply-dotnet-demo-suite","nodeId":"active-permits","contentHash":"sha256:active-permits","timestamp":"2026-05-03T12:00:03Z","actualCost":{"rows":420,"bytes":86000,"durationMs":118}}
+
+        data: {"sequence":5,"kind":"ApplyCompleted","applyToken":"apply-dotnet-demo-suite","timestamp":"2026-05-03T12:00:04Z","summary":{"totalNodes":3,"cachedNodes":1,"ranNodes":1,"failedNodes":0,"skippedNodes":0,"totalDurationMs":150,"cancelled":false}}
+
+        """;
+}

--- a/examples/SpecPlanApplyConsole/README.md
+++ b/examples/SpecPlanApplyConsole/README.md
@@ -1,0 +1,59 @@
+# Spec Plan/Apply Console
+
+Runnable scaffold for the .NET Spec workflow. The sample builds a typed
+`SpecDocumentRequest`, calls `PlanAsync`, then consumes apply events from
+`ApplyAsync`.
+
+By default it uses a deterministic in-process HTTP handler that returns a plan
+and SSE apply stream. This keeps the demo runnable before every Honua Server
+environment exposes the Spec apply endpoints.
+
+## Run With Simulated Spec API
+
+```bash
+dotnet run --project examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj
+```
+
+## Run Against Honua Server
+
+```bash
+export HONUA_SPEC_MODE=server
+export HONUA_SPEC_SERVER_URL=https://localhost:5001
+export HONUA_SPEC_API_KEY=
+export HONUA_SPEC_BEARER_TOKEN=
+
+dotnet run --project examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj
+```
+
+Credentials are optional for local unauthenticated targets. If `HONUA_SPEC_API_KEY`
+or `HONUA_SPEC_BEARER_TOKEN` is set, use HTTPS except for loopback HTTP during
+local development.
+
+## Expected Output Shape
+
+```text
+Mode: simulated
+Spec: dotnet-demo-suite
+
+Plan: plan-dotnet-demo-suite
+  source-permits [Dataset] deps=(none) hash=sha256:source-permits
+  active-permits [Compute] deps=source-permits hash=sha256:active-permits
+  operator-summary [Report] deps=active-permits hash=sha256:operator-summary
+
+Apply: apply-dotnet-demo-suite
+  #1 ApplyStarted
+  #2 Cached source-permits
+  #3 Running active-permits
+  #4 Succeeded active-permits
+  #5 ApplyCompleted
+
+Summary: total=3 ran=1 cached=1 failed=0
+```
+
+## Validation
+
+- `dotnet build examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj`
+- `dotnet run --project examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj`
+
+Live server validation should be added when the target Honua deployment exposes
+`/v1/spec/plan` and `/v1/spec/apply` with compatible contracts.

--- a/examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj
+++ b/examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1303;CA1812;CA1849</NoWarn>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Spec\Honua.Sdk.Spec.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- adds a .NET examples index and demo-suite rollout doc
- adds a runnable `SpecPlanApplyConsole` scaffold using `Honua.Sdk.Spec`
- keeps the Spec demo deterministic by default with a simulated plan/apply SSE flow
- documents realtime, routing/geofence, and mobile offline boundaries

## User Impact

.NET developers get a language-fit demo suite starting point for operator/spec workflows without implying that native mobile GeoPackage runtime belongs in the .NET SDK repo.

Refs honua-sdk-dotnet#128
Refs honua-sdk-js#55

## Validation

- `dotnet build examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj`
- `dotnet run --project examples/SpecPlanApplyConsole/SpecPlanApplyConsole.csproj`
- `dotnet test tests/Honua.Sdk.Spec.Tests/Honua.Sdk.Spec.Tests.csproj`
- `dotnet build examples/AdminBootstrapConsole/AdminBootstrapConsole.csproj`
- `git diff --check`

## Notes

Realtime worker and live routing remain gated on server/GeoServices availability; docs describe deterministic fallback paths.
