### PR TITLE
feat(grpc,geoservices,ogcfeatures,offline): expose converters publicly, surface Geometry transitively

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <HonuaSdkVersion>0.1.16-alpha.1</HonuaSdkVersion> <!-- x-release-please-version -->
+    <HonuaSdkVersion>0.1.17-alpha.2</HonuaSdkVersion> <!-- x-release-please-version -->
     <GeospatialGrpcVersion>0.1.0-alpha.1</GeospatialGrpcVersion>
     <Version>$(HonuaSdkVersion)</Version>
     <PackageVersion>$(HonuaSdkVersion)</PackageVersion>

--- a/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
@@ -11,15 +11,15 @@ namespace Honua.Sdk.GeoServices.FeatureServer.Conversion;
 
 
 /// <summary>
-/// Converts mobile/abstractions request DTOs to FeatureServer REST request
-/// shapes (query parameters, edit payloads, and form bodies).
+/// Converts abstractions request DTOs to FeatureServer REST request shapes
+/// (query parameters, edit payloads, and form bodies).
 /// </summary>
 /// <remarks>
-/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Methods
-/// are <c>internal</c> while the migration settles; promote to <c>public</c>
-/// once the abstractions DTO surface is finalised.
+/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Exposed
+/// as public surface so cross-assembly consumers (notably the mobile runtime)
+/// can compose these conversions without duplicating logic.
 /// </remarks>
-internal static class RequestConverters
+public static class RequestConverters
 {
     /// <summary>Converts an abstractions apply-edits request to a FeatureServer edit request.</summary>
     public static FeatureServerEditRequest ToFeatureServerEditRequest(ApplyEditsRequest request)

--- a/src/Honua.Sdk.Grpc/Conversion/MobileRequestConverters.cs
+++ b/src/Honua.Sdk.Grpc/Conversion/MobileRequestConverters.cs
@@ -12,15 +12,15 @@ namespace Honua.Sdk.Grpc.Conversion;
 
 
 /// <summary>
-/// Converts mobile-side request DTOs and gRPC response models for legacy
+/// Converts abstractions request DTOs and gRPC response models for legacy
 /// <c>JsonDocument</c>-returning surfaces.
 /// </summary>
 /// <remarks>
-/// Migrated from <c>Honua.Mobile.Sdk.SdkGrpcTransportMappings</c>. The converter
-/// is intentionally <c>internal</c> while the migration is in flight; only
-/// transport adapters inside this assembly are intended consumers.
+/// Migrated from <c>Honua.Mobile.Sdk.SdkGrpcTransportMappings</c>. Exposed as
+/// public surface so cross-assembly transport adapters (notably the mobile
+/// runtime) can compose these conversions without duplicating logic.
 /// </remarks>
-internal static class MobileRequestConverters
+public static class MobileRequestConverters
 {
     /// <summary>Converts an abstractions feature query request to its gRPC counterpart.</summary>
     public static GrpcModels.QueryFeaturesRequest ToGrpcQueryRequest(QueryFeaturesRequest request)

--- a/src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj
+++ b/src/Honua.Sdk.Offline.Abstractions/Honua.Sdk.Offline.Abstractions.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Honua.Sdk.Abstractions\Honua.Sdk.Abstractions.csproj" />
+    <ProjectReference Include="..\Honua.Sdk.Geometry\Honua.Sdk.Geometry.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honua.Sdk.OgcFeatures/Conversion/RequestConverters.cs
+++ b/src/Honua.Sdk.OgcFeatures/Conversion/RequestConverters.cs
@@ -11,14 +11,15 @@ namespace Honua.Sdk.OgcFeatures.Conversion;
 
 
 /// <summary>
-/// Converts mobile/abstractions request DTOs to OGC API Features request and
-/// payload shapes.
+/// Converts abstractions request DTOs to OGC API Features request and payload
+/// shapes.
 /// </summary>
 /// <remarks>
-/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Methods
-/// are <c>internal</c> while the migration settles.
+/// Migrated from <c>Honua.Mobile.Sdk.SdkFeatureTransportMappings</c>. Exposed
+/// as public surface so cross-assembly consumers (notably the mobile runtime)
+/// can compose these conversions without duplicating logic.
 /// </remarks>
-internal static class RequestConverters
+public static class RequestConverters
 {
     /// <summary>Converts a provider-neutral feature edit payload to an OGC GeoJSON feature.</summary>
     public static OgcFeature ToOgcFeature(FeatureEditFeature feature, string? featureId = null)


### PR DESCRIPTION
## Summary

Two follow-ups that complete the mobile-shim migration:

1. **Promote transport `RequestConverters` to public.** Lets cross-assembly consumers (notably the mobile runtime) compose these conversions without duplicating the logic. Affects:
   - `Honua.Sdk.Grpc.Conversion.MobileRequestConverters`
   - `Honua.Sdk.GeoServices.FeatureServer.Conversion.RequestConverters`
   - `Honua.Sdk.OgcFeatures.Conversion.RequestConverters`
   Supporting JSON contexts and the OGC envelope stay `internal` (implementation details).
2. **Add `Honua.Sdk.Geometry` as a `ProjectReference` of `Honua.Sdk.Offline.Abstractions`.** `GeographicBoundingBox` is a natural offline contract; this lets it flow transitively to downstream offline consumers instead of requiring an explicit `PackageReference`.

Bumps `HonuaSdkVersion` to `0.1.17-alpha.2`.

This is the last piece of the mobile-shim migration; with these public types in place, honua-mobile can delete `SdkFeatureTransportMappings.cs` and `SdkGrpcTransportMappings.cs` entirely and call the SDK directly.

## Dependencies

This branch was created off `trunk` and then had #151, #152, #153, #154 merged in to build cleanly. **Merge those four first**, then rebase this PR onto trunk — the resulting diff will be only:
- 3 `internal → public` visibility flips
- 1 `ProjectReference` add in `Honua.Sdk.Offline.Abstractions.csproj`
- 1 version bump in `Directory.Build.props`

## Test plan

- [x] Full `Honua.Sdk.sln` builds 0/0 with the public API change.
- [x] All existing SDK tests pass (600+ across 16 projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)