### PR TITLE
Fix protocol integration review findings

### DIFF
--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationConfigurationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationConfigurationTests.cs
@@ -14,4 +14,50 @@ public sealed class ProtocolIntegrationConfigurationTests
         Assert.DoesNotContain(options.ApiKey ?? "not-present-api-key", options.ToRedactedSummary(), StringComparison.Ordinal);
         Assert.DoesNotContain(options.BearerToken ?? "not-present-bearer-token", options.ToRedactedSummary(), StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Options_IgnoresMalformedOptionalValuesWhenDisabled()
+    {
+        using var environment = new EnvironmentVariableScope(
+            ("HONUA_PROTOCOL_INTEGRATION", null),
+            ("HONUA_PROTOCOL_EXTERNAL_BASE_URL", "not a valid uri"),
+            ("HONUA_PROTOCOL_SERVER_PORT", "not-a-port"),
+            ("HONUA_PROTOCOL_LAYER_ID", "not-an-int"),
+            ("HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE", "not-a-latitude"),
+            ("HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE", "not-a-longitude"));
+
+        var options = ProtocolIntegrationOptions.Load();
+
+        Assert.False(options.Enabled);
+        Assert.Null(options.ExternalBaseUri);
+        Assert.Equal((ushort)8080, options.ServerPort);
+        Assert.Equal(0, options.LayerId);
+        Assert.Null(options.ReverseGeocodeLatitude);
+        Assert.Null(options.ReverseGeocodeLongitude);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly IReadOnlyList<(string Name, string? Value)> _previousValues;
+
+        public EnvironmentVariableScope(params (string Name, string? Value)[] values)
+        {
+            _previousValues = values
+                .Select(value => (value.Name, Environment.GetEnvironmentVariable(value.Name)))
+                .ToArray();
+
+            foreach (var (name, value) in values)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var (name, value) in _previousValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
+    }
 }

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFixture.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationFixture.cs
@@ -97,7 +97,7 @@ public sealed class ProtocolIntegrationFixture : IAsyncLifetime, IDisposable
                 .ForPort(Options.ServerPort)
                 .ForPath(Options.ServerHealthPath)
                 .ForStatusCodeMatching(statusCode => statusCode >= System.Net.HttpStatusCode.OK &&
-                    statusCode < System.Net.HttpStatusCode.InternalServerError)));
+                    statusCode < System.Net.HttpStatusCode.MultipleChoices)));
 
         foreach (var pair in Options.BuildContainerEnvironment())
         {

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationOptions.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/ProtocolIntegrationOptions.cs
@@ -68,35 +68,44 @@ public sealed record ProtocolIntegrationOptions
         ReverseGeocodeLatitude.HasValue &&
         ReverseGeocodeLongitude.HasValue;
 
-    public static ProtocolIntegrationOptions Load() => new()
+    public static ProtocolIntegrationOptions Load()
     {
-        Enabled = ReadBoolean("HONUA_PROTOCOL_INTEGRATION"),
-        ExternalBaseUri = ReadUri("HONUA_PROTOCOL_EXTERNAL_BASE_URL"),
-        ServerImage = ReadString("HONUA_PROTOCOL_SERVER_IMAGE"),
-        ServerPort = ReadUShort("HONUA_PROTOCOL_SERVER_PORT", 8080),
-        ServerScheme = ReadString("HONUA_PROTOCOL_SERVER_SCHEME") ?? "http",
-        ServerHealthPath = ReadString("HONUA_PROTOCOL_SERVER_HEALTH_PATH") ?? "/health",
-        ApiKey = ReadString("HONUA_PROTOCOL_API_KEY"),
-        BearerToken = ReadString("HONUA_PROTOCOL_BEARER_TOKEN"),
-        ServiceName = ReadString("HONUA_PROTOCOL_SERVICE_NAME") ?? "sdk_integration",
-        LayerId = ReadInt("HONUA_PROTOCOL_LAYER_ID", 0),
-        WfsTypeName = ReadString("HONUA_PROTOCOL_WFS_TYPENAME") ?? "public:sdk_integration_points",
-        OgcCollectionId = ReadString("HONUA_PROTOCOL_OGC_COLLECTION_ID") ?? "sdk_integration_points",
-        SceneId = ReadString("HONUA_PROTOCOL_SCENE_ID"),
-        SpecId = ReadString("HONUA_PROTOCOL_SPEC_ID"),
-        RouteServiceId = ReadString("HONUA_PROTOCOL_ROUTE_SERVICE_ID"),
-        RouteLayerName = ReadString("HONUA_PROTOCOL_ROUTE_LAYER"),
-        ServiceAreaLayerName = ReadString("HONUA_PROTOCOL_SERVICE_AREA_LAYER"),
-        ClosestFacilityLayerName = ReadString("HONUA_PROTOCOL_CLOSEST_FACILITY_LAYER"),
-        GeocodeText = ReadString("HONUA_PROTOCOL_GEOCODE_TEXT"),
-        ReverseGeocodeLatitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE"),
-        ReverseGeocodeLongitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE"),
-        DestructiveEnabled = ReadBoolean("HONUA_PROTOCOL_DESTRUCTIVE"),
-        SeedProfile = ReadString("HONUA_PROTOCOL_SEED_PROFILE"),
-        FeatureServerEditAddAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON"),
-        FeatureServerEditUpdateAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON"),
-        FeatureServerEditGeometryJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_GEOMETRY_JSON")
-    };
+        var enabled = ReadBoolean("HONUA_PROTOCOL_INTEGRATION");
+        if (!enabled)
+        {
+            return new ProtocolIntegrationOptions();
+        }
+
+        return new ProtocolIntegrationOptions
+        {
+            Enabled = true,
+            ExternalBaseUri = ReadUri("HONUA_PROTOCOL_EXTERNAL_BASE_URL"),
+            ServerImage = ReadString("HONUA_PROTOCOL_SERVER_IMAGE"),
+            ServerPort = ReadUShort("HONUA_PROTOCOL_SERVER_PORT", 8080),
+            ServerScheme = ReadString("HONUA_PROTOCOL_SERVER_SCHEME") ?? "http",
+            ServerHealthPath = ReadString("HONUA_PROTOCOL_SERVER_HEALTH_PATH") ?? "/health",
+            ApiKey = ReadString("HONUA_PROTOCOL_API_KEY"),
+            BearerToken = ReadString("HONUA_PROTOCOL_BEARER_TOKEN"),
+            ServiceName = ReadString("HONUA_PROTOCOL_SERVICE_NAME") ?? "sdk_integration",
+            LayerId = ReadInt("HONUA_PROTOCOL_LAYER_ID", 0),
+            WfsTypeName = ReadString("HONUA_PROTOCOL_WFS_TYPENAME") ?? "public:sdk_integration_points",
+            OgcCollectionId = ReadString("HONUA_PROTOCOL_OGC_COLLECTION_ID") ?? "sdk_integration_points",
+            SceneId = ReadString("HONUA_PROTOCOL_SCENE_ID"),
+            SpecId = ReadString("HONUA_PROTOCOL_SPEC_ID"),
+            RouteServiceId = ReadString("HONUA_PROTOCOL_ROUTE_SERVICE_ID"),
+            RouteLayerName = ReadString("HONUA_PROTOCOL_ROUTE_LAYER"),
+            ServiceAreaLayerName = ReadString("HONUA_PROTOCOL_SERVICE_AREA_LAYER"),
+            ClosestFacilityLayerName = ReadString("HONUA_PROTOCOL_CLOSEST_FACILITY_LAYER"),
+            GeocodeText = ReadString("HONUA_PROTOCOL_GEOCODE_TEXT"),
+            ReverseGeocodeLatitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LATITUDE"),
+            ReverseGeocodeLongitude = ReadDouble("HONUA_PROTOCOL_REVERSE_GEOCODE_LONGITUDE"),
+            DestructiveEnabled = ReadBoolean("HONUA_PROTOCOL_DESTRUCTIVE"),
+            SeedProfile = ReadString("HONUA_PROTOCOL_SEED_PROFILE"),
+            FeatureServerEditAddAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_ADD_ATTRIBUTES_JSON"),
+            FeatureServerEditUpdateAttributesJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_UPDATE_ATTRIBUTES_JSON"),
+            FeatureServerEditGeometryJson = ReadString("HONUA_PROTOCOL_FEATURESERVER_EDIT_GEOMETRY_JSON")
+        };
+    }
 
     public static string? GetSkipReason(bool destructive = false)
     {

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/SpecSceneRoutingProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/SpecSceneRoutingProtocolIntegrationTests.cs
@@ -15,7 +15,7 @@ public sealed class SpecSceneRoutingProtocolIntegrationTests(ProtocolIntegration
     public async Task SpecValidatePlanAndApplyStream_AreReachable()
     {
         using var timeout = _fixture.CreateTimeoutScope(TimeSpan.FromSeconds(90));
-        var document = CreateSpecDocument(_fixture.Options.SpecId!);
+        var document = CreateSpecDocument(_fixture.Options.SpecId!, _fixture.Options.ServiceName);
 
         var validation = await _fixture.SpecClient.ValidateAsync(
             new SpecValidateRequest
@@ -148,7 +148,7 @@ public sealed class SpecSceneRoutingProtocolIntegrationTests(ProtocolIntegration
     public Task RealtimeTransport_SubscribeHeartbeatReconnectAndCursorResume_AreReachable()
         => Task.CompletedTask;
 
-    private static SpecDocumentRequest CreateSpecDocument(string specId) => new()
+    private static SpecDocumentRequest CreateSpecDocument(string specId, string serviceName) => new()
     {
         GrammarVersion = "honua.spec.v1",
         ProcessFamilyVersion = "honua.process.v1",
@@ -161,9 +161,9 @@ public sealed class SpecSceneRoutingProtocolIntegrationTests(ProtocolIntegration
                 Kind = SpecResourceKind.Dataset,
                 SourcePins = new Dictionary<string, string>
                 {
-                    ["service"] = "sdk_integration"
+                    ["service"] = serviceName
                 },
-                CanonicalFragment = "source:sdk_integration"
+                CanonicalFragment = $"source:{serviceName}"
             },
             new SpecNodeRequest
             {


### PR DESCRIPTION
## Summary
- use the configured protocol service name when constructing Spec integration documents
- require 2xx health responses before treating Testcontainers servers as ready
- avoid parsing optional typed HONUA_PROTOCOL_* values while the opt-in suite is disabled
- add regression coverage for malformed disabled-mode environment values

## Validation
- dotnet test tests/Honua.Sdk.ProtocolIntegration.Tests/Honua.Sdk.ProtocolIntegration.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true