### PR TITLE
Restore gRPC as shared canonical protocol

### DIFF
--- a/docs/source-facade.md
+++ b/docs/source-facade.md
@@ -60,6 +60,7 @@ existing provider-name aliases and normalizes them to canonical IDs:
 
 | Canonical ID | Common aliases |
 | --- | --- |
+| `grpc` | `grpc` |
 | `geoservices-feature-service` | `geoservices-featureserver`, `featureserver`, `FeatureServer` |
 | `geoservices-map-service` | `map-server`, `mapserver` |
 | `geoservices-image-service` | `image-server`, `imageserver` |
@@ -78,9 +79,7 @@ existing provider-name aliases and normalizes them to canonical IDs:
 | `maplibre-geojson` | `maplibre-geojson` |
 
 Call `FeatureProtocolIds.Normalize()` or `FeatureProtocolIds.Matches()` when
-persisted descriptors may contain older provider names. The .NET gRPC client
-continues to use `grpc` as a transport/provider identifier, but it is not part of
-the cross-SDK canonical protocol registry.
+persisted descriptors may contain older provider names.
 
 ## Capabilities
 

--- a/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureProtocolIds.cs
@@ -8,7 +8,7 @@ namespace Honua.Sdk.Abstractions.Features;
 /// </summary>
 public static class FeatureProtocolIds
 {
-    /// <summary>.NET gRPC FeatureService transport identifier.</summary>
+    /// <summary>Canonical gRPC FeatureService protocol identifier.</summary>
     public const string Grpc = "grpc";
 
     /// <summary>Canonical GeoServices Feature Service protocol identifier.</summary>
@@ -151,6 +151,7 @@ public static class FeatureProtocolIds
     /// <summary>Canonical protocol identifiers shared across Honua SDKs.</summary>
     public static IReadOnlyList<string> All { get; } =
     [
+        Grpc,
         GeoServicesFeatureService,
         GeoServicesMapService,
         GeoServicesImageService,

--- a/tests/Honua.Sdk.Abstractions.Tests/Fixtures/sdk-contract/semantic-contract.v1.json
+++ b/tests/Honua.Sdk.Abstractions.Tests/Fixtures/sdk-contract/semantic-contract.v1.json
@@ -60,6 +60,7 @@
     }
   ],
   "protocols": [
+    "grpc",
     "geoservices-feature-service",
     "geoservices-map-service",
     "geoservices-image-service",
@@ -118,6 +119,14 @@
     "processes"
   ],
   "defaultCapabilities": {
+    "grpc": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
     "geoservices-feature-service": [
       "query",
       "queryAggregate",


### PR DESCRIPTION
## Summary
- add `grpc` back to the vendored shared semantic contract fixture protocol list
- pin default gRPC source capabilities in the fixture
- include `grpc` in `FeatureProtocolIds.All`
- update source facade docs to list `grpc` as canonical

Closes #144

## Tests
- dotnet test tests/Honua.Sdk.Abstractions.Tests/Honua.Sdk.Abstractions.Tests.csproj --configuration Release
- dotnet test Honua.Sdk.sln --configuration Release

## Follow-up
JS/Python fixture copies should be updated to include `grpc` so the source fixture is identical across SDKs.