### PR TITLE
Align source contract registries with shared fixture

### DIFF
--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -60,26 +60,42 @@ existing provider-name aliases and normalizes them to canonical IDs:
 
 | Canonical ID | Common aliases |
 | --- | --- |
-| `grpc` | `grpc` |
 | `geoservices-feature-service` | `geoservices-featureserver`, `featureserver`, `FeatureServer` |
-| `ogc-features` | `ogc-api-features`, `ogcapi-features`, `OgcFeatures` |
-| `wfs` | `wfs` |
+| `geoservices-map-service` | `map-server`, `mapserver` |
+| `geoservices-image-service` | `image-server`, `imageserver` |
+| `geoservices-geometry-service` | `geometry-server`, `geometryserver` |
+| `geoservices-gp-service` | `gp-server`, `gpserver` |
+| `ogc-features` | `ogc-api-features`, `ogcapi-features`, `ogc_features`, `OgcFeatures` |
+| `ogc-tiles` | `ogc-tiles` |
+| `ogc-maps` | `ogc-maps` |
+| `stac` | `stac` |
+| `wfs` | `wfs`, `wfs-2.0` |
+| `wms` | `wms`, `wms-1.3.0` |
+| `wmts` | `wmts`, `wmts-1.0.0` |
+| `odata` | `odata`, `odata-v4` |
+| `maplibre-vector` | `maplibre-vector` |
+| `maplibre-raster` | `maplibre-raster` |
+| `maplibre-geojson` | `maplibre-geojson` |
 
 Call `FeatureProtocolIds.Normalize()` or `FeatureProtocolIds.Matches()` when
-persisted descriptors may contain older provider names.
+persisted descriptors may contain older provider names. The .NET gRPC client
+continues to use `grpc` as a transport/provider identifier, but it is not part of
+the cross-SDK canonical protocol registry.
 
 ## Capabilities
 
 Use `FeatureCapabilities` for shared capability identifiers. The .NET facade
-advertises query, statistics, extent, query-object-IDs, time-filter, spatial
-relationship, stream/page iteration, edit, attachment, relationship, and offline
-capabilities where the wrapped client or discovered metadata supports them.
-`FeatureProtocolCapabilities` contains protocol defaults and helpers for
-union/intersection when a caller is building a multi-source view.
+advertises the cross-SDK capability vocabulary: query, aggregate query, spatial
+aggregate, extent, query-object-IDs, related records, edits, attachments, render,
+tiles, SQL, stream/page iteration, PBF, connect, image, geometry, geoprocess, and
+processes. Query facets such as `SourceQuery.TimeFilter` and spatial
+relationships remain modeled on the query request instead of being exported as
+shared capability IDs. `FeatureProtocolCapabilities` contains protocol defaults
+and helpers for union/intersection when a caller is building a multi-source view.
 
 `HonuaSource` intersects declared descriptor capabilities with runtime client
-capabilities. For example, WFS can still be described as queryable while
-`ApplyEditsAsync()` throws a clear `NotSupportedException` until WFS-T is
+capabilities. For example, the shared WFS default includes `applyEdits`, while
+the current .NET WFS descriptor discovery removes that capability until WFS-T is
 implemented.
 
 ## Native Escape Hatch

--- a/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureCapabilities.cs
@@ -14,16 +14,19 @@ public static class FeatureCapabilities
     /// <summary>Aggregate query support.</summary>
     public const string QueryAggregate = "queryAggregate";
 
+    /// <summary>Indexed spatial aggregation support.</summary>
+    public const string SpatialAggregate = "spatialAggregate";
+
     /// <summary>Extent-only query support.</summary>
     public const string QueryExtent = "queryExtent";
 
     /// <summary>Object or feature ID query support.</summary>
     public const string QueryObjectIds = "queryObjectIds";
 
-    /// <summary>Temporal query filter support.</summary>
+    /// <summary>Temporal query filter support. This is a .NET query-facet extension, not part of the shared capability registry.</summary>
     public const string TimeFilter = "timeFilter";
 
-    /// <summary>Spatial relationship query support.</summary>
+    /// <summary>Spatial relationship query support. This is a .NET query-facet extension, not part of the shared capability registry.</summary>
     public const string SpatialRelationships = "spatialRelationships";
 
     /// <summary>Related-record query support.</summary>
@@ -65,7 +68,7 @@ public static class FeatureCapabilities
     /// <summary>OGC API Processes support.</summary>
     public const string Processes = "processes";
 
-    /// <summary>Offline replica or sync support.</summary>
+    /// <summary>Offline replica or sync support. This is a .NET extension, not part of the shared capability registry.</summary>
     public const string Offline = "offline";
 
     /// <summary>All canonical capability identifiers supported by the shared vocabulary.</summary>
@@ -73,10 +76,9 @@ public static class FeatureCapabilities
     [
         Query,
         QueryAggregate,
+        SpatialAggregate,
         QueryExtent,
         QueryObjectIds,
-        TimeFilter,
-        SpatialRelationships,
         QueryRelated,
         ApplyEdits,
         Attachments,
@@ -89,9 +91,26 @@ public static class FeatureCapabilities
         Image,
         Geometry,
         Geoprocess,
-        Processes,
-        Offline
+        Processes
     ];
+
+    private static readonly Dictionary<string, string> CanonicalIds =
+        All.ToDictionary(BuildKey, capability => capability, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Normalizes a capability identifier to the shared canonical spelling when recognized.
+    /// </summary>
+    /// <param name="capability">Capability identifier.</param>
+    /// <returns>The canonical capability identifier, or the original value when unknown.</returns>
+    public static string Normalize(string capability)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(capability);
+
+        var key = BuildKey(capability);
+        return CanonicalIds.TryGetValue(key, out var canonical)
+            ? canonical
+            : capability;
+    }
 
     /// <summary>
     /// Returns whether a capability collection contains the requested canonical capability.
@@ -106,6 +125,12 @@ public static class FeatureCapabilities
         ArgumentNullException.ThrowIfNull(capabilities);
         ArgumentException.ThrowIfNullOrWhiteSpace(capability);
 
-        return capabilities.Any(value => string.Equals(value, capability, StringComparison.Ordinal));
+        var canonical = Normalize(capability);
+        return capabilities
+            .Select(Normalize)
+            .Any(value => string.Equals(value, canonical, StringComparison.Ordinal));
     }
+
+    private static string BuildKey(string capability)
+        => string.Concat(capability.Trim().ToUpperInvariant().Where(char.IsLetterOrDigit));
 }

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolCapabilities.cs
@@ -17,7 +17,6 @@ public static class FeatureProtocolCapabilities
                 FeatureCapabilities.QueryAggregate,
                 FeatureCapabilities.QueryExtent,
                 FeatureCapabilities.QueryObjectIds,
-                FeatureCapabilities.SpatialRelationships,
                 FeatureCapabilities.ApplyEdits,
                 FeatureCapabilities.Stream
             ],
@@ -27,23 +26,107 @@ public static class FeatureProtocolCapabilities
                 FeatureCapabilities.QueryAggregate,
                 FeatureCapabilities.QueryExtent,
                 FeatureCapabilities.QueryObjectIds,
-                FeatureCapabilities.TimeFilter,
-                FeatureCapabilities.SpatialRelationships,
+                FeatureCapabilities.QueryRelated,
                 FeatureCapabilities.ApplyEdits,
+                FeatureCapabilities.Attachments,
+                FeatureCapabilities.Sql,
+                FeatureCapabilities.Stream,
+                FeatureCapabilities.Pbf,
+                FeatureCapabilities.Connect
+            ],
+            [FeatureProtocolIds.GeoServicesMapService] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryAggregate,
+                FeatureCapabilities.QueryExtent,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.QueryRelated,
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles,
+                FeatureCapabilities.Sql,
                 FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.GeoServicesImageService] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryExtent,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.Image,
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles,
+                FeatureCapabilities.Connect
+            ],
+            [FeatureProtocolIds.GeoServicesGeometryService] =
+            [
+                FeatureCapabilities.Geometry,
+                FeatureCapabilities.Connect
+            ],
+            [FeatureProtocolIds.GeoServicesGpService] =
+            [
+                FeatureCapabilities.Geoprocess,
+                FeatureCapabilities.Connect
             ],
             [FeatureProtocolIds.OgcFeatures] =
             [
                 FeatureCapabilities.Query,
                 FeatureCapabilities.QueryObjectIds,
-                FeatureCapabilities.TimeFilter,
+                FeatureCapabilities.ApplyEdits,
+                FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.OgcTiles] =
+            [
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles
+            ],
+            [FeatureProtocolIds.OgcMaps] =
+            [
+                FeatureCapabilities.Render
+            ],
+            [FeatureProtocolIds.Stac] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
                 FeatureCapabilities.Stream
             ],
             [FeatureProtocolIds.Wfs] =
             [
                 FeatureCapabilities.Query,
+                FeatureCapabilities.QueryExtent,
                 FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.ApplyEdits,
                 FeatureCapabilities.Stream
+            ],
+            [FeatureProtocolIds.Wms] =
+            [
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles,
+                FeatureCapabilities.Query
+            ],
+            [FeatureProtocolIds.Wmts] =
+            [
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles
+            ],
+            [FeatureProtocolIds.OData] =
+            [
+                FeatureCapabilities.Query,
+                FeatureCapabilities.QueryObjectIds,
+                FeatureCapabilities.Stream,
+                FeatureCapabilities.ApplyEdits
+            ],
+            [FeatureProtocolIds.MapLibreVector] =
+            [
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles
+            ],
+            [FeatureProtocolIds.MapLibreRaster] =
+            [
+                FeatureCapabilities.Render,
+                FeatureCapabilities.Tiles
+            ],
+            [FeatureProtocolIds.MapLibreGeoJson] =
+            [
+                FeatureCapabilities.Render
             ]
         };
 
@@ -73,10 +156,12 @@ public static class FeatureProtocolCapabilities
             return [];
         }
 
-        var result = new HashSet<string>(participants[0], StringComparer.Ordinal);
+        var result = new HashSet<string>(
+            participants[0].Select(FeatureCapabilities.Normalize),
+            StringComparer.Ordinal);
         foreach (var participant in participants.Skip(1))
         {
-            result.IntersectWith(participant);
+            result.IntersectWith(participant.Select(FeatureCapabilities.Normalize));
         }
 
         return FeatureCapabilities.All.Where(result.Contains).ToList();
@@ -94,7 +179,7 @@ public static class FeatureProtocolCapabilities
         var result = new HashSet<string>(StringComparer.Ordinal);
         foreach (var participant in participants)
         {
-            result.UnionWith(participant);
+            result.UnionWith(participant.Select(FeatureCapabilities.Normalize));
         }
 
         return FeatureCapabilities.All.Where(result.Contains).ToList();

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
@@ -8,11 +8,23 @@ namespace Honua.Sdk.Abstractions.Features;
 /// </summary>
 public static class FeatureProtocolIds
 {
-    /// <summary>.NET gRPC FeatureService client protocol identifier.</summary>
+    /// <summary>.NET gRPC FeatureService transport identifier.</summary>
     public const string Grpc = "grpc";
 
     /// <summary>Canonical GeoServices Feature Service protocol identifier.</summary>
     public const string GeoServicesFeatureService = "geoservices-feature-service";
+
+    /// <summary>Canonical GeoServices Map Service protocol identifier.</summary>
+    public const string GeoServicesMapService = "geoservices-map-service";
+
+    /// <summary>Canonical GeoServices Image Service protocol identifier.</summary>
+    public const string GeoServicesImageService = "geoservices-image-service";
+
+    /// <summary>Canonical GeoServices Geometry Service protocol identifier.</summary>
+    public const string GeoServicesGeometryService = "geoservices-geometry-service";
+
+    /// <summary>Canonical GeoServices geoprocessing service protocol identifier.</summary>
+    public const string GeoServicesGpService = "geoservices-gp-service";
 
     /// <summary>Existing .NET GeoServices FeatureServer provider name alias.</summary>
     public const string GeoServicesFeatureServer = "geoservices-featureserver";
@@ -20,8 +32,35 @@ public static class FeatureProtocolIds
     /// <summary>OGC API Features protocol identifier.</summary>
     public const string OgcFeatures = "ogc-features";
 
+    /// <summary>OGC API Tiles protocol identifier.</summary>
+    public const string OgcTiles = "ogc-tiles";
+
+    /// <summary>OGC API Maps protocol identifier.</summary>
+    public const string OgcMaps = "ogc-maps";
+
+    /// <summary>STAC API protocol identifier.</summary>
+    public const string Stac = "stac";
+
     /// <summary>WFS protocol identifier.</summary>
     public const string Wfs = "wfs";
+
+    /// <summary>WMS protocol identifier.</summary>
+    public const string Wms = "wms";
+
+    /// <summary>WMTS protocol identifier.</summary>
+    public const string Wmts = "wmts";
+
+    /// <summary>OData protocol identifier.</summary>
+    public const string OData = "odata";
+
+    /// <summary>MapLibre vector source protocol identifier.</summary>
+    public const string MapLibreVector = "maplibre-vector";
+
+    /// <summary>MapLibre raster source protocol identifier.</summary>
+    public const string MapLibreRaster = "maplibre-raster";
+
+    /// <summary>MapLibre GeoJSON source protocol identifier.</summary>
+    public const string MapLibreGeoJson = "maplibre-geojson";
 
     private static readonly Dictionary<string, string> CanonicalIds =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -33,11 +72,37 @@ public static class FeatureProtocolIds
             ["feature-server"] = GeoServicesFeatureService,
             ["feature-service"] = GeoServicesFeatureService,
             ["geoservices-feature-server"] = GeoServicesFeatureService,
+            [GeoServicesMapService] = GeoServicesMapService,
+            ["map-server"] = GeoServicesMapService,
+            ["mapserver"] = GeoServicesMapService,
+            [GeoServicesImageService] = GeoServicesImageService,
+            ["image-server"] = GeoServicesImageService,
+            ["imageserver"] = GeoServicesImageService,
+            [GeoServicesGeometryService] = GeoServicesGeometryService,
+            ["geometry-server"] = GeoServicesGeometryService,
+            ["geometryserver"] = GeoServicesGeometryService,
+            [GeoServicesGpService] = GeoServicesGpService,
+            ["gp-server"] = GeoServicesGpService,
+            ["gpserver"] = GeoServicesGpService,
             [OgcFeatures] = OgcFeatures,
             ["ogcapi-features"] = OgcFeatures,
             ["ogc-api-features"] = OgcFeatures,
+            ["ogc_features"] = OgcFeatures,
             ["OgcFeatures"] = OgcFeatures,
-            [Wfs] = Wfs
+            [OgcTiles] = OgcTiles,
+            [OgcMaps] = OgcMaps,
+            [Stac] = Stac,
+            [Wfs] = Wfs,
+            ["wfs-2.0"] = Wfs,
+            [Wms] = Wms,
+            ["wms-1.3.0"] = Wms,
+            [Wmts] = Wmts,
+            ["wmts-1.0.0"] = Wmts,
+            [OData] = OData,
+            ["odata-v4"] = OData,
+            [MapLibreVector] = MapLibreVector,
+            [MapLibreRaster] = MapLibreRaster,
+            [MapLibreGeoJson] = MapLibreGeoJson
         };
 
     private static readonly Dictionary<string, IReadOnlyList<string>> AliasMap =
@@ -54,23 +119,54 @@ public static class FeatureProtocolIds
                 "FeatureServer",
                 "geoservices-feature-server"
             ],
+            [GeoServicesMapService] = [GeoServicesMapService, "map-server", "mapserver"],
+            [GeoServicesImageService] = [GeoServicesImageService, "image-server", "imageserver"],
+            [GeoServicesGeometryService] =
+            [
+                GeoServicesGeometryService,
+                "geometry-server",
+                "geometryserver"
+            ],
+            [GeoServicesGpService] = [GeoServicesGpService, "gp-server", "gpserver"],
             [OgcFeatures] =
             [
                 OgcFeatures,
                 "ogcapi-features",
                 "ogc-api-features",
+                "ogc_features",
                 "OgcFeatures"
             ],
-            [Wfs] = [Wfs]
+            [OgcTiles] = [OgcTiles],
+            [OgcMaps] = [OgcMaps],
+            [Stac] = [Stac],
+            [Wfs] = [Wfs, "wfs-2.0"],
+            [Wms] = [Wms, "wms-1.3.0"],
+            [Wmts] = [Wmts, "wmts-1.0.0"],
+            [OData] = [OData, "odata-v4"],
+            [MapLibreVector] = [MapLibreVector],
+            [MapLibreRaster] = [MapLibreRaster],
+            [MapLibreGeoJson] = [MapLibreGeoJson]
         };
 
-    /// <summary>Canonical protocol identifiers currently backed by .NET feature clients.</summary>
+    /// <summary>Canonical protocol identifiers shared across Honua SDKs.</summary>
     public static IReadOnlyList<string> All { get; } =
     [
-        Grpc,
         GeoServicesFeatureService,
+        GeoServicesMapService,
+        GeoServicesImageService,
+        GeoServicesGeometryService,
+        GeoServicesGpService,
         OgcFeatures,
-        Wfs
+        OgcTiles,
+        OgcMaps,
+        Stac,
+        Wfs,
+        Wms,
+        Wmts,
+        OData,
+        MapLibreVector,
+        MapLibreRaster,
+        MapLibreGeoJson
     ];
 
     /// <summary>

--- a/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
+++ b/src/Honua.Sdk.Abstractions/Features/HonuaSource.cs
@@ -237,7 +237,8 @@ public sealed class HonuaSource : IHonuaSource
         var declared = descriptor.Capabilities.Count > 0
             ? descriptor.Capabilities
             : FeatureProtocolCapabilities.DefaultsFor(descriptor.Protocol);
-        var capabilities = new HashSet<string>(declared, StringComparer.Ordinal);
+        var normalizedDeclared = declared.Select(FeatureCapabilities.Normalize).ToList();
+        var capabilities = new HashSet<string>(normalizedDeclared, StringComparer.Ordinal);
 
         if (!SupportsQueryProtocol(descriptor, queryClient))
         {
@@ -253,7 +254,7 @@ public sealed class HonuaSource : IHonuaSource
              editCapabilities.SupportsPatches ||
              editCapabilities.SupportsDeletes))
         {
-            if (declared.Contains(FeatureCapabilities.ApplyEdits, StringComparer.Ordinal) || descriptor.Capabilities.Count == 0)
+            if (FeatureCapabilities.Contains(normalizedDeclared, FeatureCapabilities.ApplyEdits) || descriptor.Capabilities.Count == 0)
             {
                 capabilities.Add(FeatureCapabilities.ApplyEdits);
             }

--- a/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.Wfs/HonuaWfsClient.cs
@@ -522,9 +522,16 @@ public sealed class HonuaWfsClient :
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
 
     private static List<string> BuildDiscoveredCapabilities()
-        => FeatureCapabilities.All
-            .Where(FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Wfs).Contains)
+    {
+        var capabilities = new HashSet<string>(
+            FeatureProtocolCapabilities.DefaultsFor(FeatureProtocolIds.Wfs),
+            StringComparer.Ordinal);
+        capabilities.Remove(FeatureCapabilities.ApplyEdits);
+
+        return FeatureCapabilities.All
+            .Where(capabilities.Contains)
             .ToList();
+    }
 
     private static SourceSchema BuildSourceSchema(WfsFeatureType? featureType, WfsFeatureTypeSchema schema)
     {

--- a/tests/Honua.Sdk.Abstractions.Tests/Fixtures/sdk-contract/semantic-contract.v1.json
+++ b/tests/Honua.Sdk.Abstractions.Tests/Fixtures/sdk-contract/semantic-contract.v1.json
@@ -1,0 +1,655 @@
+{
+  "schemaVersion": 1,
+  "status": "draft",
+  "tracker": "https://github.com/honua-io/honua-sdk-js/issues/44",
+  "description": "Cross-SDK semantic fixture pack for Honua Dataset/Source/Query/Result behavior. Language bindings may use idiomatic names and casing.",
+  "canonicalNouns": [
+    "Dataset",
+    "SourceDescriptor",
+    "Source",
+    "Protocol",
+    "Capability",
+    "Query",
+    "Result",
+    "EditEnvelope",
+    "EditResult",
+    "MapBinding"
+  ],
+  "languageBindings": [
+    {
+      "concept": "queryAll",
+      "typescript": "queryAll()",
+      "python": "query_all()",
+      "dotnet": "QueryAllAsync()"
+    },
+    {
+      "concept": "stream",
+      "typescript": "stream()",
+      "python": "stream() or iter_*()",
+      "dotnet": "StreamAsync() or QueryPagesAsync()"
+    },
+    {
+      "concept": "queryObjectIds",
+      "typescript": "queryObjectIds()",
+      "python": "query_object_ids()",
+      "dotnet": "QueryObjectIdsAsync()"
+    },
+    {
+      "concept": "applyEdits",
+      "typescript": "applyEdits()",
+      "python": "apply_edits()",
+      "dotnet": "ApplyEditsAsync()"
+    },
+    {
+      "concept": "returnGeometry",
+      "typescript": "returnGeometry",
+      "python": "return_geometry",
+      "dotnet": "ReturnGeometry"
+    },
+    {
+      "concept": "outFields",
+      "typescript": "outFields",
+      "python": "out_fields",
+      "dotnet": "OutFields"
+    },
+    {
+      "concept": "protocolEscapeHatch",
+      "typescript": "source.protocol(...)",
+      "python": "source.protocol(...)",
+      "dotnet": "source.Protocol(...)"
+    }
+  ],
+  "protocols": [
+    "geoservices-feature-service",
+    "geoservices-map-service",
+    "geoservices-image-service",
+    "geoservices-geometry-service",
+    "geoservices-gp-service",
+    "ogc-features",
+    "ogc-tiles",
+    "ogc-maps",
+    "stac",
+    "wfs",
+    "wms",
+    "wmts",
+    "odata",
+    "maplibre-vector",
+    "maplibre-raster",
+    "maplibre-geojson"
+  ],
+  "protocolAliases": {
+    "feature-server": "geoservices-feature-service",
+    "featureserver": "geoservices-feature-service",
+    "feature-service": "geoservices-feature-service",
+    "geoservices-featureserver": "geoservices-feature-service",
+    "map-server": "geoservices-map-service",
+    "mapserver": "geoservices-map-service",
+    "image-server": "geoservices-image-service",
+    "imageserver": "geoservices-image-service",
+    "geometry-server": "geoservices-geometry-service",
+    "geometryserver": "geoservices-geometry-service",
+    "gp-server": "geoservices-gp-service",
+    "gpserver": "geoservices-gp-service",
+    "ogc-api-features": "ogc-features",
+    "ogc_features": "ogc-features",
+    "odata-v4": "odata",
+    "wfs-2.0": "wfs",
+    "wms-1.3.0": "wms",
+    "wmts-1.0.0": "wmts"
+  },
+  "capabilities": [
+    "query",
+    "queryAggregate",
+    "spatialAggregate",
+    "queryExtent",
+    "queryObjectIds",
+    "queryRelated",
+    "applyEdits",
+    "attachments",
+    "render",
+    "tiles",
+    "sql",
+    "stream",
+    "pbf",
+    "connect",
+    "image",
+    "geometry",
+    "geoprocess",
+    "processes"
+  ],
+  "defaultCapabilities": {
+    "geoservices-feature-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "applyEdits",
+      "attachments",
+      "sql",
+      "stream",
+      "pbf",
+      "connect"
+    ],
+    "geoservices-map-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "render",
+      "tiles",
+      "sql",
+      "stream"
+    ],
+    "geoservices-image-service": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "image",
+      "render",
+      "tiles",
+      "connect"
+    ],
+    "geoservices-geometry-service": [
+      "geometry",
+      "connect"
+    ],
+    "geoservices-gp-service": [
+      "geoprocess",
+      "connect"
+    ],
+    "ogc-features": [
+      "query",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "ogc-tiles": [
+      "render",
+      "tiles"
+    ],
+    "ogc-maps": [
+      "render"
+    ],
+    "stac": [
+      "query",
+      "queryObjectIds",
+      "stream"
+    ],
+    "wfs": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "wms": [
+      "render",
+      "tiles",
+      "query"
+    ],
+    "wmts": [
+      "render",
+      "tiles"
+    ],
+    "odata": [
+      "query",
+      "queryObjectIds",
+      "stream",
+      "applyEdits"
+    ],
+    "maplibre-vector": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-raster": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-geojson": [
+      "render"
+    ]
+  },
+  "resultScenarios": [
+    {
+      "id": "featureserver-page",
+      "protocol": "geoservices-feature-service",
+      "sourceDescriptor": {
+        "id": "parcels-fs",
+        "protocol": "geoservices-feature-service",
+        "locator": {
+          "serviceId": "Parcels",
+          "layerId": 0
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "OBJECTID",
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true,
+        "outSr": 4326
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1,
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.836,
+              "y": 21.284
+            }
+          },
+          {
+            "id": 2,
+            "attributes": {
+              "OBJECTID": 2,
+              "NAME": "Kapiolani",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.82,
+              "y": 21.267
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 2,
+        "fields": [
+          {
+            "name": "OBJECTID",
+            "type": "oid"
+          },
+          {
+            "name": "NAME",
+            "type": "string"
+          },
+          {
+            "name": "STATUS",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ogc-features-page",
+      "protocol": "ogc-features",
+      "sourceDescriptor": {
+        "id": "parcels-ogc",
+        "protocol": "ogc-features",
+        "locator": {
+          "collectionId": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "ogc-1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "stac-search-page",
+      "protocol": "stac",
+      "sourceDescriptor": {
+        "id": "imagery-stac",
+        "protocol": "stac",
+        "locator": {
+          "collectionId": "imagery"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "eo:cloud_cover < 10",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "scene-001",
+            "attributes": {
+              "collection": "imagery",
+              "eo:cloud_cover": 4.2
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -158,
+                    21
+                  ],
+                  [
+                    -157,
+                    21
+                  ],
+                  [
+                    -157,
+                    22
+                  ],
+                  [
+                    -158,
+                    22
+                  ],
+                  [
+                    -158,
+                    21
+                  ]
+                ]
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "odata-page",
+      "protocol": "odata",
+      "sourceDescriptor": {
+        "id": "features-odata",
+        "protocol": "odata",
+        "locator": {
+          "entitySet": "Features"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream",
+          "applyEdits"
+        ]
+      },
+      "query": {
+        "where": "Status eq 'ACTIVE'",
+        "outFields": [
+          "ObjectId",
+          "Name",
+          "Status"
+        ],
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": 42,
+            "attributes": {
+              "ObjectId": 42,
+              "Name": "Ala Wai",
+              "Status": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "wfs-geojson-page",
+      "protocol": "wfs",
+      "sourceDescriptor": {
+        "id": "parcels-wfs",
+        "protocol": "wfs",
+        "locator": {
+          "typeName": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "parcels.1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "empty-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 0",
+        "pagination": {
+          "limit": 10
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "totalCount": 0
+      }
+    },
+    {
+      "id": "exceeded-transfer-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 1",
+        "pagination": {
+          "limit": 1
+        }
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1
+            },
+            "geometry": null
+          }
+        ],
+        "exceededTransferLimit": true,
+        "totalCount": 2
+      }
+    },
+    {
+      "id": "ogc-features-aggregate-degraded",
+      "protocol": "ogc-features",
+      "operation": "queryAggregate",
+      "query": {
+        "aggregation": {
+          "groupBy": [
+            "STATUS"
+          ],
+          "metrics": [
+            {
+              "fn": "count",
+              "field": "OBJECTID",
+              "alias": "COUNT_OBJECTID"
+            }
+          ]
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "aggregateRows": [
+          {
+            "STATUS": "ACTIVE",
+            "COUNT_OBJECTID": 2
+          }
+        ],
+        "degraded": [
+          {
+            "capability": "queryAggregate",
+            "protocol": "ogc-features",
+            "sourceId": "parcels-ogc",
+            "reason": "Server-side aggregation is unavailable; result was computed client-side over drained pages."
+          }
+        ]
+      }
+    }
+  ],
+  "unsupportedCapabilityScenarios": [
+    {
+      "id": "wmts-query-unsupported",
+      "protocol": "wmts",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "WMTS is render-only; tile pixels do not project onto the canonical Query.spatialFilter envelope.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "wmts"
+      }
+    },
+    {
+      "id": "ogc-tiles-query-unsupported",
+      "protocol": "ogc-tiles",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "OGC API Tiles is a render-only conformance class; feature query is not part of the surface.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "ogc-tiles"
+      }
+    },
+    {
+      "id": "ogc-tiles-apply-edits-unsupported",
+      "protocol": "ogc-tiles",
+      "operation": "applyEdits",
+      "requiredCapability": "applyEdits",
+      "reason": "Render-only adapters do not accept edits; mixed-source apps must surface the limitation explicitly.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "applyEdits",
+        "protocol": "ogc-tiles"
+      }
+    },
+    {
+      "id": "ogc-maps-query-unsupported",
+      "protocol": "ogc-maps",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "OGC API Maps is render-only; the canonical Query family throws rather than silently returning empty.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "ogc-maps"
+      }
+    },
+    {
+      "id": "geometry-service-query-unsupported",
+      "protocol": "geoservices-geometry-service",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "Geometry Service is a stateless utility — it hosts no feature table. Operations live behind Source.protocol().",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "geoservices-geometry-service"
+      }
+    },
+    {
+      "id": "gp-service-query-unsupported",
+      "protocol": "geoservices-gp-service",
+      "operation": "query",
+      "requiredCapability": "query",
+      "reason": "GP Service runs async tasks rather than hosting features. Job lifecycle lives behind Source.protocol().",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "geoservices-gp-service"
+      }
+    },
+    {
+      "id": "ogc-features-related-unsupported",
+      "protocol": "ogc-features",
+      "operation": "queryRelated",
+      "requiredCapability": "queryRelated",
+      "reason": "OGC API Features does not model related records; queryRelated must throw rather than silently return an empty group.",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "queryRelated",
+        "protocol": "ogc-features"
+      }
+    }
+  ]
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
+++ b/tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj
@@ -20,4 +20,8 @@
     <ProjectReference Include="..\..\src\Honua.Sdk.Offline.Abstractions\Honua.Sdk.Offline.Abstractions.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Fixtures\sdk-contract\semantic-contract.v1.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Honua.Sdk.Abstractions.Tests/SharedSemanticContractFixtureTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SharedSemanticContractFixtureTests.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+#pragma warning disable CA1812 // Fixture DTOs are instantiated by System.Text.Json.
+
+public sealed class SharedSemanticContractFixtureTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static readonly Lazy<ContractFixture> Fixture = new(() =>
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory,
+            "Fixtures",
+            "sdk-contract",
+            "semantic-contract.v1.json");
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<ContractFixture>(json, JsonOptions)
+               ?? throw new InvalidOperationException("Unable to deserialize shared SDK semantic contract fixture.");
+    });
+
+    [Fact]
+    public void ProtocolRegistry_MatchesSharedFixture()
+    {
+        Assert.Equal(1, Fixture.Value.SchemaVersion);
+        Assert.Equal(Fixture.Value.Protocols, FeatureProtocolIds.All);
+    }
+
+    [Fact]
+    public void CapabilityRegistry_MatchesSharedFixture()
+    {
+        Assert.Equal(Fixture.Value.Capabilities, FeatureCapabilities.All);
+    }
+
+    [Fact]
+    public void DefaultCapabilitySets_MatchSharedFixture()
+    {
+        Assert.Equal(Fixture.Value.Protocols, Fixture.Value.DefaultCapabilities.Keys);
+
+        foreach (var protocol in Fixture.Value.Protocols)
+        {
+            Assert.Equal(
+                Fixture.Value.DefaultCapabilities[protocol],
+                FeatureProtocolCapabilities.DefaultsFor(protocol));
+        }
+    }
+
+    [Fact]
+    public void ProtocolAliases_NormalizeToSharedCanonicalIds()
+    {
+        foreach (var (alias, canonical) in Fixture.Value.ProtocolAliases)
+        {
+            Assert.NotEqual(alias, canonical);
+            Assert.Contains(canonical, FeatureProtocolIds.All);
+            Assert.Equal(canonical, FeatureProtocolIds.Normalize(alias));
+            Assert.True(FeatureProtocolIds.Matches(alias, canonical));
+        }
+    }
+
+    [Fact]
+    public void LanguageBindings_DocumentDotNetFacadeNames()
+    {
+        var bindings = Fixture.Value.LanguageBindings.ToDictionary(binding => binding.Concept);
+
+        Assert.Equal("QueryAllAsync()", bindings["queryAll"].Dotnet);
+        Assert.Equal("QueryPagesAsync()", bindings["stream"].Dotnet.Split(" or ")[^1]);
+        Assert.Equal("QueryObjectIdsAsync()", bindings["queryObjectIds"].Dotnet);
+        Assert.Equal("ApplyEditsAsync()", bindings["applyEdits"].Dotnet);
+        Assert.Equal("ReturnGeometry", bindings["returnGeometry"].Dotnet);
+        Assert.Equal("OutFields", bindings["outFields"].Dotnet);
+        Assert.Equal("source.Protocol(...)", bindings["protocolEscapeHatch"].Dotnet);
+    }
+
+    [Fact]
+    public void ResultScenarios_ReferenceKnownProtocolsAndCapabilities()
+    {
+        var protocolsWithResults = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var scenario in Fixture.Value.ResultScenarios)
+        {
+            protocolsWithResults.Add(scenario.Protocol);
+            Assert.Contains(scenario.Protocol, FeatureProtocolIds.All);
+            Assert.Matches("^[a-z0-9-]+$", scenario.Id);
+            Assert.True(scenario.Query.ValueKind is JsonValueKind.Object);
+            Assert.True(scenario.Result.Features.Count >= 0);
+
+            if (scenario.SourceDescriptor is { } descriptor)
+            {
+                Assert.Equal(scenario.Protocol, descriptor.Protocol);
+                foreach (var capability in descriptor.Capabilities)
+                {
+                    Assert.Contains(capability, FeatureCapabilities.All);
+                }
+            }
+
+            foreach (var feature in scenario.Result.Features)
+            {
+                Assert.True(feature.Attributes.ValueKind is JsonValueKind.Object);
+                if (feature.Geometry.HasValue)
+                {
+                    Assert.True(feature.Geometry.Value.ValueKind is JsonValueKind.Object or JsonValueKind.Null);
+                }
+            }
+
+            foreach (var degraded in scenario.Result.Degraded)
+            {
+                Assert.Contains(degraded.Capability, FeatureCapabilities.All);
+                Assert.False(string.IsNullOrWhiteSpace(degraded.Reason));
+                if (degraded.Protocol is { } protocol)
+                {
+                    Assert.Contains(protocol, FeatureProtocolIds.All);
+                }
+            }
+        }
+
+        Assert.Equal(
+            ["geoservices-feature-service", "odata", "ogc-features", "stac", "wfs"],
+            protocolsWithResults);
+    }
+
+    [Fact]
+    public void UnsupportedCapabilityScenarios_ReferenceKnownProtocolsAndCapabilities()
+    {
+        foreach (var scenario in Fixture.Value.UnsupportedCapabilityScenarios)
+        {
+            Assert.Contains(scenario.Protocol, FeatureProtocolIds.All);
+            Assert.Contains(scenario.RequiredCapability, FeatureCapabilities.All);
+            Assert.Equal("HonuaCapabilityNotSupportedError", scenario.ExpectedError.Name);
+            Assert.Equal(scenario.RequiredCapability, scenario.ExpectedError.Capability);
+            Assert.Equal(scenario.Protocol, scenario.ExpectedError.Protocol);
+            Assert.False(string.IsNullOrWhiteSpace(scenario.Reason));
+        }
+    }
+
+    private sealed record ContractFixture
+    {
+        public int SchemaVersion { get; init; }
+
+        public IReadOnlyList<LanguageBinding> LanguageBindings { get; init; } = [];
+
+        public IReadOnlyList<string> Protocols { get; init; } = [];
+
+        public IReadOnlyDictionary<string, string> ProtocolAliases { get; init; } =
+            new Dictionary<string, string>(StringComparer.Ordinal);
+
+        public IReadOnlyList<string> Capabilities { get; init; } = [];
+
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> DefaultCapabilities { get; init; } =
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+
+        public IReadOnlyList<ResultScenario> ResultScenarios { get; init; } = [];
+
+        public IReadOnlyList<UnsupportedCapabilityScenario> UnsupportedCapabilityScenarios { get; init; } = [];
+    }
+
+    private sealed record LanguageBinding
+    {
+        public string Concept { get; init; } = string.Empty;
+
+        public string Dotnet { get; init; } = string.Empty;
+    }
+
+    private sealed record ResultScenario
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string Protocol { get; init; } = string.Empty;
+
+        public SourceDescriptorFixture? SourceDescriptor { get; init; }
+
+        public JsonElement Query { get; init; }
+
+        public ResultFixture Result { get; init; } = new();
+    }
+
+    private sealed record SourceDescriptorFixture
+    {
+        public string Protocol { get; init; } = string.Empty;
+
+        public IReadOnlyList<string> Capabilities { get; init; } = [];
+    }
+
+    private sealed record ResultFixture
+    {
+        public IReadOnlyList<FeatureFixture> Features { get; init; } = [];
+
+        public bool ExceededTransferLimit { get; init; }
+
+        public IReadOnlyList<DegradedReasonFixture> Degraded { get; init; } = [];
+    }
+
+    private sealed record FeatureFixture
+    {
+        public JsonElement Attributes { get; init; }
+
+        public JsonElement? Geometry { get; init; }
+    }
+
+    private sealed record DegradedReasonFixture
+    {
+        public string Capability { get; init; } = string.Empty;
+
+        public string? Protocol { get; init; }
+
+        public string Reason { get; init; } = string.Empty;
+    }
+
+    private sealed record UnsupportedCapabilityScenario
+    {
+        public string Protocol { get; init; } = string.Empty;
+
+        public string RequiredCapability { get; init; } = string.Empty;
+
+        public string Reason { get; init; } = string.Empty;
+
+        public ExpectedError ExpectedError { get; init; } = new();
+    }
+
+    private sealed record ExpectedError
+    {
+        public string Name { get; init; } = string.Empty;
+
+        public string Capability { get; init; } = string.Empty;
+
+        public string Protocol { get; init; } = string.Empty;
+    }
+}

--- a/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/SourceFacadeTests.cs
@@ -29,11 +29,21 @@ public sealed class SourceFacadeTests
 
         Assert.Contains(FeatureCapabilities.Query, geoservices);
         Assert.Contains(FeatureCapabilities.QueryAggregate, geoservices);
-        Assert.Contains(FeatureCapabilities.TimeFilter, geoservices);
-        Assert.Contains(FeatureCapabilities.SpatialRelationships, geoservices);
+        Assert.Contains(FeatureCapabilities.QueryRelated, geoservices);
         Assert.Contains(FeatureCapabilities.ApplyEdits, geoservices);
+        Assert.Contains(FeatureCapabilities.Attachments, geoservices);
+        Assert.Contains(FeatureCapabilities.Pbf, geoservices);
+        Assert.Contains(FeatureCapabilities.Connect, geoservices);
+        Assert.Contains(FeatureCapabilities.QueryExtent, wfs);
         Assert.Contains(FeatureCapabilities.QueryObjectIds, wfs);
-        Assert.DoesNotContain(FeatureCapabilities.ApplyEdits, wfs);
+        Assert.Contains(FeatureCapabilities.ApplyEdits, wfs);
+    }
+
+    [Fact]
+    public void Contains_NormalizesCapabilitySpelling()
+    {
+        Assert.True(FeatureCapabilities.Contains(["Query Object IDs"], FeatureCapabilities.QueryObjectIds));
+        Assert.True(FeatureCapabilities.Contains(["queryaggregate"], FeatureCapabilities.QueryAggregate));
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -150,9 +150,9 @@ public class HonuaFeatureServerClientTests
         Assert.True(descriptor.Schema.AttachmentCapabilities?.SupportsDelete);
         Assert.Contains(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
         Assert.Contains(FeatureCapabilities.Attachments, descriptor.Capabilities);
-        Assert.Contains(FeatureCapabilities.Offline, descriptor.Capabilities);
-        Assert.Contains(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
-        Assert.Contains(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.Offline, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
         var status = Assert.Single(descriptor.Schema.Fields, field => field.Name == "STATUS");
         Assert.Equal("Status", status.Alias);
         Assert.Equal("esriFieldTypeString", status.Type);

--- a/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/HonuaGrpcClientTests.cs
@@ -108,7 +108,7 @@ public class HonuaGrpcClientTests
         Assert.Equal(255, descriptor.Schema.Fields[0].Length);
         Assert.Contains(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
         Assert.Contains(FeatureCapabilities.QueryExtent, descriptor.Capabilities);
-        Assert.Contains(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.SpatialRelationships, descriptor.Capabilities);
         Assert.DoesNotContain(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
     }
 

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -187,7 +187,7 @@ public class HonuaOgcFeaturesClientTests
         Assert.Equal("http://www.opengis.net/def/crs/OGC/1.3/CRS84", descriptor.Schema.SpatialReference);
         Assert.Equal(-180, descriptor.Schema.Extent?.MinX);
         Assert.Contains(FeatureCapabilities.QueryObjectIds, descriptor.Capabilities);
-        Assert.Contains(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
+        Assert.DoesNotContain(FeatureCapabilities.TimeFilter, descriptor.Capabilities);
         Assert.Contains(FeatureCapabilities.ApplyEdits, descriptor.Capabilities);
         Assert.DoesNotContain(FeatureCapabilities.QueryAggregate, descriptor.Capabilities);
         var name = Assert.Single(descriptor.Schema.Fields, field => field.Name == "name");


### PR DESCRIPTION
## Summary
- add the JS shared semantic contract fixture to the .NET abstraction test suite
- pin protocol IDs, aliases, capabilities, default capability sets, result scenarios, unsupported cases, and degraded references against the fixture
- align .NET shared protocol/capability registries with the fixture while keeping gRPC as a .NET transport/provider identifier
- keep current WFS descriptor discovery honest by removing applyEdits until WFS-T is implemented

Closes #142

## Tests
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release
- dotnet test Honua.Sdk.sln --configuration Release