### PR TITLE
Add protocol integration test scaffold

### DIFF
--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -75,6 +75,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoutingGeofenceConsole", "e
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoSuite.Tests", "tests\DemoSuite.Tests\DemoSuite.Tests.csproj", "{A090875A-0818-4812-B5D8-B8D3A6BDEB88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.ProtocolIntegration.Tests", "tests\Honua.Sdk.ProtocolIntegration.Tests\Honua.Sdk.ProtocolIntegration.Tests.csproj", "{F11B7B36-D382-475D-B974-7E81F10CE000}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -481,6 +483,18 @@ Global
 		{A090875A-0818-4812-B5D8-B8D3A6BDEB88}.Release|x64.Build.0 = Release|Any CPU
 		{A090875A-0818-4812-B5D8-B8D3A6BDEB88}.Release|x86.ActiveCfg = Release|Any CPU
 		{A090875A-0818-4812-B5D8-B8D3A6BDEB88}.Release|x86.Build.0 = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|x64.Build.0 = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Debug|x86.Build.0 = Debug|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|x64.ActiveCfg = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|x64.Build.0 = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|x86.ActiveCfg = Release|Any CPU
+		{F11B7B36-D382-475D-B974-7E81F10CE000}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -519,5 +533,6 @@ Global
 		{4134FB59-239E-4830-9204-513F9F144FA9} = {4E4E4E4E-4E4E-4E4E-4E4E-4E4E4E4E4E4E}
 		{F5CFB130-98EA-41C4-847E-6C2C9530324C} = {4E4E4E4E-4E4E-4E4E-4E4E-4E4E4E4E4E4E}
 		{A090875A-0818-4812-B5D8-B8D3A6BDEB88} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
+		{F11B7B36-D382-475D-B974-7E81F10CE000} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -454,6 +454,9 @@ third_party/
 - **[Staging Integration Guide](docs/staging-integration.md)** -- staging
   environment inputs, CI evidence artifacts, common failures, and bounded
   follow-on tickets for shared staging ownership
+- **[Protocol Integration Tests](docs/protocol-integration-tests.md)** --
+  Testcontainers-backed local protocol coverage plan, fixture contract, and CI
+  setup notes for SDK clients
 - **[Client Behavior](docs/client-behavior.md)** -- timeout, retry, error,
   pagination, and typed endpoint coverage behavior across packages
 - **[Spec Workspace Contracts](docs/spec-workspace-contracts.md)** -- package

--- a/docs/protocol-integration-tests.md
+++ b/docs/protocol-integration-tests.md
@@ -1,0 +1,118 @@
+# Protocol Integration Tests
+
+`tests/Honua.Sdk.ProtocolIntegration.Tests` is the SDK-side Testcontainers
+integration suite for real Honua Server protocol coverage. It is skipped by
+default and becomes active only when explicitly configured with a server image
+or an external test server URL.
+
+This suite complements, rather than replaces:
+
+- package/unit tests that use deterministic mock HTTP/gRPC handlers;
+- `tests/Honua.Sdk.IntegrationTests`, which validates deployed staging on a
+  schedule or release path;
+- server-side fixture tests in `honua-server`.
+
+## Local Configuration
+
+Run against a Testcontainers-managed Honua Server image:
+
+```bash
+export HONUA_PROTOCOL_INTEGRATION=true
+export HONUA_PROTOCOL_SERVER_IMAGE=ghcr.io/honua-io/honua-server:test-fixture
+export HONUA_PROTOCOL_SERVER_PORT=8080
+export HONUA_PROTOCOL_SERVER_HEALTH_PATH=/health
+export HONUA_PROTOCOL_API_KEY=replace-me
+export HONUA_PROTOCOL_SEED_PROFILE=sdk-protocol
+
+dotnet test tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj --configuration Release
+```
+
+Run against an already-started server:
+
+```bash
+export HONUA_PROTOCOL_INTEGRATION=true
+export HONUA_PROTOCOL_EXTERNAL_BASE_URL=http://localhost:5000
+export HONUA_PROTOCOL_API_KEY=replace-me
+
+dotnet test tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj --configuration Release
+```
+
+Common fixture identifiers:
+
+- `HONUA_PROTOCOL_SERVICE_NAME`, default `sdk_integration`
+- `HONUA_PROTOCOL_LAYER_ID`, default `0`
+- `HONUA_PROTOCOL_WFS_TYPENAME`, default `public:sdk_integration_points`
+- `HONUA_PROTOCOL_OGC_COLLECTION_ID`, default `sdk_integration_points`
+- `HONUA_PROTOCOL_SCENE_ID`, required for scene tests
+- `HONUA_PROTOCOL_SPEC_ID`, required for Spec tests
+- `HONUA_PROTOCOL_ROUTE_SERVICE_ID`, required with
+  `HONUA_PROTOCOL_ROUTE_LAYER` for routing tests
+- `HONUA_PROTOCOL_SERVICE_AREA_LAYER`, optional routing service-area coverage
+- `HONUA_PROTOCOL_CLOSEST_FACILITY_LAYER`, optional closest-facility coverage
+- `HONUA_PROTOCOL_GEOCODE_TEXT`, required with reverse geocode coordinates for
+  geocoding tests
+- `HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE`
+- `HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE`
+
+Destructive/write tests require:
+
+- `HONUA_PROTOCOL_DESTRUCTIVE=true`
+- `HONUA_PROTOCOL_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON`
+- `HONUA_PROTOCOL_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON`
+- `HONUA_PROTOCOL_FEATURESERVER_EDIT_GEOMETRY_JSON`, optional
+
+## CI Lane
+
+Keep protocol integration CI opt-in until the Honua Server image and fixture
+contract are stable enough to make it a required check. A workflow should be
+`workflow_dispatch` only, accept either a server image or external URL, forward
+the `HONUA_PROTOCOL_*` variables and secrets listed above, and run:
+
+```bash
+dotnet test tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj \
+  --configuration Release \
+  /p:TreatWarningsAsErrors=true \
+  /p:EnforceCodeStyleInBuild=true
+```
+
+With no image or URL, all protocol integration facts are skipped with a clear
+reason.
+
+## Coverage Matrix
+
+| Client surface | Testcontainers checks |
+|----------------|-----------------------|
+| Admin | Compatibility, service settings, enabled protocol assertions |
+| Catalog | Service listing and service lookup through `IHonuaCatalogClient` |
+| Geocoding | Forward, reverse, suggest, and batch when geocoder fixture values are configured |
+| Spec | Validate canonical spec JSON, plan, apply SSE stream |
+| gRPC | Bounded `QueryFeaturesAsync`, geometry omitted |
+| WFS | `GetCapabilities`, `DescribeFeatureType`, `GetFeatures`, hits/count |
+| GeoServices FeatureServer | Service info, layer info, bounded query, count, IDs |
+| FeatureServer edits | Add/update/delete round-trip in destructive lane |
+| FeatureServer attachments | Planned destructive lane once fixture exposes attachment-enabled layer |
+| OGC API Features | Collections, collection, queryables, bounded items, item by id |
+| OGC edits | Planned destructive lane after fixture advertises writable OGC collection |
+| Scenes | List, metadata get, resolve 3D Tiles-capable scene |
+| Routing/NAServer | Metadata, directions, optional service area, optional closest facility |
+| Realtime | Placeholder skipped until server realtime fixture exists |
+| Source facade | Equivalent bounded query across gRPC, FeatureServer, WFS, and OGC |
+
+## Server Fixture Contract
+
+The eventual server seed should expose:
+
+- one non-empty service/layer pair with point, line, polygon, object ID, string,
+  numeric, temporal, and nullable fields;
+- enabled gRPC, FeatureServer, WFS, and OGC API Features for the same data;
+- known WFS type name and OGC collection id;
+- a writable disposable layer for destructive edit tests;
+- an attachment-enabled layer for attachment CRUD;
+- a scene fixture with 3D Tiles endpoint metadata;
+- a spec fixture that validates, plans, applies, streams progress, and supports
+  cancellation;
+- routing fixture metadata if NAServer coverage is expected locally;
+- realtime stream fixture after server transport lands.
+
+Until those server prerequisites are all available, the suite is intentionally
+useful as a scaffold and opt-in smoke lane rather than a PR-blocking gate.

--- a/docs/staging-integration.md
+++ b/docs/staging-integration.md
@@ -7,6 +7,11 @@ read-only and does not execute the mutating bootstrap sample against shared
 staging. A FeatureServer edit round-trip can be enabled only against a
 dedicated disposable edit fixture.
 
+For local throwaway server coverage, use the Testcontainers suite documented in
+[`protocol-integration-tests.md`](protocol-integration-tests.md). Staging
+validates a deployed environment; protocol integration validates SDK clients
+against a deterministic local server fixture.
+
 ## What The Suite Covers
 
 - Admin compatibility and service settings through `IHonuaAdminClient`

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/AdminProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/AdminProtocolIntegrationTests.cs
@@ -1,0 +1,67 @@
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+[Collection(ProtocolIntegrationCollection.Name)]
+[Trait("Category", "ProtocolIntegration")]
+public sealed class AdminProtocolIntegrationTests(ProtocolIntegrationFixture fixture)
+{
+    private readonly ProtocolIntegrationFixture _fixture = fixture;
+
+    [ProtocolIntegrationFact]
+    public async Task AdminCompatibility_AndServiceSettings_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var compatibility = await _fixture.AdminClient.CheckCompatibilityAsync(timeout.Token).ConfigureAwait(false);
+        Assert.True(
+            compatibility.IsSupported,
+            compatibility.UnsupportedReason ?? "Containerized server did not meet the SDK compatibility baseline.");
+
+        var settings = await _fixture.AdminClient.GetServiceSettingsAsync(
+            _fixture.Options.ServiceName,
+            timeout.Token).ConfigureAwait(false);
+
+        Assert.Equal(_fixture.Options.ServiceName, settings.ServiceName);
+        Assert.Contains(settings.EnabledProtocols, protocol => string.Equals(protocol, "Grpc", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(settings.EnabledProtocols, protocol => string.Equals(protocol, "FeatureServer", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [ProtocolIntegrationFact]
+    public async Task Catalog_SearchAndServiceLookup_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var services = await _fixture.CatalogClient.ListServicesAsync(ct: timeout.Token).ConfigureAwait(false);
+        Assert.Contains(services, service => string.Equals(service.Name, _fixture.Options.ServiceName, StringComparison.OrdinalIgnoreCase));
+
+        var service = await _fixture.CatalogClient.GetServiceAsync(_fixture.Options.ServiceName, timeout.Token).ConfigureAwait(false);
+        Assert.NotNull(service);
+        Assert.Equal(_fixture.Options.ServiceName, service.Name);
+    }
+
+    [ProtocolIntegrationFact(false, ProtocolIntegrationRequiredFixture.Geocoding)]
+    public async Task Geocoding_ForwardReverseSuggestAndBatch_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var forward = await _fixture.GeocodingClient.ForwardGeocodeAsync(
+            _fixture.Options.GeocodeText!,
+            ct: timeout.Token).ConfigureAwait(false);
+        Assert.NotEmpty(forward);
+
+        var reverse = await _fixture.GeocodingClient.ReverseGeocodeAsync(
+            _fixture.Options.ReverseGeocodeLatitude!.Value,
+            _fixture.Options.ReverseGeocodeLongitude!.Value,
+            ct: timeout.Token).ConfigureAwait(false);
+        Assert.NotNull(reverse);
+
+        var suggestions = await _fixture.GeocodingClient.SuggestAsync(
+            _fixture.Options.GeocodeText!,
+            ct: timeout.Token).ConfigureAwait(false);
+        Assert.NotEmpty(suggestions);
+
+        var batch = await _fixture.GeocodingClient.BatchGeocodeAsync(
+            [_fixture.Options.GeocodeText!],
+            ct: timeout.Token).ConfigureAwait(false);
+        Assert.NotEmpty(batch);
+    }
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/DestructiveProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/DestructiveProtocolIntegrationTests.cs
@@ -1,0 +1,151 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+[Collection(ProtocolIntegrationCollection.Name)]
+[Trait("Category", "ProtocolIntegration")]
+[Trait("Mutation", "Destructive")]
+public sealed class DestructiveProtocolIntegrationTests(ProtocolIntegrationFixture fixture)
+{
+    private readonly ProtocolIntegrationFixture _fixture = fixture;
+
+    [ProtocolIntegrationFact(true)]
+    public async Task FeatureServerApplyEdits_AddUpdateDelete_RoundTrips()
+    {
+        using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
+        var addAttributes = ParseAttributes(
+            _fixture.Options.FeatureServerEditAddAttributesJson,
+            "HONUA_PROTOCOL_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON");
+        var updateAttributes = ParseAttributes(
+            _fixture.Options.FeatureServerEditUpdateAttributesJson,
+            "HONUA_PROTOCOL_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON");
+        var geometry = ParseOptionalElement(_fixture.Options.FeatureServerEditGeometryJson);
+        long? objectIdForCleanup = null;
+
+        try
+        {
+            var addResponse = await _fixture.FeatureServerEditClient.AddFeaturesAsync(
+                _fixture.Options.ServiceName,
+                _fixture.Options.LayerId,
+                [
+                    new FeatureServerFeature
+                    {
+                        Attributes = addAttributes,
+                        Geometry = geometry
+                    }
+                ],
+                rollbackOnFailure: true,
+                timeout.Token).ConfigureAwait(false);
+
+            var addResult = Assert.Single(addResponse.AddResults);
+            Assert.True(addResult.Success, FormatError(addResult.Error));
+            Assert.True(addResult.ObjectId.HasValue, "FeatureServer add did not return an object ID.");
+            objectIdForCleanup = addResult.ObjectId.Value;
+
+            var sharedEditClient = _fixture.Services
+                .GetServices<IHonuaFeatureEditClient>()
+                .Single(client => client.ProviderName == "geoservices-featureserver");
+
+            var updateResponse = await sharedEditClient.ApplyEditsAsync(
+                new FeatureEditRequest
+                {
+                    Source = new FeatureSource
+                    {
+                        ServiceId = _fixture.Options.ServiceName,
+                        LayerId = _fixture.Options.LayerId
+                    },
+                    Updates =
+                    [
+                        new FeatureEditFeature
+                        {
+                            ObjectId = objectIdForCleanup.Value,
+                            Attributes = updateAttributes
+                        }
+                    ],
+                    RollbackOnFailure = true
+                },
+                timeout.Token).ConfigureAwait(false);
+
+            var updateResult = Assert.Single(updateResponse.UpdateResults);
+            Assert.True(updateResult.Succeeded, FormatError(updateResult.Error));
+
+            var deleteResponse = await _fixture.FeatureServerEditClient.DeleteFeaturesAsync(
+                _fixture.Options.ServiceName,
+                _fixture.Options.LayerId,
+                [objectIdForCleanup.Value],
+                rollbackOnFailure: true,
+                timeout.Token).ConfigureAwait(false);
+
+            var deleteResult = Assert.Single(deleteResponse.DeleteResults);
+            Assert.True(deleteResult.Success, FormatError(deleteResult.Error));
+            objectIdForCleanup = null;
+        }
+        finally
+        {
+            if (objectIdForCleanup.HasValue)
+            {
+                using var cleanup = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await TryDeleteAsync(objectIdForCleanup.Value, cleanup.Token).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task TryDeleteAsync(long objectId, CancellationToken ct)
+    {
+        try
+        {
+            await _fixture.FeatureServerEditClient.DeleteFeaturesAsync(
+                _fixture.Options.ServiceName,
+                _fixture.Options.LayerId,
+                [objectId],
+                rollbackOnFailure: true,
+                ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Preserve the original edit failure.
+        }
+    }
+
+    private static Dictionary<string, JsonElement> ParseAttributes(string? json, string name)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new Xunit.Sdk.XunitException($"{name} must be a JSON object.");
+        }
+
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.ValueKind != JsonValueKind.Object)
+        {
+            throw new Xunit.Sdk.XunitException($"{name} must be a JSON object.");
+        }
+
+        return document.RootElement.EnumerateObject()
+            .ToDictionary(property => property.Name, property => property.Value.Clone());
+    }
+
+    private static JsonElement? ParseOptionalElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+
+    private static string FormatError(FeatureServerEditError? error)
+        => error is null
+            ? "FeatureServer edit result did not succeed."
+            : $"FeatureServer edit failed: code={error.Code?.ToString(CultureInfo.InvariantCulture) ?? "unknown"}; message={error.Description ?? error.Message ?? "unknown"}";
+
+    private static string FormatError(FeatureEditError? error)
+        => error is null
+            ? "Shared FeatureServer edit result did not succeed."
+            : $"Shared FeatureServer edit failed: code={error.Code}; message={error.Message}";
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/FeatureProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/FeatureProtocolIntegrationTests.cs
@@ -1,0 +1,231 @@
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.Grpc.Models;
+using Honua.Sdk.OgcFeatures.Models;
+using Honua.Sdk.Wfs.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+[Collection(ProtocolIntegrationCollection.Name)]
+[Trait("Category", "ProtocolIntegration")]
+public sealed class FeatureProtocolIntegrationTests(ProtocolIntegrationFixture fixture)
+{
+    private readonly ProtocolIntegrationFixture _fixture = fixture;
+
+    [ProtocolIntegrationFact]
+    public async Task GrpcQuery_IsBoundedAndCanOmitGeometry()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var response = await _fixture.GrpcClient.QueryFeaturesAsync(
+            new QueryFeaturesRequest
+            {
+                ServiceId = _fixture.Options.ServiceName,
+                LayerId = _fixture.Options.LayerId,
+                Where = "1=1",
+                ReturnGeometry = false,
+                ResultRecordCount = 3
+            },
+            timeout.Token).ConfigureAwait(false);
+
+        Assert.InRange(response.Features.Count, 1, 3);
+        Assert.All(response.Features, feature => Assert.Null(feature.Geometry));
+    }
+
+    [ProtocolIntegrationFact]
+    public async Task WfsCapabilities_DescribeFeatureType_GetFeature_AndCount_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var capabilities = await _fixture.WfsClient.GetCapabilitiesAsync(timeout.Token).ConfigureAwait(false);
+        Assert.Contains(
+            capabilities.FeatureTypes,
+            featureType => string.Equals(featureType.Name, _fixture.Options.WfsTypeName, StringComparison.OrdinalIgnoreCase));
+
+        var schema = await _fixture.WfsClient.DescribeFeatureTypeAsync(
+            _fixture.Options.WfsTypeName,
+            timeout.Token).ConfigureAwait(false);
+        Assert.False(string.IsNullOrWhiteSpace(schema.ElementName));
+
+        var features = await _fixture.WfsClient.GetFeaturesAsync(
+            new GetFeaturesRequest
+            {
+                TypeNames = _fixture.Options.WfsTypeName,
+                Count = 2
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.InRange(features.Features.Count, 1, 2);
+
+        var count = await _fixture.WfsClient.GetFeatureCountAsync(
+            _fixture.Options.WfsTypeName,
+            ct: timeout.Token).ConfigureAwait(false);
+        Assert.True(count is null or >= 1);
+    }
+
+    [ProtocolIntegrationFact]
+    public async Task FeatureServer_Metadata_QueryStatisticsAndVectorPayload_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var serviceInfo = await _fixture.FeatureServerClient.GetServiceInfoAsync(
+            _fixture.Options.ServiceName,
+            timeout.Token).ConfigureAwait(false);
+        Assert.Contains(serviceInfo.Layers ?? [], layer => layer.Id == _fixture.Options.LayerId);
+
+        var layer = await _fixture.FeatureServerClient.GetLayerInfoAsync(
+            _fixture.Options.ServiceName,
+            _fixture.Options.LayerId,
+            timeout.Token).ConfigureAwait(false);
+        Assert.Equal(_fixture.Options.LayerId, layer.Id);
+
+        var query = await _fixture.FeatureServerClient.QueryAsync(
+            _fixture.Options.ServiceName,
+            _fixture.Options.LayerId,
+            new FeatureServerQueryParams
+            {
+                Where = "1=1",
+                ReturnGeometry = false,
+                ResultRecordCount = 3
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.InRange(query.Features?.Count ?? 0, 1, 3);
+        Assert.All(
+            query.Features ?? [],
+            feature => Assert.True(
+                !feature.Geometry.HasValue || feature.Geometry.Value.ValueKind == JsonValueKind.Null,
+                "FeatureServer query returned geometry for returnGeometry=false."));
+
+        var count = await _fixture.FeatureServerClient.QueryCountAsync(
+            _fixture.Options.ServiceName,
+            _fixture.Options.LayerId,
+            new FeatureServerQueryParams { Where = "1=1" },
+            timeout.Token).ConfigureAwait(false);
+        Assert.True(count >= 1);
+
+        var ids = await _fixture.FeatureServerClient.QueryIdsAsync(
+            _fixture.Options.ServiceName,
+            _fixture.Options.LayerId,
+            new FeatureServerQueryParams { Where = "1=1" },
+            timeout.Token).ConfigureAwait(false);
+        Assert.NotEmpty(ids);
+    }
+
+    [ProtocolIntegrationFact]
+    public async Task OgcCollections_Items_Queryables_AndSingleItem_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var collections = await _fixture.OgcFeaturesClient.ListCollectionsAsync(timeout.Token).ConfigureAwait(false);
+        Assert.Contains(
+            collections,
+            collection => string.Equals(collection.Id, _fixture.Options.OgcCollectionId, StringComparison.OrdinalIgnoreCase));
+
+        var collection = await _fixture.OgcFeaturesClient.GetCollectionAsync(
+            _fixture.Options.OgcCollectionId,
+            timeout.Token).ConfigureAwait(false);
+        Assert.Equal(_fixture.Options.OgcCollectionId, collection.Id);
+
+        var queryables = await _fixture.OgcFeaturesClient.GetQueryablesAsync(
+            _fixture.Options.OgcCollectionId,
+            timeout.Token).ConfigureAwait(false);
+        Assert.NotNull(queryables);
+
+        var items = await _fixture.OgcFeaturesClient.GetItemsAsync(
+            _fixture.Options.OgcCollectionId,
+            new OgcItemsParams { Limit = 2 },
+            timeout.Token).ConfigureAwait(false);
+        var features = items.Features ?? [];
+        Assert.InRange(features.Count, 1, 2);
+
+        var firstItemId = GetFeatureId(features[0]);
+        var item = await _fixture.OgcFeaturesClient.GetItemAsync(
+            _fixture.Options.OgcCollectionId,
+            firstItemId,
+            timeout.Token).ConfigureAwait(false);
+        Assert.Equal("Feature", item.Type);
+    }
+
+    [ProtocolIntegrationFact]
+    public async Task SourceFacade_QueriesConfiguredFeatureProtocols()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+        var sources = new[]
+        {
+            CreateSource(
+                "grpc",
+                FeatureProtocolIds.Grpc,
+                new SourceLocator { ServiceId = _fixture.Options.ServiceName, LayerId = _fixture.Options.LayerId }),
+            CreateSource(
+                "geoservices",
+                FeatureProtocolIds.GeoServicesFeatureService,
+                new SourceLocator { ServiceId = _fixture.Options.ServiceName, LayerId = _fixture.Options.LayerId }),
+            CreateSource(
+                "wfs",
+                FeatureProtocolIds.Wfs,
+                new SourceLocator { TypeName = _fixture.Options.WfsTypeName }),
+            CreateSource(
+                "ogc",
+                FeatureProtocolIds.OgcFeatures,
+                new SourceLocator { CollectionId = _fixture.Options.OgcCollectionId })
+        };
+
+        foreach (var source in sources)
+        {
+            var result = await source.QueryAsync(
+                new SourceQuery
+                {
+                    Where = BuildWhere(source.Descriptor.CanonicalProtocol),
+                    FilterLanguage = BuildFilterLanguage(source.Descriptor.CanonicalProtocol),
+                    ReturnGeometry = false,
+                    Limit = 1
+                },
+                timeout.Token).ConfigureAwait(false);
+
+            Assert.InRange(result.Features.Count, 1, 1);
+        }
+    }
+
+    private HonuaSource CreateSource(string id, string protocol, SourceLocator locator)
+    {
+        var queryClient = _fixture.Services
+            .GetServices<IHonuaFeatureQueryClient>()
+            .Single(client => FeatureProtocolIds.Matches(protocol, client.ProviderName));
+        var editClient = _fixture.Services
+            .GetServices<IHonuaFeatureEditClient>()
+            .SingleOrDefault(client => FeatureProtocolIds.Matches(protocol, client.ProviderName));
+
+        return new HonuaSource(
+            new SourceDescriptor
+            {
+                Id = id,
+                Protocol = protocol,
+                Locator = locator
+            },
+            queryClient,
+            editClient,
+            queryClient);
+    }
+
+    private static string GetFeatureId(OgcFeature feature)
+    {
+        var id = feature.Id ?? throw new Xunit.Sdk.XunitException("OGC items response did not include a feature ID.");
+        return id.ValueKind switch
+        {
+            JsonValueKind.String => id.GetString() ?? throw new Xunit.Sdk.XunitException("OGC feature ID was empty."),
+            JsonValueKind.Number => id.GetRawText(),
+            _ => throw new Xunit.Sdk.XunitException($"Unsupported OGC feature ID kind: {id.ValueKind}.")
+        };
+    }
+
+    private static string? BuildWhere(string protocol)
+        => protocol is FeatureProtocolIds.Grpc or FeatureProtocolIds.GeoServicesFeatureService
+            ? "1=1"
+            : null;
+
+    private static FeatureFilterLanguage BuildFilterLanguage(string protocol)
+        => protocol is FeatureProtocolIds.Grpc or FeatureProtocolIds.GeoServicesFeatureService
+            ? FeatureFilterLanguage.SqlWhere
+            : FeatureFilterLanguage.ProviderDefault;
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/GlobalUsings.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Testcontainers" Version="4.11.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Admin\Honua.Sdk.Admin.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.GeoServices\Honua.Sdk.GeoServices.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Grpc\Honua.Sdk.Grpc.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.OgcFeatures\Honua.Sdk.OgcFeatures.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Scenes\Honua.Sdk.Scenes.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Spec\Honua.Sdk.Spec.csproj" />
+    <ProjectReference Include="..\..\src\Honua.Sdk.Wfs\Honua.Sdk.Wfs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationConfigurationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationConfigurationTests.cs
@@ -1,0 +1,17 @@
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+public sealed class ProtocolIntegrationConfigurationTests
+{
+    [Fact]
+    public void Options_LoadsDefaultsAndRedactsCredentials()
+    {
+        var options = ProtocolIntegrationOptions.Load();
+
+        Assert.False(string.IsNullOrWhiteSpace(options.ServiceName));
+        Assert.False(string.IsNullOrWhiteSpace(options.WfsTypeName));
+        Assert.False(string.IsNullOrWhiteSpace(options.OgcCollectionId));
+        Assert.Contains("apiKey=", options.ToRedactedSummary(), StringComparison.Ordinal);
+        Assert.DoesNotContain(options.ApiKey ?? "not-present-api-key", options.ToRedactedSummary(), StringComparison.Ordinal);
+        Assert.DoesNotContain(options.BearerToken ?? "not-present-bearer-token", options.ToRedactedSummary(), StringComparison.Ordinal);
+    }
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFactAttribute.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFactAttribute.cs
@@ -1,0 +1,53 @@
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+public enum ProtocolIntegrationRequiredFixture
+{
+    None,
+    Routing,
+    Realtime,
+    Geocoding,
+    Spec,
+    Scene,
+    SpecAndScene
+}
+
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class ProtocolIntegrationFactAttribute : FactAttribute
+{
+    public ProtocolIntegrationFactAttribute(
+        bool destructive = false,
+        ProtocolIntegrationRequiredFixture requiredFixture = ProtocolIntegrationRequiredFixture.None)
+    {
+        Destructive = destructive;
+        RequiredFixture = requiredFixture;
+        Skip = ProtocolIntegrationOptions.GetSkipReason(destructive);
+        if (Skip is not null)
+        {
+            return;
+        }
+
+        var options = ProtocolIntegrationOptions.Load();
+        Skip = requiredFixture switch
+        {
+            ProtocolIntegrationRequiredFixture.Routing when !options.HasRoutingFixture =>
+                "Set HONUA_PROTOCOL_ROUTE_SERVICE_ID and HONUA_PROTOCOL_ROUTE_LAYER to run routing protocol integration tests.",
+            ProtocolIntegrationRequiredFixture.Realtime =>
+                "Realtime server transport integration is pending the Honua Server realtime fixture.",
+            ProtocolIntegrationRequiredFixture.Geocoding when !options.HasGeocodingFixture =>
+                "Set HONUA_PROTOCOL_GEOCODE_TEXT, HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE, and HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE to run geocoding tests.",
+            ProtocolIntegrationRequiredFixture.Spec when string.IsNullOrWhiteSpace(options.SpecId) =>
+                "Set HONUA_PROTOCOL_SPEC_ID to run Spec protocol integration tests.",
+            ProtocolIntegrationRequiredFixture.Scene when string.IsNullOrWhiteSpace(options.SceneId) =>
+                "Set HONUA_PROTOCOL_SCENE_ID to run Scenes protocol integration tests.",
+            ProtocolIntegrationRequiredFixture.SpecAndScene when string.IsNullOrWhiteSpace(options.SpecId) =>
+                "Set HONUA_PROTOCOL_SPEC_ID to run Spec protocol integration tests.",
+            ProtocolIntegrationRequiredFixture.SpecAndScene when string.IsNullOrWhiteSpace(options.SceneId) =>
+                "Set HONUA_PROTOCOL_SCENE_ID to run Scenes protocol integration tests.",
+            _ => null
+        };
+    }
+
+    public bool Destructive { get; }
+
+    public ProtocolIntegrationRequiredFixture RequiredFixture { get; }
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFixture.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFixture.cs
@@ -1,0 +1,185 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Honua.Sdk.Abstractions.Routing;
+using Honua.Sdk.Abstractions.Scenes;
+using Honua.Sdk.Admin;
+using Honua.Sdk.Admin.Catalog;
+using Honua.Sdk.Admin.Extensions;
+using Honua.Sdk.Admin.Geocoding;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.Grpc;
+using Honua.Sdk.Grpc.Extensions;
+using Honua.Sdk.OgcFeatures;
+using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.Scenes.Extensions;
+using Honua.Sdk.Spec;
+using Honua.Sdk.Spec.Extensions;
+using Honua.Sdk.Wfs;
+using Honua.Sdk.Wfs.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class ProtocolIntegrationCollection : ICollectionFixture<ProtocolIntegrationFixture>
+{
+    public const string Name = "ProtocolIntegration";
+}
+
+public sealed class ProtocolIntegrationFixture : IAsyncLifetime, IDisposable
+{
+    private IContainer? _serverContainer;
+
+    public ProtocolIntegrationOptions Options { get; } = ProtocolIntegrationOptions.Load();
+
+    public Uri BaseUri { get; private set; } = new("http://localhost");
+
+    public ServiceProvider Services { get; private set; } = new ServiceCollection().BuildServiceProvider();
+
+    public IHonuaAdminClient AdminClient => Services.GetRequiredService<IHonuaAdminClient>();
+
+    public IHonuaCatalogClient CatalogClient => Services.GetRequiredService<IHonuaCatalogClient>();
+
+    public IHonuaGeocodingClient GeocodingClient => Services.GetRequiredService<IHonuaGeocodingClient>();
+
+    public IHonuaSpecClient SpecClient => Services.GetRequiredService<IHonuaSpecClient>();
+
+    public IHonuaGrpcClient GrpcClient => Services.GetRequiredService<IHonuaGrpcClient>();
+
+    public IHonuaWfsClient WfsClient => Services.GetRequiredService<IHonuaWfsClient>();
+
+    public IHonuaFeatureServerClient FeatureServerClient => Services.GetRequiredService<IHonuaFeatureServerClient>();
+
+    public IHonuaFeatureServerEditClient FeatureServerEditClient => Services.GetRequiredService<IHonuaFeatureServerEditClient>();
+
+    public IHonuaOgcFeaturesClient OgcFeaturesClient => Services.GetRequiredService<IHonuaOgcFeaturesClient>();
+
+    public IHonuaSceneClient SceneClient => Services.GetRequiredService<IHonuaSceneClient>();
+
+    public IHonuaRoutingClient RoutingClient => Services.GetRequiredService<IHonuaRoutingClient>();
+
+    public async Task InitializeAsync()
+    {
+        if (!Options.Enabled)
+        {
+            return;
+        }
+
+        BaseUri = Options.ExternalBaseUri ?? await StartServerContainerAsync().ConfigureAwait(false);
+        Services = BuildServiceProvider(BaseUri);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_serverContainer is not null)
+        {
+            await _serverContainer.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    public void Dispose() => Services.Dispose();
+
+    public CancellationTokenSource CreateTimeoutScope(TimeSpan? timeout = null)
+        => new(timeout ?? TimeSpan.FromSeconds(45));
+
+    private async Task<Uri> StartServerContainerAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Options.ServerImage))
+        {
+            throw new InvalidOperationException("HONUA_PROTOCOL_SERVER_IMAGE is required when HONUA_PROTOCOL_EXTERNAL_BASE_URL is not set.");
+        }
+
+        var image = Options.ServerImage;
+        var builder = new ContainerBuilder(image)
+            .WithPortBinding(Options.ServerPort, assignRandomHostPort: true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
+                .ForPort(Options.ServerPort)
+                .ForPath(Options.ServerHealthPath)
+                .ForStatusCodeMatching(statusCode => statusCode >= System.Net.HttpStatusCode.OK &&
+                    statusCode < System.Net.HttpStatusCode.InternalServerError)));
+
+        foreach (var pair in Options.BuildContainerEnvironment())
+        {
+            builder = builder.WithEnvironment(pair.Key, pair.Value);
+        }
+
+        _serverContainer = builder.Build();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        await _serverContainer.StartAsync(timeout.Token).ConfigureAwait(false);
+
+        return new UriBuilder(
+            Options.ServerScheme,
+            _serverContainer.Hostname,
+            _serverContainer.GetMappedPublicPort(Options.ServerPort)).Uri;
+    }
+
+    private ServiceProvider BuildServiceProvider(Uri baseUri)
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaAdmin(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaGeocoding(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaSpec(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaGrpc(options =>
+        {
+            options.Address = baseUri.ToString();
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaWfs(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+            options.RoutingServiceId = Options.RouteServiceId ?? "Routing";
+            options.RoutingRouteLayerName = Options.RouteLayerName ?? "Route";
+            options.RoutingServiceAreaLayerName = Options.ServiceAreaLayerName ?? "ServiceArea";
+            options.RoutingClosestFacilityLayerName = Options.ClosestFacilityLayerName ?? "ClosestFacility";
+        });
+        services.AddHonuaRouting(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+            options.RoutingServiceId = Options.RouteServiceId ?? "Routing";
+            options.RoutingRouteLayerName = Options.RouteLayerName ?? "Route";
+            options.RoutingServiceAreaLayerName = Options.ServiceAreaLayerName ?? "ServiceArea";
+            options.RoutingClosestFacilityLayerName = Options.ClosestFacilityLayerName ?? "ClosestFacility";
+        });
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+        services.AddHonuaScenes(options =>
+        {
+            options.BaseAddress = baseUri;
+            options.ApiKey = Options.ApiKey;
+            options.BearerToken = Options.BearerToken;
+        });
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationOptions.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationOptions.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+public sealed record ProtocolIntegrationOptions
+{
+    public bool Enabled { get; init; }
+
+    public Uri? ExternalBaseUri { get; init; }
+
+    public string? ServerImage { get; init; }
+
+    public ushort ServerPort { get; init; } = 8080;
+
+    public string ServerScheme { get; init; } = "http";
+
+    public string ServerHealthPath { get; init; } = "/health";
+
+    public string? ApiKey { get; init; }
+
+    public string? BearerToken { get; init; }
+
+    public string ServiceName { get; init; } = "sdk_integration";
+
+    public int LayerId { get; init; }
+
+    public string WfsTypeName { get; init; } = "public:sdk_integration_points";
+
+    public string OgcCollectionId { get; init; } = "sdk_integration_points";
+
+    public string? SceneId { get; init; }
+
+    public string? SpecId { get; init; }
+
+    public string? RouteServiceId { get; init; }
+
+    public string? RouteLayerName { get; init; }
+
+    public string? ServiceAreaLayerName { get; init; }
+
+    public string? ClosestFacilityLayerName { get; init; }
+
+    public string? GeocodeText { get; init; }
+
+    public double? ReverseGeocodeLatitude { get; init; }
+
+    public double? ReverseGeocodeLongitude { get; init; }
+
+    public bool DestructiveEnabled { get; init; }
+
+    public string? SeedProfile { get; init; }
+
+    public string? FeatureServerEditAddAttributesJson { get; init; }
+
+    public string? FeatureServerEditUpdateAttributesJson { get; init; }
+
+    public string? FeatureServerEditGeometryJson { get; init; }
+
+    public bool HasServerTarget =>
+        ExternalBaseUri is not null || !string.IsNullOrWhiteSpace(ServerImage);
+
+    public bool HasRoutingFixture =>
+        !string.IsNullOrWhiteSpace(RouteServiceId) &&
+        !string.IsNullOrWhiteSpace(RouteLayerName);
+
+    public bool HasGeocodingFixture =>
+        !string.IsNullOrWhiteSpace(GeocodeText) &&
+        ReverseGeocodeLatitude.HasValue &&
+        ReverseGeocodeLongitude.HasValue;
+
+    public static ProtocolIntegrationOptions Load() => new()
+    {
+        Enabled = ReadBoolean("HONUA_PROTOCOL_INTEGRATION"),
+        ExternalBaseUri = ReadUri("HONUA_PROTOCOL_EXTERNAL_BASE_URL"),
+        ServerImage = ReadString("HONUA_PROTOCOL_SERVER_IMAGE"),
+        ServerPort = ReadUShort("HONUA_PROTOCOL_SERVER_PORT", 8080),
+        ServerScheme = ReadString("HONUA_PROTOCOL_SERVER_SCHEME") ?? "http",
+        ServerHealthPath = ReadString("HONUA_PROTOCOL_SERVER_HEALTH_PATH") ?? "/health",
+        ApiKey = ReadString("HONUA_PROTOCOL_API_KEY"),
+        BearerToken = ReadString("HONUA_PROTOCOL_BEARER_TOKEN"),
+        ServiceName = ReadString("HONUA_PROTOCOL_SERVICE_NAME") ?? "sdk_integration",
+        LayerId = ReadInt("HONUA_PROTOCOL_LAYER_ID", 0),
+        WfsTypeName = ReadString("HONUA_PROTOCOL_WFS_TYPENAME") ?? "public:sdk_integration_points",
+        OgcCollectionId = ReadString("HONUA_PROTOCOL_OGC_COLLECTION_ID") ?? "sdk_integration_points",
+        SceneId = ReadString("HONUA_PROTOCOL_SCENE_ID"),
+        SpecId = ReadString("HONUA_PROTOCOL_SPEC_ID"),
+        RouteServiceId = ReadString("HONUA_PROTOCOL_ROUTE_SERVICE_ID"),
+        RouteLayerName = ReadString("HONUA_PROTOCOL_ROUTE_LAYER"),
+        ServiceAreaLayerName = ReadString("HONUA_PROTOCOL_SERVICE_AREA_LAYER"),
+        ClosestFacilityLayerName = ReadString("HONUA_PROTOCOL_CLOSEST_FACILITY_LAYER"),
+        GeocodeText = ReadString("HONUA_PROTOCOL_GEOCODE_TEXT"),
+        ReverseGeocodeLatitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE"),
+        ReverseGeocodeLongitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE"),
+        DestructiveEnabled = ReadBoolean("HONUA_PROTOCOL_DESTRUCTIVE"),
+        SeedProfile = ReadString("HONUA_PROTOCOL_SEED_PROFILE"),
+        FeatureServerEditAddAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON"),
+        FeatureServerEditUpdateAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON"),
+        FeatureServerEditGeometryJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_GEOMETRY_JSON")
+    };
+
+    public static string? GetSkipReason(bool destructive = false)
+    {
+        var options = Load();
+        if (!options.Enabled)
+        {
+            return "Set HONUA_PROTOCOL_INTEGRATION=true to run Testcontainers protocol integration tests.";
+        }
+
+        if (!options.HasServerTarget)
+        {
+            return "Set HONUA_PROTOCOL_SERVER_IMAGE or HONUA_PROTOCOL_EXTERNAL_BASE_URL to run protocol integration tests.";
+        }
+
+        if (destructive && !options.DestructiveEnabled)
+        {
+            return "Set HONUA_PROTOCOL_DESTRUCTIVE=true to run mutating protocol integration tests.";
+        }
+
+        return null;
+    }
+
+    public IReadOnlyDictionary<string, string> BuildContainerEnvironment()
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        AddIfPresent(values, "HONUA_PROTOCOL_SEED_PROFILE", SeedProfile);
+        AddIfPresent(values, "HONUA_SEED_PROFILE", SeedProfile);
+        AddIfPresent(values, "HONUA_API_KEY", ApiKey);
+        AddIfPresent(values, "HONUA_BEARER_TOKEN", BearerToken);
+        return values;
+    }
+
+    public string ToRedactedSummary()
+        => string.Join(
+            "; ",
+            [
+                $"enabled={Enabled}",
+                $"serverImage={(string.IsNullOrWhiteSpace(ServerImage) ? "none" : ServerImage)}",
+                $"externalBaseUrl={(ExternalBaseUri is null ? "none" : ExternalBaseUri)}",
+                $"service={ServiceName}",
+                $"layerId={LayerId.ToString(CultureInfo.InvariantCulture)}",
+                $"wfsType={WfsTypeName}",
+                $"ogcCollection={OgcCollectionId}",
+                $"scene={(string.IsNullOrWhiteSpace(SceneId) ? "none" : SceneId)}",
+                $"spec={(string.IsNullOrWhiteSpace(SpecId) ? "none" : SpecId)}",
+                $"routing={(HasRoutingFixture ? RouteServiceId : "none")}",
+                $"geocoding={(HasGeocodingFixture ? "configured" : "none")}",
+                $"destructive={DestructiveEnabled}",
+                $"apiKey={(string.IsNullOrWhiteSpace(ApiKey) ? "none" : "configured")}",
+                $"bearer={(string.IsNullOrWhiteSpace(BearerToken) ? "none" : "configured")}"
+            ]);
+
+    private static string? ReadString(string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static Uri? ReadUri(string name)
+    {
+        var value = ReadString(name);
+        return value is null ? null : new Uri(value, UriKind.Absolute);
+    }
+
+    private static bool ReadBoolean(string name)
+    {
+        var value = ReadString(name);
+        return value is not null &&
+            (string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(value, "1", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(value, "yes", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static int ReadInt(string name, int defaultValue)
+    {
+        var value = ReadString(name);
+        return value is null
+            ? defaultValue
+            : int.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+    }
+
+    private static double? ReadDouble(string name)
+    {
+        var value = ReadString(name);
+        return value is null
+            ? null
+            : double.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+
+    private static ushort ReadUShort(string name, ushort defaultValue)
+    {
+        var value = ReadString(name);
+        return value is null
+            ? defaultValue
+            : ushort.Parse(value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+    }
+
+    private static void AddIfPresent(IDictionary<string, string> values, string name, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            values[name] = value;
+        }
+    }
+}

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/SpecSceneRoutingProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/SpecSceneRoutingProtocolIntegrationTests.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Routing;
+using Honua.Sdk.Abstractions.Scenes;
+using Honua.Sdk.Spec.Models;
+
+namespace Honua.Sdk.ProtocolIntegration.Tests;
+
+[Collection(ProtocolIntegrationCollection.Name)]
+[Trait("Category", "ProtocolIntegration")]
+public sealed class SpecSceneRoutingProtocolIntegrationTests(ProtocolIntegrationFixture fixture)
+{
+    private readonly ProtocolIntegrationFixture _fixture = fixture;
+
+    [ProtocolIntegrationFact(false, ProtocolIntegrationRequiredFixture.Spec)]
+    public async Task SpecValidatePlanAndApplyStream_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
+        var document = CreateSpecDocument(_fixture.Options.SpecId!);
+
+        var validation = await _fixture.SpecClient.ValidateAsync(
+            new SpecValidateRequest
+            {
+                Spec = JsonSerializer.SerializeToElement(document),
+                IncludeCanonicalJson = true
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.True(validation.IsValid, string.Join("; ", validation.Diagnostics.Select(diagnostic => diagnostic.Message)));
+
+        var plan = await _fixture.SpecClient.PlanAsync(document, timeout.Token).ConfigureAwait(false);
+        Assert.False(string.IsNullOrWhiteSpace(plan.PlanId));
+        Assert.NotEmpty(plan.Nodes);
+
+        await using var apply = await _fixture.SpecClient.ApplyAsync(document, timeout.Token).ConfigureAwait(false);
+        var events = new List<SpecApplyEvent>();
+        await foreach (var applyEvent in apply.Events.WithCancellation(timeout.Token).ConfigureAwait(false))
+        {
+            events.Add(applyEvent);
+            if (applyEvent.Kind == SpecApplyEventKind.ApplyCompleted ||
+                applyEvent.Kind == SpecApplyEventKind.Failed ||
+                applyEvent.Kind == SpecApplyEventKind.ApplyCancelled)
+            {
+                break;
+            }
+        }
+
+        Assert.NotEmpty(events);
+        Assert.Contains(events, applyEvent => applyEvent.Kind == SpecApplyEventKind.ApplyStarted);
+    }
+
+    [ProtocolIntegrationFact(false, ProtocolIntegrationRequiredFixture.Scene)]
+    public async Task SceneListGetAndResolve_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope();
+
+        var scenes = await _fixture.SceneClient.ListScenesAsync(
+            new HonuaSceneListRequest
+            {
+                Capabilities = [HonuaSceneCapabilities.ThreeDimensionalTiles]
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.Contains(scenes, scene => string.Equals(scene.Id, _fixture.Options.SceneId, StringComparison.OrdinalIgnoreCase));
+
+        var metadata = await _fixture.SceneClient.GetSceneAsync(_fixture.Options.SceneId!, timeout.Token).ConfigureAwait(false);
+        Assert.Equal(_fixture.Options.SceneId, metadata.Id);
+
+        var resolution = await _fixture.SceneClient.ResolveSceneAsync(
+            _fixture.Options.SceneId!,
+            new HonuaSceneResolveRequest
+            {
+                RequiredCapabilities = [HonuaSceneCapabilities.ThreeDimensionalTiles]
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.Equal(_fixture.Options.SceneId, resolution.SceneId);
+        Assert.True(resolution.TilesetUrl is not null || resolution.Endpoints.Count > 0);
+    }
+
+    [ProtocolIntegrationFact(false, ProtocolIntegrationRequiredFixture.Routing)]
+    public async Task RoutingMetadataDirectionsServiceAreaAndClosestFacility_AreReachable()
+    {
+        using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
+
+        var metadata = await _fixture.RoutingClient.GetServiceMetadataAsync(
+            new RouteServiceMetadataRequest
+            {
+                ServiceId = _fixture.Options.RouteServiceId,
+                RouteLayerName = _fixture.Options.RouteLayerName
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.Equal(_fixture.Options.RouteServiceId, metadata.ServiceId);
+
+        var route = await _fixture.RoutingClient.GetDirectionsAsync(
+            new RouteDirectionsRequest
+            {
+                Origin = RoutingLocation.FromLongitudeLatitude(-157.8651, 21.3060, "Start"),
+                Destination = RoutingLocation.FromLongitudeLatitude(-157.8460, 21.3193, "Finish"),
+                Options = new RouteSolveOptions
+                {
+                    ServiceId = _fixture.Options.RouteServiceId,
+                    RouteLayerName = _fixture.Options.RouteLayerName,
+                    ReturnDirections = true,
+                    ReturnRoutes = true
+                }
+            },
+            timeout.Token).ConfigureAwait(false);
+        Assert.NotEmpty(route.Routes);
+
+        if (!string.IsNullOrWhiteSpace(_fixture.Options.ServiceAreaLayerName))
+        {
+            var serviceArea = await _fixture.RoutingClient.GetServiceAreaAsync(
+                new ServiceAreaRequest
+                {
+                    Center = RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Center"),
+                    TravelTime = TimeSpan.FromMinutes(5),
+                    Options = new ServiceAreaOptions
+                    {
+                        ServiceId = _fixture.Options.RouteServiceId,
+                        ServiceAreaLayerName = _fixture.Options.ServiceAreaLayerName
+                    }
+                },
+                timeout.Token).ConfigureAwait(false);
+            Assert.True(serviceArea.RawResponse.ValueKind is not JsonValueKind.Undefined);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_fixture.Options.ClosestFacilityLayerName))
+        {
+            var closest = await _fixture.RoutingClient.FindClosestFacilityAsync(
+                new ClosestFacilityRequest
+                {
+                    Incidents = [RoutingLocation.FromLongitudeLatitude(-157.85, 21.30, "Incident")],
+                    Facilities =
+                    [
+                        RoutingLocation.FromLongitudeLatitude(-157.80, 21.28, "Facility A"),
+                        RoutingLocation.FromLongitudeLatitude(-157.82, 21.31, "Facility B")
+                    ],
+                    Options = new ClosestFacilityOptions
+                    {
+                        ServiceId = _fixture.Options.RouteServiceId,
+                        ClosestFacilityLayerName = _fixture.Options.ClosestFacilityLayerName,
+                        TargetFacilityCount = 1
+                    }
+                },
+                timeout.Token).ConfigureAwait(false);
+            Assert.True(closest.RawResponse.ValueKind is not JsonValueKind.Undefined);
+        }
+    }
+
+    [ProtocolIntegrationFact(false, ProtocolIntegrationRequiredFixture.Realtime)]
+    public Task RealtimeTransport_SubscribeHeartbeatReconnectAndCursorResume_AreReachable()
+        => Task.CompletedTask;
+
+    private static SpecDocumentRequest CreateSpecDocument(string specId) => new()
+    {
+        GrammarVersion = "honua.spec.v1",
+        ProcessFamilyVersion = "honua.process.v1",
+        SpecId = specId,
+        Nodes =
+        [
+            new SpecNodeRequest
+            {
+                Id = "source",
+                Kind = SpecResourceKind.Dataset,
+                SourcePins = new Dictionary<string, string>
+                {
+                    ["service"] = "sdk_integration"
+                },
+                CanonicalFragment = "source:sdk_integration"
+            },
+            new SpecNodeRequest
+            {
+                Id = "summary",
+                Kind = SpecResourceKind.Report,
+                Op = "count",
+                Inputs = new Dictionary<string, string>
+                {
+                    ["input"] = "source"
+                },
+                CanonicalFragment = "summary:count(source)"
+            }
+        ],
+        CacheMode = SpecCacheMode.ReadWrite,
+        MaxConcurrency = 1
+    };
+}


### PR DESCRIPTION
## Summary
- add opt-in Testcontainers protocol integration test project covering Admin, Catalog, Geocoding, gRPC, WFS, FeatureServer, OGC Features, Spec, Scenes, Routing, realtime placeholder, and shared source facade surfaces
- add destructive FeatureServer edit round-trip coverage gated behind HONUA_PROTOCOL_DESTRUCTIVE
- document fixture configuration, coverage matrix, server fixture contract, and CI setup notes

## Validation
- dotnet test tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true

Note: this PR does not add a .github/workflows file because the available GitHub token lacks workflow scope; the docs include the intended opt-in workflow command/configuration.

Closes #139