### PR TITLE
fix(geoservices): project GeoJSON Point geometry to FeatureServer {x,y}

### DIFF
--- a/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/Conversion/RequestConverters.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
+using Honua.Sdk.Geometry;
 
 namespace Honua.Sdk.GeoServices.FeatureServer.Conversion;
 
@@ -58,6 +59,13 @@ public static class RequestConverters
     }
 
     /// <summary>Converts a provider-neutral feature edit payload to a FeatureServer feature.</summary>
+    /// <remarks>
+    /// GeoJSON geometry payloads (<c>{"type":"Point","coordinates":[...]}</c> and friends) are
+    /// projected to FeatureServer's Esri JSON shape (<c>{"x":...,"y":...}</c>, <c>{"paths":[...]}</c>,
+    /// <c>{"rings":[...]}</c>, etc.) so callers can supply provider-neutral GeoJSON without each
+    /// caller re-implementing the conversion. Geometries that already match the FeatureServer
+    /// shape, or shapes the SDK cannot translate, are passed through unchanged.
+    /// </remarks>
     public static FeatureServerFeature ToFeatureServerFeature(FeatureEditFeature feature)
     {
         ArgumentNullException.ThrowIfNull(feature);
@@ -65,7 +73,75 @@ public static class RequestConverters
         return new FeatureServerFeature
         {
             Attributes = feature.Attributes.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone()),
-            Geometry = feature.Geometry?.Clone(),
+            Geometry = ProjectGeometryForFeatureServer(feature.Geometry),
+        };
+    }
+
+    /// <summary>
+    /// Projects an inbound geometry <see cref="JsonElement"/> to the FeatureServer (Esri JSON) shape.
+    /// Recognises GeoJSON Point/MultiPoint/LineString/MultiLineString/Polygon/MultiPolygon payloads
+    /// via their <c>"type"</c> discriminator and routes them through
+    /// <see cref="GeoJsonGeometryConverter"/> +
+    /// <see cref="GeoServicesGeometryConverter"/>. Geometries that already look like FeatureServer
+    /// shapes (have <c>x</c>/<c>y</c>, <c>rings</c>, <c>paths</c>, or <c>points</c>) or which we
+    /// cannot translate (GeometryCollection, etc.) are cloned and returned verbatim so the wire
+    /// payload is preserved for the server.
+    /// </summary>
+    private static JsonElement? ProjectGeometryForFeatureServer(JsonElement? geometry)
+    {
+        if (!geometry.HasValue)
+        {
+            return null;
+        }
+
+        var value = geometry.Value;
+        if (value.ValueKind != JsonValueKind.Object)
+        {
+            return value.Clone();
+        }
+
+        if (!IsGeoJsonGeometry(value))
+        {
+            // Already FeatureServer-shaped (or an unknown object we should not mutate).
+            return value.Clone();
+        }
+
+        try
+        {
+            var nts = GeoJsonGeometryConverter.ReadGeometry(value);
+            return GeoServicesGeometryConverter.WriteGeometry(nts);
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException or ArgumentException)
+        {
+            // GeoJSON shape we cannot translate (e.g., GeometryCollection or malformed payload).
+            // Fall back to the original payload so callers/servers can surface a precise error
+            // rather than this converter silently swallowing the geometry.
+            return value.Clone();
+        }
+    }
+
+    private static bool IsGeoJsonGeometry(JsonElement geometry)
+    {
+        if (geometry.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        if (!geometry.TryGetProperty("type", out var type) ||
+            type.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        return type.GetString() switch
+        {
+            "Point" or
+            "MultiPoint" or
+            "LineString" or
+            "MultiLineString" or
+            "Polygon" or
+            "MultiPolygon" => true,
+            _ => false,
         };
     }
 

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/Conversion/RequestConvertersTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/Conversion/RequestConvertersTests.cs
@@ -155,6 +155,160 @@ public class RequestConvertersTests
     }
 
     [Fact]
+    public void ToFeatureServerFeature_ProjectsGeoJsonPointToXy()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                type = "Point",
+                coordinates = new[] { -122.0, 37.5 },
+            }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.True(converted.Geometry.HasValue);
+        var geometry = converted.Geometry!.Value;
+        Assert.Equal(JsonValueKind.Object, geometry.ValueKind);
+        Assert.False(geometry.TryGetProperty("type", out _));
+        Assert.Equal(-122.0, geometry.GetProperty("x").GetDouble());
+        Assert.Equal(37.5, geometry.GetProperty("y").GetDouble());
+        Assert.False(geometry.TryGetProperty("z", out _));
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_ProjectsGeoJsonPointWithZ()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                type = "Point",
+                coordinates = new[] { -122.0, 37.5, 12.25 },
+            }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.True(converted.Geometry.HasValue);
+        var geometry = converted.Geometry!.Value;
+        Assert.Equal(-122.0, geometry.GetProperty("x").GetDouble());
+        Assert.Equal(37.5, geometry.GetProperty("y").GetDouble());
+        Assert.Equal(12.25, geometry.GetProperty("z").GetDouble());
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_PassesThroughFeatureServerShapedPoint()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                x = -122.0,
+                y = 37.5,
+                spatialReference = new { wkid = 4326 },
+            }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.True(converted.Geometry.HasValue);
+        var geometry = converted.Geometry!.Value;
+        Assert.Equal(-122.0, geometry.GetProperty("x").GetDouble());
+        Assert.Equal(37.5, geometry.GetProperty("y").GetDouble());
+        Assert.Equal(4326, geometry.GetProperty("spatialReference").GetProperty("wkid").GetInt32());
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_ProjectsGeoJsonLineStringToPaths()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                type = "LineString",
+                coordinates = new[]
+                {
+                    new[] { 0.0, 0.0 },
+                    new[] { 1.0, 1.0 },
+                    new[] { 2.0, 0.0 },
+                },
+            }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.True(converted.Geometry.HasValue);
+        var geometry = converted.Geometry!.Value;
+        Assert.False(geometry.TryGetProperty("type", out _));
+        var paths = geometry.GetProperty("paths");
+        Assert.Equal(JsonValueKind.Array, paths.ValueKind);
+        Assert.Equal(1, paths.GetArrayLength());
+        var path = paths[0];
+        Assert.Equal(3, path.GetArrayLength());
+        Assert.Equal(0.0, path[0][0].GetDouble());
+        Assert.Equal(0.0, path[0][1].GetDouble());
+        Assert.Equal(2.0, path[2][0].GetDouble());
+        Assert.Equal(0.0, path[2][1].GetDouble());
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_ProjectsGeoJsonPolygonToRings()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Geometry = JsonSerializer.SerializeToElement(new
+            {
+                type = "Polygon",
+                coordinates = new[]
+                {
+                    new[]
+                    {
+                        new[] { 0.0, 0.0 },
+                        new[] { 0.0, 1.0 },
+                        new[] { 1.0, 1.0 },
+                        new[] { 1.0, 0.0 },
+                        new[] { 0.0, 0.0 },
+                    },
+                },
+            }),
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.True(converted.Geometry.HasValue);
+        var geometry = converted.Geometry!.Value;
+        Assert.False(geometry.TryGetProperty("type", out _));
+        var rings = geometry.GetProperty("rings");
+        Assert.Equal(JsonValueKind.Array, rings.ValueKind);
+        Assert.Equal(1, rings.GetArrayLength());
+        var ring = rings[0];
+        Assert.Equal(5, ring.GetArrayLength());
+        Assert.Equal(0.0, ring[0][0].GetDouble());
+        Assert.Equal(0.0, ring[0][1].GetDouble());
+        var lastIndex = ring.GetArrayLength() - 1;
+        Assert.Equal(0.0, ring[lastIndex][0].GetDouble());
+        Assert.Equal(0.0, ring[lastIndex][1].GetDouble());
+    }
+
+    [Fact]
+    public void ToFeatureServerFeature_LeavesNullGeometryNull()
+    {
+        var feature = new FeatureEditFeature
+        {
+            Attributes = new Dictionary<string, JsonElement>
+            {
+                ["NAME"] = JsonSerializer.SerializeToElement("Alpha"),
+            },
+        };
+
+        var converted = RequestConverters.ToFeatureServerFeature(feature);
+
+        Assert.False(converted.Geometry.HasValue);
+    }
+
+    [Fact]
     public void ToFeatureServerDeleteObjectIds_CombinesNumericAndStringIds()
     {
         var request = new FeatureEditRequest


### PR DESCRIPTION
## Summary
- `ToFeatureServerFeature` in `Honua.Sdk.GeoServices.FeatureServer.Conversion.RequestConverters` previously forwarded `FeatureEditFeature.Geometry` verbatim. When callers supplied a GeoJSON `Point` (`{"type":"Point","coordinates":[lng,lat]}`), the converter shipped it to the FeatureServer `applyEdits` endpoint unchanged, which rejects/misinterprets that shape.
- The mobile-side helper that used to project this shape (`Honua.Mobile.Sdk.SdkFeatureTransportMappings`) was deleted in honua-mobile#187, leaving a real wire-format gap for any caller still relying on GeoJSON inputs. This PR closes it inside the SDK so cross-assembly consumers (notably the mobile runtime) inherit the conversion.
- GeoJSON `Point` (with optional `z`), `MultiPoint`, `LineString`/`MultiLineString`, and `Polygon`/`MultiPolygon` payloads are now projected to FeatureServer's Esri JSON shape (`{x,y[,z]}`, `{points}`, `{paths}`, `{rings}`) by routing through the existing `Honua.Sdk.Geometry.GeoJsonGeometryConverter` -> NetTopologySuite -> `GeoServicesGeometryConverter.WriteGeometry` pipeline. Already-FeatureServer-shaped geometries and any unrecognised payloads are cloned through unchanged.

## Unblocks
- honua-mobile#187 — the skipped test `ApplyEditsAsync_FeatureServerRequest_AcceptsSparseLiveImageEditResponse` can be re-enabled once the next SDK release is consumed.

## Test plan
- [x] `dotnet build src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj --no-restore -c Debug` — clean, 0 warnings under `TreatWarningsAsErrors`.
- [x] `dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj -c Debug` — 73 passed, 0 failed (7 new tests covering Point, Point+z, FS-shaped passthrough, LineString, Polygon, null geometry).
- [ ] CI pipeline green on this PR.

Marked as a fix unblocking the mobile follow-up. No version bump (release-please owns that).