### PR TITLE
feat(grpc,geoservices,ogcfeatures): migrate mobile-side transport mappings

### DIFF
--- a/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
+namespace Honua.Sdk.GeoServices.FeatureServer.Conversion;
+
+
+/// <summary>
+/// Converts mobile/abstractions request DTOs to FeatureServer REST request
+/// shapes (query parameters, edit payloads, and form bodies).
+/// </summary>
+/// <remarks>
+/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Methods
+/// are <c>internal</c> while the migration settles; promote to <c>public</c>
+/// once the abstractions DTO surface is finalised.
+/// </remarks>
+internal static class RequestConverters
+{
+    /// <summary>Converts an abstractions apply-edits request to a FeatureServer edit request.</summary>
+    public static FeatureServerEditRequest ToFeatureServerEditRequest(ApplyEditsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new FeatureServerEditRequest
+        {
+            Adds = ResolveFeatureServerFeatures(request.Adds, request.AddsJson, "adds"),
+            Updates = ResolveFeatureServerFeatures(request.Updates, request.UpdatesJson, "updates"),
+            Deletes = ResolveFeatureServerDeletes(request.Deletes, request.DeletesCsv),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+    }
+
+    /// <summary>Converts an apply-edits request to FeatureServer form parameters suitable for POST bodies.</summary>
+    public static IReadOnlyDictionary<string, string> ToFeatureServerEditFormParameters(ApplyEditsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var edit = ToFeatureServerEditRequest(request);
+        var body = new Dictionary<string, string?>
+        {
+            ["f"] = request.ResponseFormat,
+            ["adds"] = edit.Adds is { Count: > 0 } ? SerializeFeatureServerFeatures(edit.Adds) : null,
+            ["updates"] = edit.Updates is { Count: > 0 } ? SerializeFeatureServerFeatures(edit.Updates) : null,
+            ["deletes"] = edit.Deletes is { Count: > 0 } ? JoinInvariant(edit.Deletes) : null,
+            ["rollbackOnFailure"] = edit.RollbackOnFailure ? "true" : "false",
+            ["forceWrite"] = edit.ForceWrite ? "true" : null,
+        };
+
+        return body
+            .Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
+            .ToDictionary(pair => pair.Key, pair => pair.Value!);
+    }
+
+    /// <summary>Converts a provider-neutral feature edit payload to a FeatureServer feature.</summary>
+    public static FeatureServerFeature ToFeatureServerFeature(FeatureEditFeature feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        return new FeatureServerFeature
+        {
+            Attributes = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
+            Geometry = feature.Geometry?.Clone(),
+        };
+    }
+
+    /// <summary>Resolves the numeric object IDs to delete from a provider-neutral edit request.</summary>
+    public static IReadOnlyList<long>? ToFeatureServerDeleteObjectIds(FeatureEditRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var objectIds = new List<long>(request.DeleteObjectIds);
+        foreach (var id in request.DeleteIds)
+        {
+            if (!long.TryParse(id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                throw new ArgumentException("FeatureServer feature deletes require numeric feature IDs.", nameof(request));
+            }
+
+            objectIds.Add(objectId);
+        }
+
+        return objectIds.Count == 0 ? null : objectIds;
+    }
+
+    /// <summary>Converts an abstractions query request to FeatureServer query parameters.</summary>
+    public static FeatureServerQueryParams ToFeatureServerQueryParams(QueryFeaturesRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new FeatureServerQueryParams
+        {
+            Where = request.Where,
+            ObjectIds = request.ObjectIds,
+            OutFields = request.OutFields is { Count: > 0 } ? string.Join(',', request.OutFields) : "*",
+            ReturnGeometry = request.ReturnGeometry,
+            ResultOffset = request.ResultOffset,
+            ResultRecordCount = request.ResultRecordCount,
+            OrderByFields = request.OrderBy,
+            ReturnDistinctValues = request.ReturnDistinct ? true : null,
+            ReturnCountOnly = request.ReturnCountOnly ? true : null,
+            ReturnIdsOnly = request.ReturnIdsOnly ? true : null,
+            ReturnExtentOnly = request.ReturnExtentOnly ? true : null,
+            Format = ToFeatureServerFormat(request.ResponseFormat),
+        };
+    }
+
+    /// <summary>Serializes a FeatureServer query response to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(FeatureServerQueryResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return JsonDocument.Parse(JsonSerializer.Serialize(
+            response,
+            MobileTransportJsonContext.Default.FeatureServerQueryResponse));
+    }
+
+    /// <summary>Serializes a FeatureServer edit response to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(FeatureServerEditResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return JsonDocument.Parse(JsonSerializer.Serialize(
+            response,
+            MobileTransportJsonContext.Default.FeatureServerEditResponse));
+    }
+
+    private static FeatureServerFeature[]? ResolveFeatureServerFeatures(
+        IReadOnlyList<FeatureEditFeature>? features,
+        string? json,
+        string payloadName)
+    {
+        if (features is { Count: > 0 })
+        {
+            return features.Select(ToFeatureServerFeature).ToArray();
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize(
+                json,
+                MobileTransportJsonContext.Default.FeatureServerFeatureArray);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException($"FeatureServer {payloadName} JSON payload is invalid.", payloadName, ex);
+        }
+    }
+
+    private static IReadOnlyList<long>? ResolveFeatureServerDeletes(IReadOnlyList<long>? deletes, string? deletesCsv)
+    {
+        if (deletes is { Count: > 0 })
+        {
+            return deletes;
+        }
+
+        if (string.IsNullOrWhiteSpace(deletesCsv))
+        {
+            return null;
+        }
+
+        var objectIds = new List<long>();
+        foreach (var value in deletesCsv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                throw new ArgumentException("FeatureServer deletesCsv payload must contain numeric object IDs.", nameof(deletesCsv));
+            }
+
+            objectIds.Add(objectId);
+        }
+
+        return objectIds;
+    }
+
+    private static string SerializeFeatureServerFeatures(IReadOnlyList<FeatureServerFeature> features)
+        => JsonSerializer.Serialize(
+            features.ToArray(),
+            MobileTransportJsonContext.Default.FeatureServerFeatureArray);
+
+    private static string JoinInvariant(IEnumerable<long> values)
+        => string.Join(',', values.Select(value => value.ToString(CultureInfo.InvariantCulture)));
+
+    private static FeatureServerFormat? ToFeatureServerFormat(string? responseFormat)
+    {
+        var trimmed = responseFormat?.Trim();
+        if (string.IsNullOrEmpty(trimmed) || trimmed.Equals("json", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureServerFormat.Json;
+        }
+
+        if (trimmed.Equals("geojson", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureServerFormat.GeoJson;
+        }
+
+        if (trimmed.Equals("pbf", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureServerFormat.Pbf;
+        }
+
+        if (trimmed.Equals("flatgeobuf", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureServerFormat.FlatGeobuf;
+        }
+
+        if (trimmed.Equals("parquet", StringComparison.OrdinalIgnoreCase))
+        {
+            return FeatureServerFormat.Parquet;
+        }
+
+        return null;
+    }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(FeatureServerFeature[]))]
+[JsonSerializable(typeof(FeatureServerQueryResponse))]
+[JsonSerializable(typeof(FeatureServerEditResponse))]
+internal sealed partial class MobileTransportJsonContext : JsonSerializerContext
+{
+}
+

--- a/src/Honua.Sdk.Grpc/Conversion/MobileRequestConverters.cs
+++ b/src/Honua.Sdk.Grpc/Conversion/MobileRequestConverters.cs
@@ -1,0 +1,435 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Collections;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using GrpcModels = Honua.Sdk.Grpc.Models;
+
+namespace Honua.Sdk.Grpc.Conversion;
+
+
+/// <summary>
+/// Converts mobile-side request DTOs and gRPC response models for legacy
+/// <c>JsonDocument</c>-returning surfaces.
+/// </summary>
+/// <remarks>
+/// Migrated from <c>Honua.Mobile.Sdk.SdkGrpcTransportMappings</c>. The converter
+/// is intentionally <c>internal</c> while the migration is in flight; only
+/// transport adapters inside this assembly are intended consumers.
+/// </remarks>
+internal static class MobileRequestConverters
+{
+    /// <summary>Converts an abstractions feature query request to its gRPC counterpart.</summary>
+    public static GrpcModels.QueryFeaturesRequest ToGrpcQueryRequest(QueryFeaturesRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new GrpcModels.QueryFeaturesRequest
+        {
+            ServiceId = request.ServiceId,
+            LayerId = request.LayerId,
+            Where = request.Where,
+            ObjectIds = request.ObjectIds,
+            OutFields = request.OutFields,
+            ReturnGeometry = request.ReturnGeometry,
+            ResultOffset = request.ResultOffset ?? 0,
+            ResultRecordCount = request.ResultRecordCount ?? 0,
+            OrderBy = request.OrderBy ?? string.Empty,
+            ReturnDistinct = request.ReturnDistinct,
+            ReturnCountOnly = request.ReturnCountOnly,
+            ReturnIdsOnly = request.ReturnIdsOnly,
+            ReturnExtentOnly = request.ReturnExtentOnly,
+        };
+    }
+
+    /// <summary>Converts an abstractions apply-edits request to its gRPC counterpart.</summary>
+    public static GrpcModels.ApplyEditsRequest ToGrpcApplyEditsRequest(ApplyEditsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return new GrpcModels.ApplyEditsRequest
+        {
+            ServiceId = request.ServiceId,
+            LayerId = request.LayerId,
+            Adds = ToGrpcFeatures(request.Adds, request.AddsJson),
+            Updates = ToGrpcFeatures(request.Updates, request.UpdatesJson),
+            Deletes = ToGrpcDeleteObjectIds(request.Deletes, request.DeletesCsv),
+            RollbackOnFailure = request.RollbackOnFailure,
+            ForceWrite = request.ForceWrite,
+        };
+    }
+
+    /// <summary>Serializes a gRPC feature query response to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(GrpcModels.QueryFeaturesResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        var payload = new Dictionary<string, object?>
+        {
+            ["objectIdFieldName"] = response.ObjectIdFieldName,
+            ["geometryType"] = response.GeometryType.ToString(),
+            ["spatialReference"] = ToSpatialReference(response.SpatialReference),
+            ["fields"] = response.Fields.Select(ToField).ToArray(),
+            ["features"] = response.Features.Select(ToFeature).ToArray(),
+            ["exceededTransferLimit"] = response.ExceededTransferLimit,
+            ["count"] = response.Count,
+            ["objectIds"] = response.ObjectIds.ToArray(),
+            ["extent"] = ToExtent(response.Extent),
+        };
+
+        return SerializePayload(payload);
+    }
+
+    /// <summary>Serializes a gRPC streaming feature page to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(GrpcModels.FeaturePage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        var payload = new Dictionary<string, object?>
+        {
+            ["objectIdFieldName"] = page.ObjectIdFieldName,
+            ["geometryType"] = page.GeometryType.ToString(),
+            ["spatialReference"] = ToSpatialReference(page.SpatialReference),
+            ["fields"] = page.Fields.Select(ToField).ToArray(),
+            ["features"] = page.Features.Select(ToFeature).ToArray(),
+            ["isLastPage"] = page.IsLastPage,
+        };
+
+        return SerializePayload(payload);
+    }
+
+    /// <summary>Serializes a gRPC apply-edits response to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(GrpcModels.ApplyEditsResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        var payload = new Dictionary<string, object?>
+        {
+            ["addResults"] = response.AddResults.Select(ToEditResult).ToArray(),
+            ["updateResults"] = response.UpdateResults.Select(ToEditResult).ToArray(),
+            ["deleteResults"] = response.DeleteResults.Select(ToEditResult).ToArray(),
+            ["error"] = response.Error is null ? null : ToEditError(response.Error),
+        };
+
+        return SerializePayload(payload);
+    }
+
+    private static GrpcModels.Feature[]? ToGrpcFeatures(
+        IReadOnlyList<FeatureEditFeature>? features,
+        string? json)
+    {
+        if (features is { Count: > 0 })
+        {
+            return features.Select(ToGrpcFeature).ToArray();
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(json);
+        if (document.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            return document.RootElement.EnumerateArray().Select(ToGrpcFeature).ToArray();
+        }
+
+        return document.RootElement.ValueKind == JsonValueKind.Object
+            ? [ToGrpcFeature(document.RootElement)]
+            : [];
+    }
+
+    private static IReadOnlyList<long>? ToGrpcDeleteObjectIds(IReadOnlyList<long>? deletes, string? deletesCsv)
+    {
+        if (deletes is { Count: > 0 })
+        {
+            return deletes;
+        }
+
+        if (string.IsNullOrWhiteSpace(deletesCsv))
+        {
+            return null;
+        }
+
+        var objectIds = new List<long>();
+        foreach (var token in deletesCsv.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (long.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var objectId))
+            {
+                objectIds.Add(objectId);
+            }
+        }
+
+        return objectIds;
+    }
+
+    private static GrpcModels.Feature ToGrpcFeature(FeatureEditFeature feature)
+    {
+        var attributes = feature.Attributes.ToDictionary(
+            kvp => kvp.Key,
+            kvp => (object?)ToObject(kvp.Value));
+
+        return new GrpcModels.Feature
+        {
+            Id = feature.ObjectId ??
+                (TryReadObjectId(feature.Attributes, out var objectId) ? objectId : 0L),
+            Attributes = attributes,
+            Geometry = feature.Geometry is { ValueKind: JsonValueKind.Object } geometry
+                ? ToObjectDictionary(geometry)
+                : null,
+        };
+    }
+
+    private static GrpcModels.Feature ToGrpcFeature(JsonElement feature)
+    {
+        var attributes = feature.TryGetProperty("attributes", out var attributesNode) &&
+            attributesNode.ValueKind == JsonValueKind.Object
+                ? ToObjectDictionary(attributesNode)
+                : new Dictionary<string, object?>();
+
+        return new GrpcModels.Feature
+        {
+            Id = TryReadObjectId(feature, attributes, out var objectId) ? objectId : 0,
+            Attributes = attributes,
+            Geometry = feature.TryGetProperty("geometry", out var geometryNode) &&
+                geometryNode.ValueKind == JsonValueKind.Object
+                    ? ToObjectDictionary(geometryNode)
+                    : null,
+        };
+    }
+
+    private static bool TryReadObjectId(
+        JsonElement feature,
+        Dictionary<string, object?> attributes,
+        out long objectId)
+    {
+        if (TryReadObjectId(feature, "id", out objectId) ||
+            TryReadObjectId(feature, "objectId", out objectId))
+        {
+            return true;
+        }
+
+        foreach (var key in new[] { "OBJECTID", "objectid", "ObjectID", "FID" })
+        {
+            if (attributes.TryGetValue(key, out var value) && TryConvertToInt64(value, out objectId))
+            {
+                return true;
+            }
+        }
+
+        objectId = 0;
+        return false;
+    }
+
+    private static bool TryReadObjectId(IReadOnlyDictionary<string, JsonElement> attributes, out long objectId)
+    {
+        foreach (var key in new[] { "OBJECTID", "objectid", "ObjectID", "FID" })
+        {
+            if (attributes.TryGetValue(key, out var value) && value.TryGetInt64(out objectId))
+            {
+                return true;
+            }
+        }
+
+        objectId = 0;
+        return false;
+    }
+
+    private static bool TryReadObjectId(JsonElement feature, string propertyName, out long objectId)
+    {
+        if (feature.TryGetProperty(propertyName, out var node))
+        {
+            if (node.TryGetInt64(out objectId))
+            {
+                return true;
+            }
+
+            if (node.ValueKind == JsonValueKind.String &&
+                long.TryParse(node.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId))
+            {
+                return true;
+            }
+        }
+
+        objectId = 0;
+        return false;
+    }
+
+    private static Dictionary<string, object?> ToObjectDictionary(JsonElement value)
+        => value.EnumerateObject().ToDictionary(property => property.Name, property => ToObject(property.Value));
+
+    private static object? ToObject(JsonElement value)
+        => value.ValueKind switch
+        {
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            JsonValueKind.String => value.GetString(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number when value.TryGetInt64(out var int64Value) => int64Value,
+            JsonValueKind.Number => value.GetDouble(),
+            JsonValueKind.Array => value.EnumerateArray().Select(ToObject).ToArray(),
+            JsonValueKind.Object => ToObjectDictionary(value),
+            _ => value.GetRawText(),
+        };
+
+    private static bool TryConvertToInt64(object? value, out long objectId)
+    {
+        switch (value)
+        {
+            case long longValue:
+                objectId = longValue;
+                return true;
+            case int intValue:
+                objectId = intValue;
+                return true;
+            case string stringValue when long.TryParse(stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out objectId):
+                return true;
+            case JsonElement element when element.TryGetInt64(out objectId):
+                return true;
+            default:
+                objectId = 0;
+                return false;
+        }
+    }
+
+    private static Dictionary<string, object?> ToFeature(GrpcModels.Feature source)
+        => new()
+        {
+            ["id"] = source.Id,
+            ["attributes"] = source.Attributes,
+            ["geometry"] = source.Geometry,
+        };
+
+    private static Dictionary<string, object?> ToField(GrpcModels.FieldDefinition source)
+        => new()
+        {
+            ["name"] = source.Name,
+            ["fieldType"] = source.FieldType.ToString(),
+            ["length"] = source.Length,
+            ["nullable"] = source.Nullable,
+        };
+
+    private static Dictionary<string, object?>? ToSpatialReference(GrpcModels.SpatialReference? source)
+    {
+        if (source is null ||
+            (source.Wkid == 0 && source.LatestWkid == 0 && string.IsNullOrWhiteSpace(source.Wkt)))
+        {
+            return null;
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["wkid"] = source.Wkid,
+            ["latestWkid"] = source.LatestWkid,
+            ["wkt"] = source.Wkt,
+        };
+    }
+
+    private static Dictionary<string, object?>? ToExtent(GrpcModels.Extent? source)
+    {
+        if (source is null)
+        {
+            return null;
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["xmin"] = source.Xmin,
+            ["ymin"] = source.Ymin,
+            ["xmax"] = source.Xmax,
+            ["ymax"] = source.Ymax,
+            ["spatialReference"] = ToSpatialReference(source.SpatialReference),
+        };
+    }
+
+    private static Dictionary<string, object?> ToEditResult(GrpcModels.EditResult source)
+        => new()
+        {
+            ["objectId"] = source.ObjectId,
+            ["success"] = source.Success,
+            ["error"] = source.Error is null ? null : ToEditError(source.Error),
+        };
+
+    private static Dictionary<string, object?> ToEditError(GrpcModels.EditError source)
+        => new()
+        {
+            ["code"] = source.Code,
+            ["message"] = source.Message,
+        };
+
+    // TODO: Callers that only need a JsonElement should bypass this hop entirely by
+    // consuming the gRPC response types directly. The Utf8JsonWriter -> JsonDocument.Parse
+    // round-trip below remains for legacy compatibility with JsonDocument-returning surfaces.
+    // We write into a pooled IBufferWriter<byte> rather than a MemoryStream + ToArray() to
+    // skip one allocation/copy of the serialized payload.
+    private static JsonDocument SerializePayload(IReadOnlyDictionary<string, object?> payload)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            WriteObject(writer, payload);
+        }
+
+        return JsonDocument.Parse(buffer.WrittenMemory);
+    }
+
+    private static void WriteObject(Utf8JsonWriter writer, IReadOnlyDictionary<string, object?> values)
+    {
+        writer.WriteStartObject();
+        foreach (var (name, value) in values)
+        {
+            writer.WritePropertyName(name);
+            WriteValue(writer, value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNullValue();
+                break;
+            case string stringValue:
+                writer.WriteStringValue(stringValue);
+                break;
+            case bool boolValue:
+                writer.WriteBooleanValue(boolValue);
+                break;
+            case int intValue:
+                writer.WriteNumberValue(intValue);
+                break;
+            case long longValue:
+                writer.WriteNumberValue(longValue);
+                break;
+            case float floatValue:
+                writer.WriteNumberValue(floatValue);
+                break;
+            case double doubleValue:
+                writer.WriteNumberValue(doubleValue);
+                break;
+            case decimal decimalValue:
+                writer.WriteNumberValue(decimalValue);
+                break;
+            case JsonElement element:
+                element.WriteTo(writer);
+                break;
+            case IReadOnlyDictionary<string, object?> objectDictionary:
+                WriteObject(writer, objectDictionary);
+                break;
+            case IEnumerable enumerable:
+                writer.WriteStartArray();
+                foreach (var item in enumerable)
+                {
+                    WriteValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            default:
+                writer.WriteStringValue(value.ToString());
+                break;
+        }
+    }
+}
+

--- a/src/Honua.Sdk.OgcFeatures/Conversion/RequestConverters.cs
+++ b/src/Honua.Sdk.OgcFeatures/Conversion/RequestConverters.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures.Conversion;
+
+
+/// <summary>
+/// Converts mobile/abstractions request DTOs to OGC API Features request and
+/// payload shapes.
+/// </summary>
+/// <remarks>
+/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Methods
+/// are <c>internal</c> while the migration settles.
+/// </remarks>
+internal static class RequestConverters
+{
+    /// <summary>Converts a provider-neutral feature edit payload to an OGC GeoJSON feature.</summary>
+    public static OgcFeature ToOgcFeature(FeatureEditFeature feature, string? featureId = null)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        var id = featureId ?? ResolveOptionalFeatureId(feature);
+        return new OgcFeature
+        {
+            Id = id is null
+                ? null
+                : JsonSerializer.SerializeToElement(id, OgcMobileTransportJsonContext.Default.String),
+            Geometry = feature.Geometry?.Clone(),
+            Properties = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
+        };
+    }
+
+    /// <summary>Formats a numeric object ID for use as an OGC feature identifier.</summary>
+    public static string ToOgcFeatureId(long objectId)
+        => objectId.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>Converts an abstractions OGC items request to OGC items query parameters.</summary>
+    public static OgcItemsParams ToOgcItemsParams(OgcItemsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return new OgcItemsParams
+        {
+            Limit = request.Limit,
+            Offset = request.Offset,
+            Properties = request.PropertyNames is { Count: > 0 } ? string.Join(',', request.PropertyNames) : null,
+            Filter = request.CqlFilter,
+            Format = ToOgcFeaturesFormat(request.ResponseFormat),
+        };
+    }
+
+    /// <summary>Coerces an opaque OGC feature payload into an <see cref="OgcFeature"/>.</summary>
+    public static OgcFeature ToOgcFeature(object feature)
+    {
+        ArgumentNullException.ThrowIfNull(feature);
+
+        if (feature is OgcFeature ogcFeature)
+        {
+            return ogcFeature;
+        }
+
+        var json = feature switch
+        {
+            JsonElement element => element.GetRawText(),
+            JsonDocument document => document.RootElement.GetRawText(),
+            FeatureEditFeature editFeature => JsonSerializer.Serialize(
+                ToOgcFeature(editFeature),
+                OgcMobileTransportJsonContext.Default.OgcFeature),
+            _ => SerializeWithContext(feature),
+        };
+
+        return JsonSerializer.Deserialize(json, OgcMobileTransportJsonContext.Default.OgcFeature)
+            ?? throw new ArgumentException("OGC feature payload could not be deserialized.", nameof(feature));
+    }
+
+    /// <summary>Coerces an opaque value into a JSON element (used for OGC patch payloads).</summary>
+    public static JsonElement ToJsonElement(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        return value switch
+        {
+            JsonElement element => element.Clone(),
+            JsonDocument document => document.RootElement.Clone(),
+            _ => SerializeToElementWithContext(value),
+        };
+    }
+
+    /// <summary>Serializes an OGC collection list to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(IReadOnlyList<OgcCollection> collections)
+    {
+        ArgumentNullException.ThrowIfNull(collections);
+        return JsonDocument.Parse(JsonSerializer.Serialize(
+            new OgcCollectionsEnvelope { Collections = collections },
+            OgcMobileTransportJsonContext.Default.OgcCollectionsEnvelope));
+    }
+
+    /// <summary>Serializes an OGC feature collection to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(OgcFeatureCollection response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return JsonDocument.Parse(JsonSerializer.Serialize(
+            response,
+            OgcMobileTransportJsonContext.Default.OgcFeatureCollection));
+    }
+
+    /// <summary>Serializes an OGC feature to a legacy <see cref="JsonDocument"/> payload.</summary>
+    public static JsonDocument ToJsonDocument(OgcFeature response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        return JsonDocument.Parse(JsonSerializer.Serialize(
+            response,
+            OgcMobileTransportJsonContext.Default.OgcFeature));
+    }
+
+    private static string SerializeWithContext(object value)
+    {
+        try
+        {
+            return JsonSerializer.Serialize(value, value.GetType(), OgcMobileTransportJsonContext.Default);
+        }
+        catch (NotSupportedException ex)
+        {
+            throw new ArgumentException(
+                "OGC feature payload must be an OgcFeature, FeatureEditFeature, JsonElement, JsonDocument, or a source-generated JSON type.",
+                nameof(value),
+                ex);
+        }
+    }
+
+    private static JsonElement SerializeToElementWithContext(object value)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(value, value.GetType(), OgcMobileTransportJsonContext.Default);
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.Clone();
+        }
+        catch (NotSupportedException ex)
+        {
+            throw new ArgumentException(
+                "OGC patch payload must be a JsonElement, JsonDocument, or a source-generated JSON type.",
+                nameof(value),
+                ex);
+        }
+    }
+
+    private static string? ResolveOptionalFeatureId(FeatureEditFeature feature)
+        => !string.IsNullOrWhiteSpace(feature.Id)
+            ? feature.Id
+            : feature.ObjectId?.ToString(CultureInfo.InvariantCulture);
+
+    private static OgcFeaturesFormat? ToOgcFeaturesFormat(string? responseFormat)
+    {
+        var trimmed = responseFormat?.Trim();
+        if (string.IsNullOrEmpty(trimmed) || trimmed.Equals("json", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.Json;
+        }
+
+        if (trimmed.Equals("geojson", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.GeoJson;
+        }
+
+        if (trimmed.Equals("html", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.Html;
+        }
+
+        if (trimmed.Equals("gml", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.Gml;
+        }
+
+        if (trimmed.Equals("csv", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.Csv;
+        }
+
+        if (trimmed.Equals("flatgeobuf", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.FlatGeobuf;
+        }
+
+        if (trimmed.Equals("parquet", StringComparison.OrdinalIgnoreCase))
+        {
+            return OgcFeaturesFormat.Parquet;
+        }
+
+        return null;
+    }
+}
+
+internal sealed class OgcCollectionsEnvelope
+{
+    [JsonPropertyName("collections")]
+    public IReadOnlyList<OgcCollection> Collections { get; init; } = [];
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcCollectionsEnvelope))]
+[JsonSerializable(typeof(OgcFeatureCollection))]
+[JsonSerializable(typeof(OgcFeature))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(string))]
+internal sealed partial class OgcMobileTransportJsonContext : JsonSerializerContext
+{
+}
+

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/Conversion/RequestConvertersTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/Conversion/RequestConvertersTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.FeatureServer.Conversion;
+using Honua.Sdk.GeoServices.FeatureServer.Models;
+
+namespace Honua.Sdk.GeoServices.Tests.FeatureServer.Conversion;
+
+
+public class RequestConvertersTests
+{
+    [Fact]
+    public void ToFeatureServerEditRequest_MapsFeaturesAndDeletes()
+    {
+        var add = new FeatureEditFeature
+        {
+            ObjectId = 1,
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+            Geometry = JsonSerializer.SerializeToElement(new { x = 10.0, y = 20.0 }),
+        };
+        var update = new FeatureEditFeature
+        {
+            ObjectId = 99,
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["OBJECTID"] = JsonSerializer.SerializeToElement(99),
+                ["NAME"] = JsonSerializer.SerializeToElement("Beta"),
+            },
+        };
+
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            Adds = [add],
+            Updates = [update],
+            Deletes = [3L, 4L],
+            RollbackOnFailure = true,
+            ForceWrite = true,
+        };
+
+        var edit = RequestConverters.ToFeatureServerEditRequest(request);
+
+        Assert.NotNull(edit.Adds);
+        Assert.Single(edit.Adds);
+        Assert.Equal("Alpha", edit.Adds[0].Attributes!["NAME"].GetString());
+        Assert.True(edit.Adds[0].Geometry.HasValue);
+
+        Assert.NotNull(edit.Updates);
+        Assert.Single(edit.Updates);
+        Assert.Equal(99, edit.Updates[0].Attributes!["OBJECTID"].GetInt32());
+
+        Assert.Equal([3L, 4L], edit.Deletes);
+        Assert.True(edit.RollbackOnFailure);
+        Assert.True(edit.ForceWrite);
+    }
+
+    [Fact]
+    public void ToFeatureServerEditRequest_ParsesJsonFallbacks()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            AddsJson = """[{"attributes":{"OBJECTID":1,"NAME":"X"}}]""",
+            DeletesCsv = "10, 11, 12",
+        };
+
+        var edit = RequestConverters.ToFeatureServerEditRequest(request);
+
+        Assert.NotNull(edit.Adds);
+        Assert.Single(edit.Adds);
+        Assert.Equal("X", edit.Adds[0].Attributes!["NAME"].GetString());
+        Assert.Equal([10L, 11L, 12L], edit.Deletes);
+    }
+
+    [Fact]
+    public void ToFeatureServerEditRequest_ThrowsOnInvalidJson()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            AddsJson = "{not-json",
+        };
+
+        Assert.Throws<ArgumentException>(() => RequestConverters.ToFeatureServerEditRequest(request));
+    }
+
+    [Fact]
+    public void ToFeatureServerEditRequest_ThrowsOnNonNumericDeletesCsv()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            DeletesCsv = "1,abc,3",
+        };
+
+        Assert.Throws<ArgumentException>(() => RequestConverters.ToFeatureServerEditRequest(request));
+    }
+
+    [Fact]
+    public void ToFeatureServerEditFormParameters_SerializesRequiredFields()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            Adds =
+            [
+                new FeatureEditFeature
+                {
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+                    },
+                },
+            ],
+            Deletes = [1L, 2L],
+            RollbackOnFailure = true,
+            ForceWrite = false,
+        };
+
+        var form = RequestConverters.ToFeatureServerEditFormParameters(request);
+
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("true", form["rollbackOnFailure"]);
+        Assert.False(form.ContainsKey("forceWrite"));
+        Assert.Equal("1,2", form["deletes"]);
+        Assert.Contains("Alpha", form["adds"]);
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_ClonesAttributes()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+            Geometry = JsonSerializer.SerializeToElement(new { x = 1.0, y = 2.0 }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.Equal("Alpha", converted.Attributes!["NAME"].GetString());
+        Assert.True(converted.Geometry.HasValue);
+    }
+
+    [Fact]
+    public void ToFeatureServerDeleteObjectIds_CombinesNumericAndStringIds()
+    {
+        var request = new FeatureEditRequest
+        {
+            DeleteObjectIds = [1L, 2L],
+            DeleteIds = ["3", "4"],
+        };
+
+        var ids = RequestConverters.ToFeatureServerDeleteObjectIds(request);
+
+        Assert.Equal([1L, 2L, 3L, 4L], ids);
+    }
+
+    [Fact]
+    public void ToFeatureServerDeleteObjectIds_ReturnsNullWhenEmpty()
+    {
+        var request = new FeatureEditRequest();
+        Assert.Null(RequestConverters.ToFeatureServerDeleteObjectIds(request));
+    }
+
+    [Fact]
+    public void ToFeatureServerDeleteObjectIds_ThrowsOnNonNumericId()
+    {
+        var request = new FeatureEditRequest
+        {
+            DeleteIds = ["abc"],
+        };
+
+        Assert.Throws<ArgumentException>(() => RequestConverters.ToFeatureServerDeleteObjectIds(request));
+    }
+
+    [Theory]
+    [InlineData(null, FeatureServerFormat.Json)]
+    [InlineData("", FeatureServerFormat.Json)]
+    [InlineData("json", FeatureServerFormat.Json)]
+    [InlineData("GEOJSON", FeatureServerFormat.GeoJson)]
+    [InlineData("pbf", FeatureServerFormat.Pbf)]
+    [InlineData("flatgeobuf", FeatureServerFormat.FlatGeobuf)]
+    [InlineData("parquet", FeatureServerFormat.Parquet)]
+    public void ToFeatureServerQueryParams_MapsFormat(string? format, FeatureServerFormat expected)
+    {
+        var request = new QueryFeaturesRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            ResponseFormat = format ?? "json",
+        };
+
+        var qp = RequestConverters.ToFeatureServerQueryParams(request);
+        Assert.Equal(expected, qp.Format);
+    }
+
+    [Fact]
+    public void ToFeatureServerQueryParams_MapsAllFields()
+    {
+        var request = new QueryFeaturesRequest
+        {
+            ServiceId = "svc",
+            LayerId = 1,
+            Where = "STATUS='Open'",
+            ObjectIds = [1L, 2L],
+            OutFields = ["NAME", "STATUS"],
+            ReturnGeometry = false,
+            ResultOffset = 25,
+            ResultRecordCount = 50,
+            OrderBy = "NAME ASC",
+            ReturnDistinct = true,
+            ReturnCountOnly = true,
+            ReturnIdsOnly = true,
+            ReturnExtentOnly = true,
+        };
+
+        var qp = RequestConverters.ToFeatureServerQueryParams(request);
+
+        Assert.Equal("STATUS='Open'", qp.Where);
+        Assert.Equal([1L, 2L], qp.ObjectIds);
+        Assert.Equal("NAME,STATUS", qp.OutFields);
+        Assert.False(qp.ReturnGeometry);
+        Assert.Equal(25, qp.ResultOffset);
+        Assert.Equal(50, qp.ResultRecordCount);
+        Assert.Equal("NAME ASC", qp.OrderByFields);
+        Assert.True(qp.ReturnDistinctValues);
+        Assert.True(qp.ReturnCountOnly);
+        Assert.True(qp.ReturnIdsOnly);
+        Assert.True(qp.ReturnExtentOnly);
+    }
+
+    [Fact]
+    public void ToFeatureServerQueryParams_DefaultsOutFieldsToWildcard()
+    {
+        var request = new QueryFeaturesRequest { ServiceId = "svc", LayerId = 0 };
+
+        var qp = RequestConverters.ToFeatureServerQueryParams(request);
+
+        Assert.Equal("*", qp.OutFields);
+    }
+
+    [Fact]
+    public void ToJsonDocument_QueryResponse_RoundTrips()
+    {
+        var response = new FeatureServerQueryResponse
+        {
+            ObjectIdFieldName = "OBJECTID",
+            ExceededTransferLimit = true,
+        };
+
+        using var doc = RequestConverters.ToJsonDocument(response);
+        Assert.Equal("OBJECTID", doc.RootElement.GetProperty("objectIdFieldName").GetString());
+        Assert.True(doc.RootElement.GetProperty("exceededTransferLimit").GetBoolean());
+    }
+
+    [Fact]
+    public void ToJsonDocument_EditResponse_RoundTrips()
+    {
+        var response = new FeatureServerEditResponse
+        {
+            AddResults = [new FeatureServerEditResult { ObjectId = 1, Success = true }],
+        };
+
+        using var doc = RequestConverters.ToJsonDocument(response);
+        Assert.Equal(1L, doc.RootElement.GetProperty("addResults")[0].GetProperty("objectId").GetInt64());
+        Assert.True(doc.RootElement.GetProperty("addResults")[0].GetProperty("success").GetBoolean());
+    }
+}
+

--- a/tests/Honua.Sdk.Grpc.Tests/Conversion/MobileRequestConvertersTests.cs
+++ b/tests/Honua.Sdk.Grpc.Tests/Conversion/MobileRequestConvertersTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Grpc.Conversion;
+using GrpcModels = Honua.Sdk.Grpc.Models;
+
+namespace Honua.Sdk.Grpc.Tests.Conversion;
+
+
+public class MobileRequestConvertersTests
+{
+    [Fact]
+    public void ToGrpcQueryRequest_MapsAllFields()
+    {
+        var request = new QueryFeaturesRequest
+        {
+            ServiceId = "svc",
+            LayerId = 3,
+            Where = "STATUS='Open'",
+            ObjectIds = [1L, 2L, 3L],
+            OutFields = ["NAME", "STATUS"],
+            ReturnGeometry = false,
+            ResultOffset = 50,
+            ResultRecordCount = 100,
+            OrderBy = "NAME ASC",
+            ReturnDistinct = true,
+            ReturnCountOnly = true,
+            ReturnIdsOnly = true,
+            ReturnExtentOnly = true,
+        };
+
+        var grpc = MobileRequestConverters.ToGrpcQueryRequest(request);
+
+        Assert.Equal("svc", grpc.ServiceId);
+        Assert.Equal(3, grpc.LayerId);
+        Assert.Equal("STATUS='Open'", grpc.Where);
+        Assert.Equal([1L, 2L, 3L], grpc.ObjectIds);
+        Assert.Equal(["NAME", "STATUS"], grpc.OutFields);
+        Assert.False(grpc.ReturnGeometry);
+        Assert.Equal(50, grpc.ResultOffset);
+        Assert.Equal(100, grpc.ResultRecordCount);
+        Assert.Equal("NAME ASC", grpc.OrderBy);
+        Assert.True(grpc.ReturnDistinct);
+        Assert.True(grpc.ReturnCountOnly);
+        Assert.True(grpc.ReturnIdsOnly);
+        Assert.True(grpc.ReturnExtentOnly);
+    }
+
+    [Fact]
+    public void ToGrpcQueryRequest_DefaultsForOptionalFields()
+    {
+        var request = new QueryFeaturesRequest { ServiceId = "svc", LayerId = 0 };
+
+        var grpc = MobileRequestConverters.ToGrpcQueryRequest(request);
+
+        Assert.Equal(0, grpc.ResultOffset);
+        Assert.Equal(0, grpc.ResultRecordCount);
+        Assert.Equal(string.Empty, grpc.OrderBy);
+        Assert.True(grpc.ReturnGeometry);
+    }
+
+    [Fact]
+    public void ToGrpcApplyEditsRequest_MapsAddsUpdatesDeletes()
+    {
+        var add = new FeatureEditFeature
+        {
+            ObjectId = 10,
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+            Geometry = JsonSerializer.SerializeToElement(new { x = 1.0, y = 2.0 }),
+        };
+        var update = new FeatureEditFeature
+        {
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["OBJECTID"] = JsonSerializer.SerializeToElement(20),
+                ["NAME"] = JsonSerializer.SerializeToElement("Beta"),
+            },
+        };
+
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 1,
+            Adds = [add],
+            Updates = [update],
+            Deletes = [100L, 101L],
+            RollbackOnFailure = true,
+            ForceWrite = true,
+        };
+
+        var grpc = MobileRequestConverters.ToGrpcApplyEditsRequest(request);
+
+        Assert.Equal("svc", grpc.ServiceId);
+        Assert.Equal(1, grpc.LayerId);
+        Assert.True(grpc.RollbackOnFailure);
+        Assert.True(grpc.ForceWrite);
+
+        Assert.NotNull(grpc.Adds);
+        Assert.Single(grpc.Adds);
+        Assert.Equal(10L, grpc.Adds[0].Id);
+        Assert.Equal("Alpha", grpc.Adds[0].Attributes["NAME"]);
+
+        Assert.NotNull(grpc.Updates);
+        Assert.Single(grpc.Updates);
+        Assert.Equal(20L, grpc.Updates[0].Id);
+
+        Assert.Equal([100L, 101L], grpc.Deletes);
+    }
+
+    [Fact]
+    public void ToGrpcApplyEditsRequest_ParsesJsonFallbacks()
+    {
+        var request = new ApplyEditsRequest
+        {
+            ServiceId = "svc",
+            LayerId = 0,
+            AddsJson = """[{"attributes":{"OBJECTID":1,"NAME":"X"},"geometry":{"x":1,"y":2}}]""",
+            UpdatesJson = """{"attributes":{"OBJECTID":"42","NAME":"Y"}}""",
+            DeletesCsv = "1, 2 ,3",
+        };
+
+        var grpc = MobileRequestConverters.ToGrpcApplyEditsRequest(request);
+
+        Assert.NotNull(grpc.Adds);
+        Assert.Single(grpc.Adds);
+        Assert.Equal(1L, grpc.Adds[0].Id);
+
+        Assert.NotNull(grpc.Updates);
+        Assert.Single(grpc.Updates);
+        Assert.Equal(42L, grpc.Updates[0].Id);
+
+        Assert.Equal([1L, 2L, 3L], grpc.Deletes);
+    }
+
+    [Fact]
+    public void ToGrpcApplyEditsRequest_OmitsNullCollectionsWhenEmpty()
+    {
+        var request = new ApplyEditsRequest { ServiceId = "svc", LayerId = 0 };
+
+        var grpc = MobileRequestConverters.ToGrpcApplyEditsRequest(request);
+
+        Assert.Null(grpc.Adds);
+        Assert.Null(grpc.Updates);
+        Assert.Null(grpc.Deletes);
+    }
+
+    [Fact]
+    public void ToJsonDocument_QueryResponse_SerializesCoreFields()
+    {
+        var response = new GrpcModels.QueryFeaturesResponse
+        {
+            ObjectIdFieldName = "OBJECTID",
+            GeometryType = GrpcModels.GeometryType.Point,
+            SpatialReference = new GrpcModels.SpatialReference { Wkid = 4326, LatestWkid = 4326 },
+            Fields =
+            [
+                new GrpcModels.FieldDefinition { Name = "NAME", FieldType = GrpcModels.FieldType.String, Length = 50, Nullable = true },
+            ],
+            Features =
+            [
+                new GrpcModels.Feature { Id = 1, Attributes = new Dictionary<string, object?> { ["NAME"] = "A" } },
+            ],
+            ExceededTransferLimit = true,
+            Count = 1,
+            ObjectIds = [1L],
+            Extent = new GrpcModels.Extent { Xmin = 0, Ymin = 0, Xmax = 1, Ymax = 1 },
+        };
+
+        using var doc = MobileRequestConverters.ToJsonDocument(response);
+        var root = doc.RootElement;
+        Assert.Equal("OBJECTID", root.GetProperty("objectIdFieldName").GetString());
+        Assert.True(root.GetProperty("exceededTransferLimit").GetBoolean());
+        Assert.Equal(1L, root.GetProperty("count").GetInt64());
+        Assert.Equal(4326, root.GetProperty("spatialReference").GetProperty("wkid").GetInt32());
+        Assert.Equal("A", root.GetProperty("features")[0].GetProperty("attributes").GetProperty("NAME").GetString());
+        Assert.Equal(1L, root.GetProperty("features")[0].GetProperty("id").GetInt64());
+        Assert.Equal(0.0, root.GetProperty("extent").GetProperty("xmin").GetDouble());
+    }
+
+    [Fact]
+    public void ToJsonDocument_FeaturePage_SerializesIsLastPage()
+    {
+        var page = new GrpcModels.FeaturePage
+        {
+            ObjectIdFieldName = "OBJECTID",
+            GeometryType = GrpcModels.GeometryType.Polygon,
+            IsLastPage = true,
+        };
+
+        using var doc = MobileRequestConverters.ToJsonDocument(page);
+        Assert.True(doc.RootElement.GetProperty("isLastPage").GetBoolean());
+        Assert.Equal("Polygon", doc.RootElement.GetProperty("geometryType").GetString());
+    }
+
+    [Fact]
+    public void ToJsonDocument_ApplyEditsResponse_SerializesResults()
+    {
+        var response = new GrpcModels.ApplyEditsResponse
+        {
+            AddResults = [new GrpcModels.EditResult { ObjectId = 1, Success = true }],
+            UpdateResults = [new GrpcModels.EditResult { ObjectId = 2, Success = false, Error = new GrpcModels.EditError { Code = 500, Message = "boom" } }],
+            DeleteResults = [],
+            Error = null,
+        };
+
+        using var doc = MobileRequestConverters.ToJsonDocument(response);
+        var root = doc.RootElement;
+        Assert.Equal(1L, root.GetProperty("addResults")[0].GetProperty("objectId").GetInt64());
+        Assert.True(root.GetProperty("addResults")[0].GetProperty("success").GetBoolean());
+
+        var updateError = root.GetProperty("updateResults")[0].GetProperty("error");
+        Assert.Equal(500, updateError.GetProperty("code").GetInt32());
+        Assert.Equal("boom", updateError.GetProperty("message").GetString());
+
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("error").ValueKind);
+    }
+
+    [Fact]
+    public void ToGrpcApplyEditsRequest_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => MobileRequestConverters.ToGrpcApplyEditsRequest(null!));
+    }
+
+    [Fact]
+    public void ToGrpcQueryRequest_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => MobileRequestConverters.ToGrpcQueryRequest(null!));
+    }
+}
+

--- a/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
+++ b/tests/Honua.Sdk.IntegrationTests/StagingReadOnlyIntegrationTests.cs
@@ -71,7 +71,7 @@ public sealed class StagingReadOnlyIntegrationTests(StagingIntegrationFixture fi
             async ct =>
             {
                 var response = await _fixture.GrpcClient.QueryFeaturesAsync(
-                    new QueryFeaturesRequest
+                    new Honua.Sdk.Grpc.Models.QueryFeaturesRequest
                     {
                         ServiceId = _fixture.Options.ServiceName,
                         LayerId = _fixture.Options.LayerId,

--- a/tests/Honua.Sdk.OgcFeatures.Tests/Conversion/RequestConvertersTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/Conversion/RequestConvertersTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.OgcFeatures.Conversion;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures.Tests.Conversion;
+
+
+public class RequestConvertersTests
+{
+    [Fact]
+    public void ToOgcFeature_PopulatesIdGeometryAndProperties()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Id = "abc",
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+            Geometry = JsonSerializer.SerializeToElement(new { type = "Point", coordinates = new[] { 1.0, 2.0 } }),
+        };
+
+        var ogc = RequestConverters.ToOgcFeature(feature);
+
+        Assert.True(ogc.Id.HasValue);
+        Assert.Equal("abc", ogc.Id!.Value.GetString());
+        Assert.True(ogc.Geometry.HasValue);
+        Assert.Equal("Alpha", ogc.Properties!["NAME"].GetString());
+    }
+
+    [Fact]
+    public void ToOgcFeature_FallsBackToObjectIdWhenNoId()
+    {
+        var feature = new FeatureEditFeature
+        {
+            ObjectId = 99,
+            Attributes = new Dictionary<string, JsonElement>(),
+        };
+
+        var ogc = RequestConverters.ToOgcFeature(feature);
+
+        Assert.True(ogc.Id.HasValue);
+        Assert.Equal("99", ogc.Id!.Value.GetString());
+    }
+
+    [Fact]
+    public void ToOgcFeature_OmitsIdWhenNeitherIdNorObjectIdSet()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Attributes = new Dictionary<string, JsonElement>(),
+        };
+
+        var ogc = RequestConverters.ToOgcFeature(feature);
+
+        Assert.Null(ogc.Id);
+    }
+
+    [Fact]
+    public void ToOgcFeature_AcceptsExplicitFeatureId()
+    {
+        var feature = new FeatureEditFeature
+        {
+            ObjectId = 1,
+            Attributes = new Dictionary<string, JsonElement>(),
+        };
+
+        var ogc = RequestConverters.ToOgcFeature(feature, featureId: "override");
+
+        Assert.Equal("override", ogc.Id!.Value.GetString());
+    }
+
+    [Fact]
+    public void ToOgcFeatureId_FormatsInvariant()
+    {
+        Assert.Equal("12345", RequestConverters.ToOgcFeatureId(12345L));
+    }
+
+    [Theory]
+    [InlineData(null, OgcFeaturesFormat.Json)]
+    [InlineData("", OgcFeaturesFormat.Json)]
+    [InlineData("json", OgcFeaturesFormat.Json)]
+    [InlineData("GEOJSON", OgcFeaturesFormat.GeoJson)]
+    [InlineData("html", OgcFeaturesFormat.Html)]
+    [InlineData("gml", OgcFeaturesFormat.Gml)]
+    [InlineData("csv", OgcFeaturesFormat.Csv)]
+    [InlineData("flatgeobuf", OgcFeaturesFormat.FlatGeobuf)]
+    [InlineData("parquet", OgcFeaturesFormat.Parquet)]
+    public void ToOgcItemsParams_MapsFormat(string? format, OgcFeaturesFormat expected)
+    {
+        var request = new OgcItemsRequest
+        {
+            CollectionId = "c",
+            ResponseFormat = format ?? "json",
+        };
+
+        var qp = RequestConverters.ToOgcItemsParams(request);
+        Assert.Equal(expected, qp.Format);
+    }
+
+    [Fact]
+    public void ToOgcItemsParams_JoinsPropertyNames()
+    {
+        var request = new OgcItemsRequest
+        {
+            CollectionId = "c",
+            Limit = 10,
+            Offset = 20,
+            PropertyNames = ["name", "status"],
+            CqlFilter = "status='Open'",
+        };
+
+        var qp = RequestConverters.ToOgcItemsParams(request);
+
+        Assert.Equal(10, qp.Limit);
+        Assert.Equal(20, qp.Offset);
+        Assert.Equal("name,status", qp.Properties);
+        Assert.Equal("status='Open'", qp.Filter);
+    }
+
+    [Fact]
+    public void ToOgcItemsParams_LeavesPropertiesNullWhenEmpty()
+    {
+        var request = new OgcItemsRequest { CollectionId = "c" };
+
+        var qp = RequestConverters.ToOgcItemsParams(request);
+
+        Assert.Null(qp.Properties);
+    }
+
+    [Fact]
+    public void ToOgcFeature_ReturnsSameInstanceWhenAlreadyOgcFeature()
+    {
+        var feature = new OgcFeature { Type = "Feature" };
+
+        var result = RequestConverters.ToOgcFeature((object)feature);
+
+        Assert.Same(feature, result);
+    }
+
+    [Fact]
+    public void ToOgcFeature_AcceptsJsonElement()
+    {
+        var element = JsonSerializer.SerializeToElement(new
+        {
+            type = "Feature",
+            properties = new { name = "Alpha" },
+        });
+
+        var result = RequestConverters.ToOgcFeature((object)element);
+
+        Assert.Equal("Alpha", result.Properties!["name"].GetString());
+    }
+
+    [Fact]
+    public void ToOgcFeature_AcceptsJsonDocument()
+    {
+        using var doc = JsonDocument.Parse("""{"type":"Feature","properties":{"name":"Beta"}}""");
+
+        var result = RequestConverters.ToOgcFeature((object)doc);
+
+        Assert.Equal("Beta", result.Properties!["name"].GetString());
+    }
+
+    [Fact]
+    public void ToOgcFeature_AcceptsFeatureEditFeature()
+    {
+        var edit = new FeatureEditFeature
+        {
+            Id = "1",
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["status"] = JsonSerializer.SerializeToElement("Open"),
+            },
+        };
+
+        var result = RequestConverters.ToOgcFeature((object)edit);
+
+        Assert.Equal("Open", result.Properties!["status"].GetString());
+    }
+
+    [Fact]
+    public void ToJsonElement_ClonesJsonElement()
+    {
+        var element = JsonSerializer.SerializeToElement(new { a = 1 });
+        var clone = RequestConverters.ToJsonElement((object)element);
+        Assert.Equal(1, clone.GetProperty("a").GetInt32());
+    }
+
+    [Fact]
+    public void ToJsonElement_ClonesJsonDocument()
+    {
+        using var doc = JsonDocument.Parse("""{"a":1}""");
+        var clone = RequestConverters.ToJsonElement((object)doc);
+        Assert.Equal(1, clone.GetProperty("a").GetInt32());
+    }
+
+    [Fact]
+    public void ToJsonDocument_CollectionsEnvelope_RoundTrips()
+    {
+        IReadOnlyList<OgcCollection> collections =
+        [
+            new OgcCollection { Id = "c1", Title = "Collection 1" },
+        ];
+
+        using var doc = RequestConverters.ToJsonDocument(collections);
+
+        Assert.Equal("c1", doc.RootElement.GetProperty("collections")[0].GetProperty("id").GetString());
+    }
+
+    [Fact]
+    public void ToJsonDocument_FeatureCollection_RoundTrips()
+    {
+        var collection = new OgcFeatureCollection
+        {
+            Type = "FeatureCollection",
+            Features = [new OgcFeature { Type = "Feature" }],
+        };
+
+        using var doc = RequestConverters.ToJsonDocument(collection);
+
+        Assert.Equal("FeatureCollection", doc.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void ToJsonDocument_Feature_RoundTrips()
+    {
+        var feature = new OgcFeature
+        {
+            Type = "Feature",
+            Properties = new Dictionary<string, JsonElement>
+            {
+                ["name"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+        };
+
+        using var doc = RequestConverters.ToJsonDocument(feature);
+
+        Assert.Equal("Alpha", doc.RootElement.GetProperty("properties").GetProperty("name").GetString());
+    }
+}
+

--- a/tests/Honua.Sdk.ProtocolIntegration.Tests/FeatureProtocolIntegrationTests.cs
+++ b/tests/Honua.Sdk.ProtocolIntegration.Tests/FeatureProtocolIntegrationTests.cs
@@ -20,7 +20,7 @@ public sealed class FeatureProtocolIntegrationTests(ProtocolIntegrationFixture f
         using var timeout = _fixture.CreateTimeoutScope();
 
         var response = await _fixture.GrpcClient.QueryFeaturesAsync(
-            new QueryFeaturesRequest
+            new Honua.Sdk.Grpc.Models.QueryFeaturesRequest
             {
                 ServiceId = _fixture.Options.ServiceName,
                 LayerId = _fixture.Options.LayerId,


### PR DESCRIPTION
## Summary

Moves the gRPC and REST transport mappings from honua-mobile into the SDK projects that own the destination types:

- `Honua.Sdk.Grpc.Conversion.MobileRequestConverters` — gRPC half (abstractions DTOs → `Honua.Sdk.Grpc.Models` + legacy `JsonDocument` formatters).
- `Honua.Sdk.GeoServices.FeatureServer.Conversion.RequestConverters` — FeatureServer REST conversions.
- `Honua.Sdk.OgcFeatures.Conversion.RequestConverters` — OGC API Features conversions.

REST converters land in `GeoServices`/`OgcFeatures` (not in `Honua.Sdk.Abstractions/Features/Converters/` as originally sketched) because `Honua.Sdk.Abstractions` cannot reference `Honua.Sdk.GeoServices` / `Honua.Sdk.OgcFeatures` — those projects own the concrete `FeatureServerFeature` / `OgcFeature` types the converters return.

Mapping-code clean-ups vs the mobile original:
- `ToLowerInvariant()` switches rewritten as `string.Equals(..., OrdinalIgnoreCase)` chains (CA1308).
- `FeatureServerFeature[]?` / `GrpcModels.Feature[]?` return types (CA1859).
- `ApplyEditsRequest.Adds/Updates` typed as `IReadOnlyList<FeatureEditFeature>?` (the provider-neutral existing type, matches DTO PR #152).

Two pre-existing test files (`StagingReadOnlyIntegrationTests.cs:74`, `FeatureProtocolIntegrationTests.cs:23`) needed `QueryFeaturesRequest` fully-qualified to disambiguate `Honua.Sdk.Abstractions.Features.QueryFeaturesRequest` vs `Honua.Sdk.Grpc.Models.QueryFeaturesRequest`.

## Dependencies

Depends on #152 (DTOs PR) for the canonical abstractions types. Until that lands, this branch carries a temporary `_MigrationShims.cs` with `[Obsolete]` duplicates of the same DTO types so it builds green in isolation.

## Test plan

- [x] 10 new `MobileRequestConvertersTests` (Grpc) — round-trip Adds/Updates JSON fallback, applyEdits responses, query response → `JsonDocument`.
- [x] 20 new `RequestConvertersTests` (GeoServices, including a `[Theory]` with 7 rows).
- [x] 25 new `RequestConvertersTests` (OgcFeatures, including a `[Theory]` with 9 rows).
- [x] Full SDK build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)