### PR TITLE
[codex] add vector payload readers

### DIFF
--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorClientExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorClientExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.Geometry.Vector;
+
+namespace Honua.Sdk.GeoServices.FeatureServer;
+
+/// <summary>
+/// Typed vector payload helpers for FeatureServer clients.
+/// </summary>
+public static class FeatureServerVectorClientExtensions
+{
+    /// <summary>
+    /// Executes a feature query and parses supported vector payload formats into typed features
+    /// with NetTopologySuite geometries.
+    /// </summary>
+    /// <param name="client">FeatureServer client.</param>
+    /// <param name="serviceId">The service identifier.</param>
+    /// <param name="layerId">The layer ID within the service.</param>
+    /// <param name="query">Query parameters including filters, paging, and projection.</param>
+    /// <param name="format">Optional shared vector format. Defaults to the format specified by <paramref name="query"/>, or Esri JSON.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The parsed typed vector payload.</returns>
+    public static async Task<VectorPayloadFeatureSet> QueryVectorAsync(
+        this IHonuaFeatureServerClient client,
+        string serviceId,
+        int layerId,
+        FeatureServerQueryParams query,
+        VectorPayloadFormat? format = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (client is HonuaFeatureServerClient honuaClient)
+        {
+            return await honuaClient.QueryVectorAsync(serviceId, layerId, query, format, ct).ConfigureAwait(false);
+        }
+
+        var vectorFormat = format ?? FeatureServerVectorFormats.FromFeatureServerFormat(query.Format);
+        var protocolFormat = FeatureServerVectorFormats.ToFeatureServerFormat(vectorFormat);
+        using var response = await client.QueryRawAsync(
+            serviceId,
+            layerId,
+            query with { Format = protocolFormat },
+            ct).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, ct: ct).ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorFormats.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorFormats.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.Geometry.Vector;
+
+namespace Honua.Sdk.GeoServices.FeatureServer;
+
+/// <summary>
+/// Maps shared vector payload formats to GeoServices FeatureServer query formats.
+/// </summary>
+public static class FeatureServerVectorFormats
+{
+    /// <summary>Vector payload formats supported by FeatureServer typed vector queries.</summary>
+    public static IReadOnlyList<VectorPayloadFormat> SupportedFormats { get; } =
+        [VectorPayloadFormat.EsriJson, VectorPayloadFormat.GeoJson];
+
+    /// <summary>
+    /// Converts a shared vector format to the FeatureServer query format value.
+    /// </summary>
+    /// <param name="format">Shared vector payload format.</param>
+    /// <returns>The FeatureServer format value.</returns>
+    public static FeatureServerFormat ToFeatureServerFormat(VectorPayloadFormat format) => format switch
+    {
+        VectorPayloadFormat.EsriJson => FeatureServerFormat.Json,
+        VectorPayloadFormat.GeoJson => FeatureServerFormat.GeoJson,
+        VectorPayloadFormat.Gml => throw new NotSupportedException("FeatureServer does not expose GML query output."),
+        _ => throw new NotSupportedException($"Vector payload format '{format}' is not supported by FeatureServer.")
+    };
+
+    /// <summary>
+    /// Resolves a FeatureServer query format to the shared vector payload reader format.
+    /// </summary>
+    /// <param name="format">FeatureServer query format.</param>
+    /// <returns>The shared vector payload format.</returns>
+    public static VectorPayloadFormat FromFeatureServerFormat(FeatureServerFormat? format) => format switch
+    {
+        null or FeatureServerFormat.Json => VectorPayloadFormat.EsriJson,
+        FeatureServerFormat.GeoJson => VectorPayloadFormat.GeoJson,
+        FeatureServerFormat.Pbf => throw new NotSupportedException("PBF vector payload parsing is not implemented by this SDK."),
+        FeatureServerFormat.FlatGeobuf => throw new NotSupportedException("FlatGeobuf vector payload parsing is not implemented by this SDK."),
+        FeatureServerFormat.Parquet => throw new NotSupportedException("Parquet vector payload parsing is not implemented by this SDK."),
+        _ => throw new NotSupportedException($"FeatureServer format '{format}' is not supported by typed vector queries.")
+    };
+}

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -6,11 +6,13 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices;
 using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.Geometry.Vector;
 
 namespace Honua.Sdk.GeoServices.FeatureServer;
 
@@ -492,6 +494,29 @@ public sealed class HonuaFeatureServerClient :
         var body = await PostFormAsync(basePath, parameters, ct).ConfigureAwait(false);
         return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerValidateSqlResponse)
             ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize validateSQL response.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task<VectorPayloadFeatureSet> QueryVectorAsync(
+        string serviceId,
+        int layerId,
+        FeatureServerQueryParams query,
+        VectorPayloadFormat? format = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(serviceId);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var vectorFormat = format ?? FeatureServerVectorFormats.FromFeatureServerFormat(query.Format);
+        var protocolFormat = FeatureServerVectorFormats.ToFeatureServerFormat(vectorFormat);
+        var body = await ExecuteQueryAsync(
+            serviceId,
+            layerId,
+            BuildQueryParams(query with { Format = protocolFormat }),
+            ct).ConfigureAwait(false);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, ct: ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.GeoServices/FeatureServer/IHonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/IHonuaFeatureServerClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.GeoServices.FeatureServer.Models;
-
 namespace Honua.Sdk.GeoServices.FeatureServer;
 
 /// <summary>

--- a/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
+++ b/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Sdk.Geometry/Vector/EsriJsonVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/EsriJsonVectorPayloadReader.cs
@@ -1,0 +1,289 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Reads GeoServices/Esri JSON feature payloads into typed vector features.
+/// </summary>
+public sealed class EsriJsonVectorPayloadReader : IVectorPayloadReader
+{
+    private static readonly GeometryFactory DefaultGeometryFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory();
+
+    /// <summary>Shared stateless reader instance.</summary>
+    public static EsriJsonVectorPayloadReader Instance { get; } = new();
+
+    /// <inheritdoc />
+    public VectorPayloadFormat Format => VectorPayloadFormat.EsriJson;
+
+    /// <inheritdoc />
+    public async Task<VectorPayloadFeatureSet> ReadAsync(
+        Stream stream,
+        VectorPayloadReadOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        return Read(document.RootElement, options);
+    }
+
+    /// <summary>
+    /// Reads a GeoServices/Esri JSON payload from a JSON element.
+    /// </summary>
+    /// <param name="root">Payload root element.</param>
+    /// <param name="options">Optional reader settings.</param>
+    /// <returns>The typed feature collection.</returns>
+    public VectorPayloadFeatureSet Read(JsonElement root, VectorPayloadReadOptions? options = null)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("Esri JSON vector payload must be a JSON object.");
+        }
+
+        var spatialReference = root.TryGetProperty("spatialReference", out var srElement)
+            ? ReadSpatialReferenceIdentifier(srElement)
+            : null;
+        var rootFactory = CreateGeometryFactory(spatialReference, options?.GeometryFactory);
+        var objectIdFieldName = TryGetString(root, "objectIdFieldName");
+        var features = ReadFeatures(root, objectIdFieldName, rootFactory).ToList();
+
+        return new VectorPayloadFeatureSet
+        {
+            Format = Format,
+            Features = features,
+            NumberMatched = TryGetInt64(root, "count"),
+            NumberReturned = features.Count,
+            HasMoreResults = TryGetBoolean(root, "exceededTransferLimit"),
+            ObjectIdFieldName = objectIdFieldName,
+            ObjectIds = ReadObjectIds(root),
+            Extent = ReadExtent(root, rootFactory),
+            Crs = spatialReference
+        };
+    }
+
+    private static IEnumerable<VectorPayloadFeature> ReadFeatures(
+        JsonElement root,
+        string? objectIdFieldName,
+        GeometryFactory rootFactory)
+    {
+        if (!root.TryGetProperty("features", out var featuresElement) ||
+            featuresElement.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var featureElement in featuresElement.EnumerateArray())
+        {
+            if (featureElement.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var attributes = featureElement.TryGetProperty("attributes", out var attributesElement)
+                ? ReadAttributes(attributesElement)
+                : new Dictionary<string, JsonElement>();
+            var id = TryResolveId(attributes, objectIdFieldName);
+            var geometryJson = featureElement.TryGetProperty("geometry", out var geometryElement) &&
+                geometryElement.ValueKind is JsonValueKind.Object
+                    ? geometryElement.Clone()
+                    : (JsonElement?)null;
+            var geometry = geometryJson.HasValue
+                ? ReadGeometry(geometryJson.Value, rootFactory)
+                : null;
+
+            yield return new VectorPayloadFeature
+            {
+                Id = id,
+                Attributes = attributes,
+                Geometry = geometry,
+                GeometryJson = geometryJson,
+                Crs = geometry?.SRID > 0
+                    ? string.Create(CultureInfo.InvariantCulture, $"EPSG:{geometry.SRID}")
+                    : null
+            };
+        }
+    }
+
+    private static Dictionary<string, JsonElement> ReadAttributes(JsonElement attributesElement)
+    {
+        if (attributesElement.ValueKind != JsonValueKind.Object)
+        {
+            return [];
+        }
+
+        var attributes = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var property in attributesElement.EnumerateObject())
+        {
+            attributes[property.Name] = property.Value.Clone();
+        }
+
+        return attributes;
+    }
+
+    private static NetTopologySuite.Geometries.Geometry ReadGeometry(
+        JsonElement geometryElement,
+        GeometryFactory rootFactory)
+    {
+        return geometryElement.TryGetProperty("spatialReference", out var geometrySpatialReference) &&
+            geometrySpatialReference.ValueKind == JsonValueKind.Object
+                ? GeoServicesGeometryConverter.ReadGeometry(geometryElement)
+                : GeoServicesGeometryConverter.ReadGeometry(geometryElement, rootFactory);
+    }
+
+    private static string? TryResolveId(
+        Dictionary<string, JsonElement> attributes,
+        string? objectIdFieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(objectIdFieldName) &&
+            attributes.TryGetValue(objectIdFieldName, out var idElement))
+        {
+            return JsonElementToString(idElement);
+        }
+
+        foreach (var candidate in new[] { "OBJECTID", "ObjectID", "objectid", "FID", "id" })
+        {
+            if (attributes.TryGetValue(candidate, out var candidateIdElement))
+            {
+                return JsonElementToString(candidateIdElement);
+            }
+        }
+
+        return null;
+    }
+
+    private static List<long> ReadObjectIds(JsonElement root)
+    {
+        if (!root.TryGetProperty("objectIds", out var objectIdsElement) ||
+            objectIdsElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var objectIds = new List<long>();
+        foreach (var objectIdElement in objectIdsElement.EnumerateArray())
+        {
+            if (objectIdElement.TryGetInt64(out var objectId))
+            {
+                objectIds.Add(objectId);
+            }
+        }
+
+        return objectIds;
+    }
+
+    private static Envelope? ReadExtent(JsonElement root, GeometryFactory rootFactory)
+    {
+        if (!root.TryGetProperty("extent", out var extentElement) ||
+            extentElement.ValueKind != JsonValueKind.Object ||
+            !TryGetDouble(extentElement, "xmin", out var minX) ||
+            !TryGetDouble(extentElement, "ymin", out var minY) ||
+            !TryGetDouble(extentElement, "xmax", out var maxX) ||
+            !TryGetDouble(extentElement, "ymax", out var maxY))
+        {
+            return null;
+        }
+
+        var envelope = new Envelope(minX, maxX, minY, maxY);
+        return rootFactory.SRID > 0
+            ? envelope.Copy()
+            : envelope;
+    }
+
+    private static GeometryFactory CreateGeometryFactory(string? spatialReference, GeometryFactory? fallback)
+    {
+        if (TryReadSrid(spatialReference, out var srid))
+        {
+            return (fallback ?? DefaultGeometryFactory).WithSRID(srid);
+        }
+
+        return fallback ?? DefaultGeometryFactory;
+    }
+
+    private static string? ReadSpatialReferenceIdentifier(JsonElement spatialReference)
+    {
+        if (spatialReference.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (TryGetInt32(spatialReference, "latestWkid", out var latestWkid) && latestWkid > 0)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"EPSG:{latestWkid}");
+        }
+
+        if (TryGetInt32(spatialReference, "wkid", out var wkid) && wkid > 0)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"EPSG:{wkid}");
+        }
+
+        return TryGetString(spatialReference, "wkt");
+    }
+
+    private static bool TryReadSrid(string? spatialReference, out int srid)
+    {
+        srid = 0;
+        if (string.IsNullOrWhiteSpace(spatialReference))
+        {
+            return false;
+        }
+
+        var trimmed = spatialReference.Trim();
+        var separator = trimmed.LastIndexOf(':');
+        var code = separator >= 0 ? trimmed[(separator + 1)..] : trimmed;
+        return int.TryParse(code, NumberStyles.Integer, CultureInfo.InvariantCulture, out srid) && srid > 0;
+    }
+
+    private static string? JsonElementToString(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+
+    private static string? TryGetString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static bool TryGetBoolean(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.True;
+
+    private static long? TryGetInt64(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.TryGetInt64(out var value)
+            ? value
+            : null;
+
+    private static bool TryGetInt32(JsonElement element, string name, out int value)
+    {
+        if (element.TryGetProperty(name, out var property) && property.TryGetInt32(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static bool TryGetDouble(JsonElement element, string name, out double value)
+    {
+        if (element.TryGetProperty(name, out var property) && property.TryGetDouble(out value))
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+}

--- a/src/Honua.Sdk.Geometry/Vector/GeoJsonVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/GeoJsonVectorPayloadReader.cs
@@ -1,0 +1,217 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Reads GeoJSON feature payloads into typed vector features.
+/// </summary>
+public sealed class GeoJsonVectorPayloadReader : IVectorPayloadReader
+{
+    /// <summary>Shared stateless reader instance.</summary>
+    public static GeoJsonVectorPayloadReader Instance { get; } = new();
+
+    /// <inheritdoc />
+    public VectorPayloadFormat Format => VectorPayloadFormat.GeoJson;
+
+    /// <inheritdoc />
+    public async Task<VectorPayloadFeatureSet> ReadAsync(
+        Stream stream,
+        VectorPayloadReadOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        using var document = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+        return Read(document.RootElement, options);
+    }
+
+    /// <summary>
+    /// Reads a GeoJSON payload from a JSON element.
+    /// </summary>
+    /// <param name="root">Payload root element.</param>
+    /// <param name="options">Optional reader settings.</param>
+    /// <returns>The typed feature collection.</returns>
+    public VectorPayloadFeatureSet Read(JsonElement root, VectorPayloadReadOptions? options = null)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("GeoJSON vector payload must be a JSON object.");
+        }
+
+        var type = TryGetString(root, "type");
+        if (string.Equals(type, "Feature", StringComparison.OrdinalIgnoreCase))
+        {
+            var feature = ReadFeature(root, options);
+            return new VectorPayloadFeatureSet
+            {
+                Format = Format,
+                Features = [feature],
+                NumberReturned = 1,
+                Crs = ReadCrs(root)
+            };
+        }
+
+        if (!string.Equals(type, "FeatureCollection", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new JsonException("GeoJSON vector payload must be a Feature or FeatureCollection.");
+        }
+
+        var features = root.TryGetProperty("features", out var featuresElement) &&
+            featuresElement.ValueKind == JsonValueKind.Array
+                ? featuresElement.EnumerateArray()
+                    .Where(featureElement => featureElement.ValueKind == JsonValueKind.Object)
+                    .Select(featureElement => ReadFeature(featureElement, options))
+                    .ToList()
+                : [];
+        var links = ReadLinks(root).ToList();
+
+        return new VectorPayloadFeatureSet
+        {
+            Format = Format,
+            Features = features,
+            NumberMatched = TryGetInt64(root, "numberMatched"),
+            NumberReturned = TryGetInt32(root, "numberReturned") ?? features.Count,
+            HasMoreResults = links.Any(link => string.Equals(link.Rel, "next", StringComparison.OrdinalIgnoreCase)),
+            Extent = ReadBbox(root),
+            Crs = ReadCrs(root),
+            Links = links
+        };
+    }
+
+    private static VectorPayloadFeature ReadFeature(JsonElement featureElement, VectorPayloadReadOptions? options)
+    {
+        var geometryJson = featureElement.TryGetProperty("geometry", out var geometryElement) &&
+            geometryElement.ValueKind is JsonValueKind.Object
+                ? geometryElement.Clone()
+                : (JsonElement?)null;
+        var geometry = geometryJson.HasValue
+            ? GeoJsonGeometryConverter.ReadGeometry(geometryJson.Value, options?.GeometryFactory)
+            : null;
+
+        return new VectorPayloadFeature
+        {
+            Id = featureElement.TryGetProperty("id", out var idElement) ? JsonElementToString(idElement) : null,
+            Attributes = featureElement.TryGetProperty("properties", out var propertiesElement)
+                ? ReadProperties(propertiesElement)
+                : new Dictionary<string, JsonElement>(),
+            Geometry = geometry,
+            GeometryJson = geometryJson
+        };
+    }
+
+    private static Dictionary<string, JsonElement> ReadProperties(JsonElement propertiesElement)
+    {
+        if (propertiesElement.ValueKind != JsonValueKind.Object)
+        {
+            return [];
+        }
+
+        var properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var property in propertiesElement.EnumerateObject())
+        {
+            properties[property.Name] = property.Value.Clone();
+        }
+
+        return properties;
+    }
+
+    private static IEnumerable<VectorPayloadLink> ReadLinks(JsonElement root)
+    {
+        if (!root.TryGetProperty("links", out var linksElement) ||
+            linksElement.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var linkElement in linksElement.EnumerateArray())
+        {
+            if (linkElement.ValueKind != JsonValueKind.Object ||
+                !linkElement.TryGetProperty("href", out var hrefElement) ||
+                hrefElement.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(hrefElement.GetString()))
+            {
+                continue;
+            }
+
+            yield return new VectorPayloadLink
+            {
+                Href = hrefElement.GetString()!,
+                Rel = TryGetString(linkElement, "rel"),
+                Type = TryGetString(linkElement, "type"),
+                Title = TryGetString(linkElement, "title")
+            };
+        }
+    }
+
+    private static Envelope? ReadBbox(JsonElement root)
+    {
+        if (!root.TryGetProperty("bbox", out var bboxElement) ||
+            bboxElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var coordinates = bboxElement.EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.Number)
+            .Select(item => item.GetDouble())
+            .Take(4)
+            .ToArray();
+        return coordinates.Length >= 4
+            ? new Envelope(coordinates[0], coordinates[2], coordinates[1], coordinates[3])
+            : null;
+    }
+
+    private static string? ReadCrs(JsonElement root)
+    {
+        if (!root.TryGetProperty("crs", out var crsElement) ||
+            crsElement.ValueKind != JsonValueKind.Object ||
+            !crsElement.TryGetProperty("properties", out var propertiesElement) ||
+            propertiesElement.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        return TryGetString(propertiesElement, "name");
+    }
+
+    private static long? TryGetInt64(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var property))
+        {
+            return null;
+        }
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.Number when property.TryGetInt64(out var value) => value,
+            JsonValueKind.String when long.TryParse(property.GetString(), out var value) => value,
+            _ => null
+        };
+    }
+
+    private static int? TryGetInt32(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.TryGetInt32(out var value)
+            ? value
+            : null;
+
+    private static string? TryGetString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+
+    private static string? JsonElementToString(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+}

--- a/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
@@ -1,0 +1,371 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Xml;
+using System.Xml.Linq;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.GML2;
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Reads GML feature payloads into typed vector features.
+/// </summary>
+public sealed class GmlVectorPayloadReader : IVectorPayloadReader
+{
+    private static readonly XNamespace Wfs20 = "http://www.opengis.net/wfs/2.0";
+    private static readonly XNamespace Wfs11 = "http://www.opengis.net/wfs";
+    private static readonly XNamespace Gml32 = "http://www.opengis.net/gml/3.2";
+    private static readonly XNamespace Gml = "http://www.opengis.net/gml";
+    private static readonly XNamespace Xml = "http://www.w3.org/XML/1998/namespace";
+    private static readonly GeometryFactory DefaultGeometryFactory =
+        NtsGeometryServices.Instance.CreateGeometryFactory();
+
+    /// <summary>Shared stateless reader instance.</summary>
+    public static GmlVectorPayloadReader Instance { get; } = new();
+
+    /// <inheritdoc />
+    public VectorPayloadFormat Format => VectorPayloadFormat.Gml;
+
+    /// <inheritdoc />
+    public async Task<VectorPayloadFeatureSet> ReadAsync(
+        Stream stream,
+        VectorPayloadReadOptions? options = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var settings = new XmlReaderSettings
+        {
+            Async = true,
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null
+        };
+
+        using var reader = XmlReader.Create(stream, settings);
+        var document = await XDocument.LoadAsync(reader, LoadOptions.None, ct).ConfigureAwait(false);
+        return Read(document, options);
+    }
+
+    /// <summary>
+    /// Reads a GML payload from an XML document.
+    /// </summary>
+    /// <param name="document">GML or WFS XML document.</param>
+    /// <param name="options">Optional reader settings.</param>
+    /// <returns>The typed feature collection.</returns>
+    public VectorPayloadFeatureSet Read(XDocument document, VectorPayloadReadOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var root = document.Root ?? throw new XmlException("GML vector payload has no root element.");
+        var features = ReadFeatureElements(root, options).ToList();
+        var numberReturned = TryReadInt(root.Attribute("numberReturned")?.Value) ?? features.Count;
+        var numberMatched = ReadNumberMatched(root.Attribute("numberMatched")?.Value);
+
+        return new VectorPayloadFeatureSet
+        {
+            Format = Format,
+            Features = features,
+            NumberMatched = numberMatched,
+            NumberReturned = numberReturned,
+            HasMoreResults = numberMatched.HasValue && numberReturned < numberMatched.Value,
+            Extent = ReadEnvelope(root, options?.GeometryFactory),
+            Crs = ReadFirstSrsName(root)
+        };
+    }
+
+    private static IEnumerable<VectorPayloadFeature> ReadFeatureElements(
+        XElement root,
+        VectorPayloadReadOptions? options)
+    {
+        var members = GetMemberElements(root).ToList();
+        if (members.Count == 0)
+        {
+            if (IsGeometryElement(root))
+            {
+                yield return ReadGeometryOnlyFeature(root, options);
+            }
+
+            yield break;
+        }
+
+        foreach (var member in members)
+        {
+            var featureElement = GetFeatureElement(member);
+            if (featureElement is null)
+            {
+                continue;
+            }
+
+            yield return ReadFeature(featureElement, options);
+        }
+    }
+
+    private static IEnumerable<XElement> GetMemberElements(XElement root)
+    {
+        var directMembers = root.Elements().Where(IsMemberElement).SelectMany(ExpandMemberElement).ToList();
+        if (directMembers.Count > 0)
+        {
+            return directMembers;
+        }
+
+        if (IsMemberElement(root))
+        {
+            return ExpandMemberElement(root);
+        }
+
+        return root.Descendants().Where(IsMemberElement).SelectMany(ExpandMemberElement);
+    }
+
+    private static IEnumerable<XElement> ExpandMemberElement(XElement member)
+    {
+        if (string.Equals(member.Name.LocalName, "featureMembers", StringComparison.Ordinal))
+        {
+            return member.Elements().Where(element => !IsFrameworkElement(element));
+        }
+
+        return [member];
+    }
+
+    private static XElement? GetFeatureElement(XElement member)
+    {
+        if (!IsMemberElement(member))
+        {
+            return member;
+        }
+
+        return member.Elements().FirstOrDefault(element => !IsFrameworkElement(element));
+    }
+
+    private static VectorPayloadFeature ReadGeometryOnlyFeature(XElement geometryElement, VectorPayloadReadOptions? options)
+    {
+        var geometry = ReadGeometry(geometryElement, options?.GeometryFactory);
+        var crs = ReadSrsName(geometryElement);
+        ApplySrid(geometry, crs);
+        return new VectorPayloadFeature
+        {
+            Geometry = geometry,
+            NativeTypeName = geometryElement.Name.LocalName,
+            Crs = crs
+        };
+    }
+
+    private static VectorPayloadFeature ReadFeature(XElement featureElement, VectorPayloadReadOptions? options)
+    {
+        NetTopologySuite.Geometries.Geometry? geometry = null;
+        string? crs = null;
+        var attributes = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+        foreach (var propertyElement in featureElement.Elements())
+        {
+            if (IsFrameworkElement(propertyElement))
+            {
+                continue;
+            }
+
+            var geometryElement = IsGeometryElement(propertyElement)
+                ? propertyElement
+                : propertyElement.Descendants().FirstOrDefault(IsGeometryElement);
+
+            if (geometryElement is not null && geometry is null)
+            {
+                geometry = ReadGeometry(geometryElement, options?.GeometryFactory);
+                crs = ReadSrsName(geometryElement);
+                ApplySrid(geometry, crs);
+                continue;
+            }
+
+            if (!propertyElement.HasElements)
+            {
+                attributes[propertyElement.Name.LocalName] = CreateJsonElement(propertyElement.Value);
+            }
+        }
+
+        return new VectorPayloadFeature
+        {
+            Id = ReadFeatureId(featureElement),
+            Attributes = attributes,
+            Geometry = geometry,
+            NativeTypeName = featureElement.Name.LocalName,
+            Crs = crs
+        };
+    }
+
+    private static NetTopologySuite.Geometries.Geometry ReadGeometry(
+        XElement geometryElement,
+        GeometryFactory? geometryFactory)
+    {
+        var reader = new GMLReader(geometryFactory ?? DefaultGeometryFactory);
+        return reader.Read(new XDocument(new XElement(geometryElement)));
+    }
+
+    private static Envelope? ReadEnvelope(XElement root, GeometryFactory? geometryFactory)
+    {
+        var envelopeElement = root.Descendants()
+            .FirstOrDefault(element => IsGeometryNamespace(element.Name.Namespace) &&
+                string.Equals(element.Name.LocalName, "Envelope", StringComparison.Ordinal));
+        if (envelopeElement is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var geometry = ReadGeometry(envelopeElement, geometryFactory);
+            return geometry.EnvelopeInternal;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ReadFeatureId(XElement featureElement)
+    {
+        var gmlId = featureElement.Attribute(Gml32 + "id") ??
+            featureElement.Attribute(Gml + "id") ??
+            featureElement.Attribute("id") ??
+            featureElement.Attribute(Xml + "id");
+        return gmlId?.Value;
+    }
+
+    private static string? ReadFirstSrsName(XElement root)
+        => root.DescendantsAndSelf()
+            .Select(ReadSrsName)
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+    private static string? ReadSrsName(XElement element)
+        => element.Attribute("srsName")?.Value;
+
+    private static void ApplySrid(NetTopologySuite.Geometries.Geometry geometry, string? crs)
+    {
+        if (TryReadSrid(crs, out var srid))
+        {
+            geometry.SRID = srid;
+        }
+    }
+
+    private static bool TryReadSrid(string? crs, out int srid)
+    {
+        srid = 0;
+        if (string.IsNullOrWhiteSpace(crs))
+        {
+            return false;
+        }
+
+        var trimmed = crs.Trim();
+        var separators = new[] { '/', ':' };
+        var index = trimmed.LastIndexOfAny(separators);
+        var code = index >= 0 ? trimmed[(index + 1)..] : trimmed;
+        return int.TryParse(code, NumberStyles.Integer, CultureInfo.InvariantCulture, out srid) && srid > 0;
+    }
+
+    private static bool IsMemberElement(XElement element)
+    {
+        return (IsWfsNamespace(element.Name.Namespace) || IsGeometryNamespace(element.Name.Namespace)) &&
+            (string.Equals(element.Name.LocalName, "member", StringComparison.Ordinal) ||
+             string.Equals(element.Name.LocalName, "featureMember", StringComparison.Ordinal) ||
+             string.Equals(element.Name.LocalName, "featureMembers", StringComparison.Ordinal));
+    }
+
+    private static bool IsFrameworkElement(XElement element)
+    {
+        return IsWfsNamespace(element.Name.Namespace) ||
+            IsGeometryNamespace(element.Name.Namespace) ||
+            string.Equals(element.Name.LocalName, "boundedBy", StringComparison.Ordinal);
+    }
+
+    private static bool IsGeometryElement(XElement element)
+    {
+        if (!IsGeometryNamespace(element.Name.Namespace))
+        {
+            return false;
+        }
+
+        return element.Name.LocalName switch
+        {
+            "Point" or
+            "LineString" or
+            "LinearRing" or
+            "Polygon" or
+            "MultiPoint" or
+            "MultiLineString" or
+            "MultiCurve" or
+            "MultiPolygon" or
+            "MultiSurface" or
+            "GeometryCollection" or
+            "Envelope" => true,
+            _ => false
+        };
+    }
+
+    private static bool IsWfsNamespace(XNamespace ns)
+        => ns == Wfs20 || ns == Wfs11;
+
+    private static bool IsGeometryNamespace(XNamespace ns)
+        => ns == Gml32 || ns == Gml;
+
+    private static long? ReadNumberMatched(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) ||
+            string.Equals(value, "unknown", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static int? TryReadInt(string? value)
+    {
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static JsonElement CreateJsonElement(string value)
+    {
+        if (bool.TryParse(value, out var boolean))
+        {
+            return boolean ? JsonElementFromLiteral("true") : JsonElementFromLiteral("false");
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        {
+            return JsonElementFromLiteral(value);
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _) &&
+            value.Any(char.IsDigit))
+        {
+            return JsonElementFromLiteral(value);
+        }
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStringValue(value);
+        }
+
+        return JsonElementFromBytes(stream.ToArray());
+    }
+
+    private static JsonElement JsonElementFromLiteral(string literal)
+        => JsonElementFromBytes(Encoding.UTF8.GetBytes(literal));
+
+    private static JsonElement JsonElementFromBytes(byte[] bytes)
+    {
+        using var document = JsonDocument.Parse(bytes);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/Honua.Sdk.Geometry/Vector/IVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/IVectorPayloadReader.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Reads a vector payload into typed feature records and NetTopologySuite geometries.
+/// </summary>
+public interface IVectorPayloadReader
+{
+    /// <summary>The vector format handled by this reader.</summary>
+    VectorPayloadFormat Format { get; }
+
+    /// <summary>
+    /// Reads a vector payload stream.
+    /// </summary>
+    /// <param name="stream">Payload stream.</param>
+    /// <param name="options">Optional reader settings.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The typed feature collection.</returns>
+    Task<VectorPayloadFeatureSet> ReadAsync(
+        Stream stream,
+        VectorPayloadReadOptions? options = null,
+        CancellationToken ct = default);
+}

--- a/src/Honua.Sdk.Geometry/Vector/VectorPayloadFormat.cs
+++ b/src/Honua.Sdk.Geometry/Vector/VectorPayloadFormat.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Vector payload formats understood by the shared payload readers.
+/// </summary>
+public enum VectorPayloadFormat
+{
+    /// <summary>No vector payload format has been specified.</summary>
+    Unspecified = 0,
+
+    /// <summary>GeoServices/Esri JSON feature payloads.</summary>
+    EsriJson = 1,
+
+    /// <summary>GeoJSON Feature or FeatureCollection payloads.</summary>
+    GeoJson = 2,
+
+    /// <summary>GML feature or feature collection payloads.</summary>
+    Gml = 3
+}

--- a/src/Honua.Sdk.Geometry/Vector/VectorPayloadModels.cs
+++ b/src/Honua.Sdk.Geometry/Vector/VectorPayloadModels.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using NetTopologySuite.Geometries;
+using NtsGeometry = NetTopologySuite.Geometries.Geometry;
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// A link advertised by a vector payload, normally copied from GeoJSON or OGC responses.
+/// </summary>
+public sealed record VectorPayloadLink
+{
+    /// <summary>The link target.</summary>
+    public required string Href { get; init; }
+
+    /// <summary>The link relation type.</summary>
+    public string? Rel { get; init; }
+
+    /// <summary>The linked representation media type.</summary>
+    public string? Type { get; init; }
+
+    /// <summary>A human-readable link title.</summary>
+    public string? Title { get; init; }
+}
+
+/// <summary>
+/// A typed vector feature parsed from a protocol payload.
+/// </summary>
+public sealed record VectorPayloadFeature
+{
+    /// <summary>Provider feature identifier, when present.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Feature attributes or properties as JSON values.</summary>
+    public IReadOnlyDictionary<string, JsonElement> Attributes { get; init; } =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>Feature geometry parsed into NetTopologySuite, when present and supported.</summary>
+    public NtsGeometry? Geometry { get; init; }
+
+    /// <summary>Raw geometry JSON for JSON-backed formats, when present.</summary>
+    public JsonElement? GeometryJson { get; init; }
+
+    /// <summary>Native feature type name for XML/GML payloads, when available.</summary>
+    public string? NativeTypeName { get; init; }
+
+    /// <summary>Native CRS identifier read from the feature geometry, when available.</summary>
+    public string? Crs { get; init; }
+}
+
+/// <summary>
+/// A typed vector feature collection parsed from a protocol payload.
+/// </summary>
+public sealed record VectorPayloadFeatureSet
+{
+    /// <summary>The payload format used to parse the response.</summary>
+    public required VectorPayloadFormat Format { get; init; }
+
+    /// <summary>Features returned in this payload.</summary>
+    public IReadOnlyList<VectorPayloadFeature> Features { get; init; } = [];
+
+    /// <summary>Total matching features when the provider reports it.</summary>
+    public long? NumberMatched { get; init; }
+
+    /// <summary>Number of features returned by this payload.</summary>
+    public int NumberReturned { get; init; }
+
+    /// <summary>Whether the provider indicates more results may be available.</summary>
+    public bool HasMoreResults { get; init; }
+
+    /// <summary>FeatureServer object ID field name, when present.</summary>
+    public string? ObjectIdFieldName { get; init; }
+
+    /// <summary>Matching object IDs for ID-only responses, when present.</summary>
+    public IReadOnlyList<long> ObjectIds { get; init; } = [];
+
+    /// <summary>Provider-reported extent, when present.</summary>
+    public Envelope? Extent { get; init; }
+
+    /// <summary>Collection CRS identifier, when present.</summary>
+    public string? Crs { get; init; }
+
+    /// <summary>Payload links such as GeoJSON or OGC next-page links.</summary>
+    public IReadOnlyList<VectorPayloadLink> Links { get; init; } = [];
+}

--- a/src/Honua.Sdk.Geometry/Vector/VectorPayloadReadOptions.cs
+++ b/src/Honua.Sdk.Geometry/Vector/VectorPayloadReadOptions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Options used by vector payload readers.
+/// </summary>
+public sealed record VectorPayloadReadOptions
+{
+    /// <summary>Optional geometry factory used by JSON and GML readers.</summary>
+    public GeometryFactory? GeometryFactory { get; init; }
+}

--- a/src/Honua.Sdk.Geometry/Vector/VectorPayloadReaders.cs
+++ b/src/Honua.Sdk.Geometry/Vector/VectorPayloadReaders.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Geometry.Vector;
+
+/// <summary>
+/// Factory and convenience methods for shared vector payload readers.
+/// </summary>
+public static class VectorPayloadReaders
+{
+    /// <summary>
+    /// Gets a reader for a supported vector payload format.
+    /// </summary>
+    /// <param name="format">The payload format.</param>
+    /// <returns>A reader for the requested format.</returns>
+    public static IVectorPayloadReader ForFormat(VectorPayloadFormat format) => format switch
+    {
+        VectorPayloadFormat.EsriJson => EsriJsonVectorPayloadReader.Instance,
+        VectorPayloadFormat.GeoJson => GeoJsonVectorPayloadReader.Instance,
+        VectorPayloadFormat.Gml => GmlVectorPayloadReader.Instance,
+        _ => throw new NotSupportedException($"Vector payload format '{format}' is not supported.")
+    };
+
+    /// <summary>
+    /// Reads a vector payload stream with the reader selected by format.
+    /// </summary>
+    /// <param name="stream">Payload stream.</param>
+    /// <param name="format">The payload format.</param>
+    /// <param name="options">Optional reader settings.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The typed feature collection.</returns>
+    public static Task<VectorPayloadFeatureSet> ReadAsync(
+        Stream stream,
+        VectorPayloadFormat format,
+        VectorPayloadReadOptions? options = null,
+        CancellationToken ct = default)
+    {
+        return ForFormat(format).ReadAsync(stream, options, ct);
+    }
+}

--- a/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
+++ b/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Geometry.Vector;
 using Honua.Sdk.OgcFeatures.Exceptions;
 using Honua.Sdk.OgcFeatures.Models;
 
@@ -330,6 +331,25 @@ public sealed class HonuaOgcFeaturesClient :
         ArgumentNullException.ThrowIfNull(collectionId);
         var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items{BuildQueryString(query)}";
         return await _http.GetAsync(CreateRequestUri(url), ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<VectorPayloadFeatureSet> GetItemsVectorAsync(
+        string collectionId,
+        OgcItemsParams? query = null,
+        VectorPayloadFormat? format = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(collectionId);
+
+        var vectorFormat = format ?? OgcFeaturesVectorFormats.FromOgcFeaturesFormat(query?.Format);
+        var protocolFormat = OgcFeaturesVectorFormats.ToOgcFeaturesFormat(vectorFormat);
+        var vectorQuery = (query ?? new OgcItemsParams()) with { Format = protocolFormat };
+        var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items{BuildQueryString(vectorQuery)}";
+        var body = await GetStringAsync(url, ct).ConfigureAwait(false);
+
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, ct: ct).ConfigureAwait(false);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorClientExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorClientExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures;
+
+/// <summary>
+/// Typed vector payload helpers for OGC API Features clients.
+/// </summary>
+public static class OgcFeaturesVectorClientExtensions
+{
+    /// <summary>
+    /// Gets items from a collection and parses supported vector payload formats into typed features
+    /// with NetTopologySuite geometries.
+    /// </summary>
+    /// <param name="client">OGC API Features client.</param>
+    /// <param name="collectionId">The collection identifier.</param>
+    /// <param name="query">Optional query parameters for filtering, paging, and projection.</param>
+    /// <param name="format">Optional shared vector format. Defaults to the format specified by <paramref name="query"/>, or GeoJSON.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The parsed typed vector payload.</returns>
+    public static async Task<VectorPayloadFeatureSet> GetItemsVectorAsync(
+        this IHonuaOgcFeaturesClient client,
+        string collectionId,
+        OgcItemsParams? query = null,
+        VectorPayloadFormat? format = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        if (client is HonuaOgcFeaturesClient honuaClient)
+        {
+            return await honuaClient.GetItemsVectorAsync(collectionId, query, format, ct).ConfigureAwait(false);
+        }
+
+        var vectorFormat = format ?? OgcFeaturesVectorFormats.FromOgcFeaturesFormat(query?.Format);
+        var protocolFormat = OgcFeaturesVectorFormats.ToOgcFeaturesFormat(vectorFormat);
+        using var response = await client.GetItemsRawAsync(
+            collectionId,
+            (query ?? new OgcItemsParams()) with { Format = protocolFormat },
+            ct).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, ct: ct).ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorFormats.cs
+++ b/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorFormats.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures;
+
+/// <summary>
+/// Maps shared vector payload formats to OGC API Features item formats.
+/// </summary>
+public static class OgcFeaturesVectorFormats
+{
+    /// <summary>Vector payload formats supported by OGC API Features typed vector queries.</summary>
+    public static IReadOnlyList<VectorPayloadFormat> SupportedFormats { get; } =
+        [VectorPayloadFormat.GeoJson, VectorPayloadFormat.Gml];
+
+    /// <summary>
+    /// Converts a shared vector format to the OGC API Features format value.
+    /// </summary>
+    /// <param name="format">Shared vector payload format.</param>
+    /// <returns>The OGC API Features format value.</returns>
+    public static OgcFeaturesFormat ToOgcFeaturesFormat(VectorPayloadFormat format) => format switch
+    {
+        VectorPayloadFormat.GeoJson => OgcFeaturesFormat.GeoJson,
+        VectorPayloadFormat.Gml => OgcFeaturesFormat.Gml,
+        VectorPayloadFormat.EsriJson => throw new NotSupportedException("OGC API Features does not expose Esri JSON item output."),
+        _ => throw new NotSupportedException($"Vector payload format '{format}' is not supported by OGC API Features.")
+    };
+
+    /// <summary>
+    /// Resolves an OGC API Features item format to the shared vector payload reader format.
+    /// </summary>
+    /// <param name="format">OGC API Features format value.</param>
+    /// <returns>The shared vector payload format.</returns>
+    public static VectorPayloadFormat FromOgcFeaturesFormat(OgcFeaturesFormat? format) => format switch
+    {
+        null or OgcFeaturesFormat.GeoJson or OgcFeaturesFormat.Json => VectorPayloadFormat.GeoJson,
+        OgcFeaturesFormat.Gml => VectorPayloadFormat.Gml,
+        OgcFeaturesFormat.Html => throw new NotSupportedException("HTML item output is not a typed vector payload."),
+        OgcFeaturesFormat.Csv => throw new NotSupportedException("CSV vector payload parsing is not implemented by this SDK."),
+        OgcFeaturesFormat.FlatGeobuf => throw new NotSupportedException("FlatGeobuf vector payload parsing is not implemented by this SDK."),
+        OgcFeaturesFormat.Parquet => throw new NotSupportedException("Parquet vector payload parsing is not implemented by this SDK."),
+        _ => throw new NotSupportedException($"OGC API Features format '{format}' is not supported by typed vector queries.")
+    };
+}

--- a/src/Honua.Sdk.Wfs/Formats/VectorPayloadFeatureSetHandler.cs
+++ b/src/Honua.Sdk.Wfs/Formats/VectorPayloadFeatureSetHandler.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+
+namespace Honua.Sdk.Wfs.Formats;
+
+/// <summary>
+/// Deserializes WFS GetFeature responses into the shared typed vector payload model.
+/// </summary>
+public sealed class VectorPayloadFeatureSetHandler : IWfsOutputFormatHandler<VectorPayloadFeatureSet>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VectorPayloadFeatureSetHandler"/> class.
+    /// </summary>
+    /// <param name="format">Shared vector payload format to request and parse.</param>
+    public VectorPayloadFeatureSetHandler(VectorPayloadFormat format = VectorPayloadFormat.GeoJson)
+    {
+        Format = format;
+        MediaType = WfsVectorFormats.ToOutputFormat(format);
+    }
+
+    /// <summary>The shared vector payload format parsed by this handler.</summary>
+    public VectorPayloadFormat Format { get; }
+
+    /// <inheritdoc />
+    public string MediaType { get; }
+
+    /// <inheritdoc />
+    public Task<VectorPayloadFeatureSet> ReadAsync(Stream responseStream, CancellationToken ct = default)
+        => VectorPayloadReaders.ReadAsync(responseStream, Format, ct: ct);
+}

--- a/src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj
+++ b/src/Honua.Sdk.Wfs/Honua.Sdk.Wfs.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Geometry.Vector;
 using Honua.Sdk.Wfs.Exceptions;
 using Honua.Sdk.Wfs.Formats;
 using Honua.Sdk.Wfs.Models;
@@ -278,6 +279,16 @@ public sealed class HonuaWfsClient :
             response.Dispose();
             throw;
         }
+    }
+
+    /// <inheritdoc />
+    public Task<VectorPayloadFeatureSet> GetFeaturesVectorAsync(
+        GetFeaturesRequest request,
+        VectorPayloadFormat format = VectorPayloadFormat.GeoJson,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return GetFeaturesAsync(request, new VectorPayloadFeatureSetHandler(format), ct);
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.Wfs/WfsVectorClientExtensions.cs
+++ b/src/Honua.Sdk.Wfs/WfsVectorClientExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.Wfs.Formats;
+using Honua.Sdk.Wfs.Models;
+
+namespace Honua.Sdk.Wfs;
+
+/// <summary>
+/// Typed vector payload helpers for WFS clients.
+/// </summary>
+public static class WfsVectorClientExtensions
+{
+    /// <summary>
+    /// Retrieves features using a supported typed vector output format and parses geometries
+    /// with NetTopologySuite.
+    /// </summary>
+    /// <param name="client">WFS client.</param>
+    /// <param name="request">The feature request parameters.</param>
+    /// <param name="format">Vector payload format to request. Defaults to GeoJSON.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The parsed typed vector payload.</returns>
+    public static Task<VectorPayloadFeatureSet> GetFeaturesVectorAsync(
+        this IHonuaWfsClient client,
+        GetFeaturesRequest request,
+        VectorPayloadFormat format = VectorPayloadFormat.GeoJson,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        return client.GetFeaturesAsync(request, new VectorPayloadFeatureSetHandler(format), ct);
+    }
+}

--- a/src/Honua.Sdk.Wfs/WfsVectorFormats.cs
+++ b/src/Honua.Sdk.Wfs/WfsVectorFormats.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+
+namespace Honua.Sdk.Wfs;
+
+/// <summary>
+/// Maps shared vector payload formats to WFS OUTPUTFORMAT values.
+/// </summary>
+public static class WfsVectorFormats
+{
+    /// <summary>Default WFS GeoJSON output format value.</summary>
+    public const string GeoJsonOutputFormat = "application/geo+json";
+
+    /// <summary>Default WFS GML 3.2 output format value.</summary>
+    public const string GmlOutputFormat = "application/gml+xml; version=3.2";
+
+    /// <summary>Vector payload formats supported by WFS typed vector queries.</summary>
+    public static IReadOnlyList<VectorPayloadFormat> SupportedFormats { get; } =
+        [VectorPayloadFormat.GeoJson, VectorPayloadFormat.Gml];
+
+    /// <summary>
+    /// Converts a shared vector format to a WFS OUTPUTFORMAT value.
+    /// </summary>
+    /// <param name="format">Shared vector payload format.</param>
+    /// <returns>The WFS OUTPUTFORMAT value.</returns>
+    public static string ToOutputFormat(VectorPayloadFormat format) => format switch
+    {
+        VectorPayloadFormat.GeoJson => GeoJsonOutputFormat,
+        VectorPayloadFormat.Gml => GmlOutputFormat,
+        VectorPayloadFormat.EsriJson => throw new NotSupportedException("WFS does not expose Esri JSON GetFeature output."),
+        _ => throw new NotSupportedException($"Vector payload format '{format}' is not supported by WFS.")
+    };
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/FeatureServerVectorPayloadTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/FeatureServerVectorPayloadTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Honua.Sdk.Geometry.Vector;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.GeoServices.Tests.FeatureServer;
+
+public sealed class FeatureServerVectorPayloadTests
+{
+    [Fact]
+    public async Task QueryVectorAsync_DefaultsToEsriJsonAndParsesNtsGeometry()
+    {
+        const string json = """
+            {
+              "objectIdFieldName": "OBJECTID",
+              "spatialReference": { "wkid": 4326 },
+              "features": [
+                {
+                  "attributes": { "OBJECTID": 7, "name": "Harbor" },
+                  "geometry": { "x": -157.865, "y": 21.306 }
+                }
+              ]
+            }
+            """;
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            Assert.Equal("/rest/services/parks/FeatureServer/0/query", req.RequestUri!.AbsolutePath);
+            Assert.Contains("f=json", req.RequestUri.Query);
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var result = await client.QueryVectorAsync("parks", 0, new FeatureServerQueryParams());
+
+        Assert.Equal(VectorPayloadFormat.EsriJson, result.Format);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("7", feature.Id);
+        Assert.Equal("Harbor", feature.Attributes["name"].GetString());
+        var point = Assert.IsType<Point>(feature.Geometry);
+        Assert.Equal(4326, point.SRID);
+    }
+
+    [Fact]
+    public async Task QueryVectorAsync_GeoJson_RequestsGeoJsonAndParsesNtsGeometry()
+    {
+        const string geoJson = """
+            {
+              "type": "FeatureCollection",
+              "numberReturned": 1,
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": "parks.9",
+                  "properties": { "name": "Lagoon" },
+                  "geometry": { "type": "Point", "coordinates": [-157.84, 21.29] }
+                }
+              ]
+            }
+            """;
+        var client = TestHelpers.CreateFeatureServerClient(req =>
+        {
+            Assert.Contains("f=geojson", req.RequestUri!.Query);
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(geoJson));
+        });
+
+        var result = await client.QueryVectorAsync(
+            "parks",
+            0,
+            new FeatureServerQueryParams(),
+            VectorPayloadFormat.GeoJson);
+
+        Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
+        var point = Assert.IsType<Point>(Assert.Single(result.Features).Geometry);
+        Assert.Equal(-157.84, point.X, 2);
+    }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj
+++ b/tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Honua.Sdk.GeoServices\Honua.Sdk.GeoServices.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text;
+using Honua.Sdk.Geometry.Vector;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Geometry.Tests;
+
+public sealed class VectorPayloadReaderTests
+{
+    [Fact]
+    public async Task EsriJsonReader_ParsesFeaturesIntoNtsGeometry()
+    {
+        const string json = """
+            {
+              "objectIdFieldName": "OBJECTID",
+              "spatialReference": { "wkid": 4326 },
+              "features": [
+                {
+                  "attributes": { "OBJECTID": 42, "name": "Ala Moana" },
+                  "geometry": { "x": -157.842, "y": 21.291 }
+                }
+              ],
+              "exceededTransferLimit": true
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.EsriJson);
+
+        Assert.Equal(VectorPayloadFormat.EsriJson, result.Format);
+        Assert.Equal("OBJECTID", result.ObjectIdFieldName);
+        Assert.True(result.HasMoreResults);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("42", feature.Id);
+        Assert.Equal("Ala Moana", feature.Attributes["name"].GetString());
+        var point = Assert.IsType<Point>(feature.Geometry);
+        Assert.Equal(4326, point.SRID);
+        Assert.Equal(-157.842, point.X, 3);
+        Assert.Equal(21.291, point.Y, 3);
+    }
+
+    [Fact]
+    public async Task GeoJsonReader_ParsesFeatureCollectionIntoNtsGeometry()
+    {
+        const string json = """
+            {
+              "type": "FeatureCollection",
+              "numberMatched": 2,
+              "numberReturned": 1,
+              "bbox": [-158, 21, -157, 22],
+              "links": [
+                { "rel": "next", "href": "http://localhost/next", "type": "application/geo+json" }
+              ],
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": "parks.1",
+                  "properties": { "name": "Kapiolani" },
+                  "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-157.82, 21.27], [-157.81, 21.28]]
+                  }
+                }
+              ]
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.GeoJson);
+
+        Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
+        Assert.Equal(2, result.NumberMatched);
+        Assert.Equal(1, result.NumberReturned);
+        Assert.True(result.HasMoreResults);
+        Assert.NotNull(result.Extent);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("parks.1", feature.Id);
+        Assert.Equal("Kapiolani", feature.Attributes["name"].GetString());
+        var line = Assert.IsType<LineString>(feature.Geometry);
+        Assert.Equal(2, line.NumPoints);
+    }
+
+    [Fact]
+    public async Task GmlReader_ParsesWfsMembersIntoNtsGeometry()
+    {
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <wfs:member>
+                <honua:park gml:id="parks.1">
+                  <honua:name>Kapiolani</honua:name>
+                  <honua:rating>5</honua:rating>
+                  <honua:shape>
+                    <gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                      <gml:pos>-157.819 21.267</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:park>
+              </wfs:member>
+            </wfs:FeatureCollection>
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(gml), VectorPayloadFormat.Gml);
+
+        Assert.Equal(VectorPayloadFormat.Gml, result.Format);
+        Assert.Equal(1, result.NumberMatched);
+        Assert.Equal(1, result.NumberReturned);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("parks.1", feature.Id);
+        Assert.Equal("park", feature.NativeTypeName);
+        Assert.Equal("Kapiolani", feature.Attributes["name"].GetString());
+        Assert.Equal(5, feature.Attributes["rating"].GetInt32());
+        var point = Assert.IsType<Point>(feature.Geometry);
+        Assert.Equal(4326, point.SRID);
+        Assert.Equal(-157.819, point.X, 3);
+        Assert.Equal(21.267, point.Y, 3);
+    }
+
+    private static Stream ToStream(string payload)
+        => new MemoryStream(Encoding.UTF8.GetBytes(payload));
+}

--- a/tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
     <ProjectReference Include="..\..\src\Honua.Sdk.OgcFeatures\Honua.Sdk.OgcFeatures.csproj" />
   </ItemGroup>
 

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.OgcFeatures.Models;
+using Honua.Sdk.OgcFeatures.Tests.Fixtures;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.OgcFeatures.Tests.OgcFeatures;
+
+public sealed class OgcFeaturesVectorPayloadTests
+{
+    [Fact]
+    public async Task GetItemsVectorAsync_DefaultsToGeoJsonAndParsesNtsGeometry()
+    {
+        const string geoJson = """
+            {
+              "type": "FeatureCollection",
+              "numberMatched": 1,
+              "numberReturned": 1,
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": "parks.1",
+                  "properties": { "name": "Kewalo" },
+                  "geometry": { "type": "Point", "coordinates": [-157.861, 21.293] }
+                }
+              ]
+            }
+            """;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            Assert.Equal("/ogc/features/collections/parks/items", req.RequestUri!.AbsolutePath);
+            Assert.Contains("f=json", req.RequestUri.Query);
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(geoJson));
+        });
+
+        var result = await client.GetItemsVectorAsync("parks");
+
+        Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
+        Assert.Equal(1, result.NumberMatched);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("Kewalo", feature.Attributes["name"].GetString());
+        Assert.IsType<Point>(feature.Geometry);
+    }
+
+    [Fact]
+    public async Task GetItemsVectorAsync_Gml_RequestsGmlAndParsesNtsGeometry()
+    {
+        const string gml = """
+            <gml:FeatureCollection
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <gml:featureMember>
+                <honua:park gml:id="parks.2">
+                  <honua:name>Magic Island</honua:name>
+                  <honua:shape>
+                    <gml:Point srsName="EPSG:4326">
+                      <gml:pos>-157.847 21.286</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:park>
+              </gml:featureMember>
+            </gml:FeatureCollection>
+            """;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            Assert.Contains("f=gml", req.RequestUri!.Query);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(gml, System.Text.Encoding.UTF8, "application/gml+xml")
+            });
+        });
+
+        var result = await client.GetItemsVectorAsync(
+            "parks",
+            new OgcItemsParams { Limit = 1 },
+            VectorPayloadFormat.Gml);
+
+        Assert.Equal(VectorPayloadFormat.Gml, result.Format);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("parks.2", feature.Id);
+        Assert.Equal("Magic Island", feature.Attributes["name"].GetString());
+        Assert.Equal(4326, Assert.IsType<Point>(feature.Geometry).SRID);
+    }
+}

--- a/tests/Honua.Sdk.Wfs.Tests/GetFeaturesVectorTests.cs
+++ b/tests/Honua.Sdk.Wfs.Tests/GetFeaturesVectorTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.Wfs.Models;
+using Honua.Sdk.Wfs.Tests.Fixtures;
+using NetTopologySuite.Geometries;
+
+namespace Honua.Sdk.Wfs.Tests;
+
+public sealed class GetFeaturesVectorTests
+{
+    [Fact]
+    public async Task GetFeaturesVectorAsync_DefaultsToGeoJsonAndParsesNtsGeometry()
+    {
+        const string geoJson = """
+            {
+              "type": "FeatureCollection",
+              "numberMatched": 1,
+              "numberReturned": 1,
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": "parks.1",
+                  "properties": { "name": "Sand Island" },
+                  "geometry": { "type": "Point", "coordinates": [-157.886, 21.319] }
+                }
+              ]
+            }
+            """;
+        var client = TestHelpers.CreateClient(req =>
+        {
+            Assert.Contains("OUTPUTFORMAT=application%2Fgeo%2Bjson", req.RequestUri!.Query);
+            return Task.FromResult(TestHelpers.CreateGeoJsonResponse(geoJson));
+        });
+
+        var result = await client.GetFeaturesVectorAsync(new GetFeaturesRequest { TypeNames = "parks" });
+
+        Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("parks.1", feature.Id);
+        Assert.Equal("Sand Island", feature.Attributes["name"].GetString());
+        Assert.IsType<Point>(feature.Geometry);
+    }
+
+    [Fact]
+    public async Task GetFeaturesVectorAsync_Gml_RequestsGmlAndParsesNtsGeometry()
+    {
+        const string gml = """
+            <wfs:FeatureCollection
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <wfs:member>
+                <honua:park gml:id="parks.3">
+                  <honua:name>Foster</honua:name>
+                  <honua:shape>
+                    <gml:Point srsName="EPSG:4326">
+                      <gml:pos>-157.858 21.315</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:park>
+              </wfs:member>
+            </wfs:FeatureCollection>
+            """;
+        var client = TestHelpers.CreateClient(req =>
+        {
+            Assert.Contains("OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2", req.RequestUri!.Query);
+            return Task.FromResult(TestHelpers.CreateXmlResponse(gml));
+        });
+
+        var result = await client.GetFeaturesVectorAsync(
+            new GetFeaturesRequest { TypeNames = "parks" },
+            VectorPayloadFormat.Gml);
+
+        Assert.Equal(VectorPayloadFormat.Gml, result.Format);
+        var feature = Assert.Single(result.Features);
+        Assert.Equal("parks.3", feature.Id);
+        Assert.Equal("Foster", feature.Attributes["name"].GetString());
+        Assert.Equal(4326, Assert.IsType<Point>(feature.Geometry).SRID);
+    }
+}

--- a/tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj
+++ b/tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
     <ProjectReference Include="..\..\src\Honua.Sdk.Wfs\Honua.Sdk.Wfs.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds a shared typed vector payload reader layer for Esri JSON, GeoJSON, and GML responses. The readers live in `Honua.Sdk.Geometry` and parse supported geometry payloads into NetTopologySuite geometries while preserving feature attributes, IDs, paging metadata, links, and protocol CRS hints.

Adds protocol-specific format negotiation and typed vector query APIs for:

- GeoServices FeatureServer: Esri JSON and GeoJSON via `QueryVectorAsync`
- OGC API Features: GeoJSON and GML via `GetItemsVectorAsync`
- WFS: GeoJSON and GML via `GetFeaturesVectorAsync` plus a reusable WFS output-format handler

Binary/non-implemented vector encodings remain explicit unsupported typed paths and can still use raw/custom response handling.

Closes #133.

## Validation

- `dotnet test tests/Honua.Sdk.Geometry.Tests/Honua.Sdk.Geometry.Tests.csproj --no-restore`
- `dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --no-restore`
- `dotnet test tests/Honua.Sdk.OgcFeatures.Tests/Honua.Sdk.OgcFeatures.Tests.csproj --no-restore`
- `dotnet test tests/Honua.Sdk.Wfs.Tests/Honua.Sdk.Wfs.Tests.csproj --no-restore`