### PR TITLE
[codex] field: add local project package contracts

### DIFF
--- a/src/Honua.Sdk.Field/Forms/FormModels.cs
+++ b/src/Honua.Sdk.Field/Forms/FormModels.cs
@@ -101,8 +101,17 @@ public sealed record FormField
     /// <summary>Choice values for single- or multi-choice fields.</summary>
     public IReadOnlyList<FieldChoice> Choices { get; init; } = [];
 
+    /// <summary>Shared choice-set identifier when choices are resolved from a catalog.</summary>
+    public string? ChoiceSetId { get; init; }
+
     /// <summary>Validation constraints for this field.</summary>
     public FieldValidationRule Validation { get; init; } = new();
+
+    /// <summary>Media capture policy for photo, video, audio, signature, sketch, or file fields.</summary>
+    public FieldMediaCapturePolicy? MediaPolicy { get; init; }
+
+    /// <summary>Referenced form identifier for record-link fields.</summary>
+    public string? ReferencedFormId { get; init; }
 
     /// <summary>Optional visibility rule evaluated against the current record.</summary>
     public FieldVisibilityRule? VisibilityRule { get; init; }
@@ -193,6 +202,12 @@ public sealed record FieldChoice
 
     /// <summary>Display label for host UI.</summary>
     public string? Label { get; init; }
+
+    /// <summary>Parent choice value for hierarchical classifications.</summary>
+    public string? ParentValue { get; init; }
+
+    /// <summary>Nested child choices for classification or cascading choice fields.</summary>
+    public IReadOnlyList<FieldChoice> Children { get; init; } = [];
 }
 
 /// <summary>
@@ -217,6 +232,30 @@ public sealed record FieldValidationRule
 
     /// <summary>Minimum media attachment count required for media fields.</summary>
     public int? MinMediaCount { get; init; }
+
+    /// <summary>Maximum media attachment count allowed for media fields.</summary>
+    public int? MaxMediaCount { get; init; }
+}
+
+/// <summary>
+/// Capture and export policy for media-like form fields.
+/// </summary>
+public sealed record FieldMediaCapturePolicy
+{
+    /// <summary>Allowed content types. Empty means runtime default.</summary>
+    public IReadOnlyList<string> AllowedContentTypes { get; init; } = [];
+
+    /// <summary>Maximum attachment size in bytes.</summary>
+    public long? MaxAttachmentBytes { get; init; }
+
+    /// <summary>Whether captured media should include location metadata when available.</summary>
+    public bool CaptureLocation { get; init; } = true;
+
+    /// <summary>Whether timed media should include a GPS track reference when available.</summary>
+    public bool CaptureGpsTrack { get; init; }
+
+    /// <summary>Whether captured photos should request face blurring before export/upload.</summary>
+    public bool RequiresFaceBlur { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.Field/Forms/FormValidator.cs
+++ b/src/Honua.Sdk.Field/Forms/FormValidator.cs
@@ -157,6 +157,11 @@ public static class FormValidator
         {
             errors.Add(new FormValidationError(field.FieldId, $"{field.Label} requires at least {minMedia} media item(s)."));
         }
+
+        if (field.Validation.MaxMediaCount is { } maxMedia && mediaCount > maxMedia)
+        {
+            errors.Add(new FormValidationError(field.FieldId, $"{field.Label} allows at most {maxMedia} media item(s)."));
+        }
     }
 
     private static int CountMedia(FieldRecord record, FormField field)

--- a/src/Honua.Sdk.Field/Projects/FieldProjectPackage.cs
+++ b/src/Honua.Sdk.Field/Projects/FieldProjectPackage.cs
@@ -1,0 +1,704 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Sdk.Field.Projects;
+
+/// <summary>
+/// Portable, no-cloud package describing a field project that a runtime can import locally.
+/// </summary>
+public sealed record FieldProjectPackage
+{
+    /// <summary>Current schema version for local field project package manifests.</summary>
+    public const string CurrentSchemaVersion = "honua.field-project-package.v1";
+
+    /// <summary>Manifest schema version.</summary>
+    public required string SchemaVersion { get; init; }
+
+    /// <summary>Stable project identifier.</summary>
+    public required string ProjectId { get; init; }
+
+    /// <summary>Human-readable project name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Optional package/project version.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Optional package description.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>UTC time the package was generated.</summary>
+    public DateTimeOffset? GeneratedAtUtc { get; init; }
+
+    /// <summary>Feature sources included in the project package.</summary>
+    public IReadOnlyList<SourceDescriptor> Sources { get; init; } = [];
+
+    /// <summary>Field forms included in the project package.</summary>
+    public IReadOnlyList<FormDefinition> Forms { get; init; } = [];
+
+    /// <summary>Bindings that connect forms to feature sources and offline package entries.</summary>
+    public IReadOnlyList<FieldProjectBinding> Bindings { get; init; } = [];
+
+    /// <summary>Offline feature/scene package artifacts bundled or referenced by this project.</summary>
+    public IReadOnlyList<FieldOfflinePackageReference> OfflinePackages { get; init; } = [];
+
+    /// <summary>Package-wide media capture/export policy.</summary>
+    public FieldProjectMediaPolicy MediaPolicy { get; init; } = new();
+
+    /// <summary>Package-wide record lifecycle policy.</summary>
+    public FieldRecordLifecyclePolicy LifecyclePolicy { get; init; } = FieldRecordLifecyclePolicy.Default;
+
+    /// <summary>Optional task packets that seed local field assignments.</summary>
+    public IReadOnlyList<FieldTaskPacket> TaskPackets { get; init; } = [];
+
+    /// <summary>Additional non-UI package metadata.</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Parses a package manifest JSON payload using the package contract defaults.</summary>
+    /// <param name="json">Manifest JSON.</param>
+    /// <returns>Parsed package manifest.</returns>
+    public static FieldProjectPackage ParseJson(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        return JsonSerializer.Deserialize<FieldProjectPackage>(json, FieldProjectPackageJson.Options)
+            ?? throw new JsonException("Field project package manifest was empty.");
+    }
+
+    /// <summary>Serializes this package manifest using the package contract defaults.</summary>
+    /// <returns>Manifest JSON.</returns>
+    public string ToJson()
+        => JsonSerializer.Serialize(this, FieldProjectPackageJson.Options);
+
+    /// <summary>Validates this package manifest.</summary>
+    /// <returns>Validation result with warnings and blocking errors.</returns>
+    public FieldProjectPackageValidationResult Validate()
+        => FieldProjectPackageValidator.Validate(this);
+}
+
+/// <summary>
+/// Connects one form to one portable source within a local field project package.
+/// </summary>
+public sealed record FieldProjectBinding
+{
+    /// <summary>Stable binding identifier.</summary>
+    public required string BindingId { get; init; }
+
+    /// <summary>Form identifier from <see cref="FieldProjectPackage.Forms"/>.</summary>
+    public required string FormId { get; init; }
+
+    /// <summary>Source descriptor identifier from <see cref="FieldProjectPackage.Sources"/>.</summary>
+    public required string SourceId { get; init; }
+
+    /// <summary>Optional offline artifact identifier that backs this binding.</summary>
+    public string? OfflinePackageId { get; init; }
+
+    /// <summary>Optional query used to seed the local package or filter assigned records.</summary>
+    public SourceQuery? SourceQuery { get; init; }
+
+    /// <summary>Whether records for this binding are expected to include geometry.</summary>
+    public bool RequiresGeometry { get; init; } = true;
+
+    /// <summary>Whether local create/update/delete operations are allowed for this binding.</summary>
+    public bool Editable { get; init; } = true;
+
+    /// <summary>Field id used as the primary display label in host UIs.</summary>
+    public string? DisplayFieldId { get; init; }
+
+    /// <summary>Field id used for local duplicate checks, when different from display field.</summary>
+    public string? DuplicateKeyFieldId { get; init; }
+}
+
+/// <summary>
+/// Portable reference to an offline artifact used by a field project package.
+/// </summary>
+public sealed record FieldOfflinePackageReference
+{
+    /// <summary>Stable offline package identifier.</summary>
+    public required string PackageId { get; init; }
+
+    /// <summary>Artifact kind.</summary>
+    public FieldOfflinePackageKind Kind { get; init; } = FieldOfflinePackageKind.FeatureData;
+
+    /// <summary>Relative path or file name inside the local package archive.</summary>
+    public string? RelativePath { get; init; }
+
+    /// <summary>Content type of the artifact, when known.</summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>Declared artifact size in bytes.</summary>
+    public long? SizeBytes { get; init; }
+
+    /// <summary>Lowercase hexadecimal SHA-256 digest, when supplied.</summary>
+    public string? Sha256 { get; init; }
+
+    /// <summary>Source ids represented by this artifact.</summary>
+    public IReadOnlyList<string> SourceIds { get; init; } = [];
+
+    /// <summary>UTC time after which the artifact should be considered stale.</summary>
+    public DateTimeOffset? StaleAfterUtc { get; init; }
+
+    /// <summary>UTC time after which offline use should be blocked or explicitly degraded.</summary>
+    public DateTimeOffset? OfflineUseExpiresAtUtc { get; init; }
+}
+
+/// <summary>
+/// Offline artifact kinds understood by field package consumers.
+/// </summary>
+public enum FieldOfflinePackageKind
+{
+    /// <summary>Feature data package such as GeoPackage, SQLite, or an SDK feature bundle.</summary>
+    FeatureData,
+
+    /// <summary>Map tile/style package used for local display.</summary>
+    MapTiles,
+
+    /// <summary>3D scene package used for local scene/AR workflows.</summary>
+    Scene,
+
+    /// <summary>Media seed package used for local reference attachments.</summary>
+    Media,
+
+    /// <summary>Opaque runtime-specific artifact.</summary>
+    Other
+}
+
+/// <summary>
+/// Package-level media capture and export policy.
+/// </summary>
+public sealed record FieldProjectMediaPolicy
+{
+    /// <summary>Allowed media content types. Empty means runtime default.</summary>
+    public IReadOnlyList<string> AllowedContentTypes { get; init; } = [];
+
+    /// <summary>Maximum single attachment size in bytes.</summary>
+    public long? MaxAttachmentBytes { get; init; }
+
+    /// <summary>Whether photo capture should request face blurring before export/upload.</summary>
+    public bool RequiresFaceBlurByDefault { get; init; }
+
+    /// <summary>Whether media capture should include GPS metadata when available.</summary>
+    public bool CaptureLocationByDefault { get; init; } = true;
+
+    /// <summary>Whether video/audio capture may include track metadata when available.</summary>
+    public bool CaptureGpsTrackForTimedMedia { get; init; }
+
+    /// <summary>Per-field media requirements and overrides.</summary>
+    public IReadOnlyList<FieldMediaRequirement> Requirements { get; init; } = [];
+}
+
+/// <summary>
+/// Per-field media requirement declared by a local field package.
+/// </summary>
+public sealed record FieldMediaRequirement
+{
+    /// <summary>Form identifier that owns the field.</summary>
+    public required string FormId { get; init; }
+
+    /// <summary>Field identifier for the media field.</summary>
+    public required string FieldId { get; init; }
+
+    /// <summary>Expected media type.</summary>
+    public FieldMediaType MediaType { get; init; }
+
+    /// <summary>Minimum attachment count for this field.</summary>
+    public int? MinCount { get; init; }
+
+    /// <summary>Maximum attachment count for this field.</summary>
+    public int? MaxCount { get; init; }
+
+    /// <summary>Allowed content types for this field. Empty means package default.</summary>
+    public IReadOnlyList<string> AllowedContentTypes { get; init; } = [];
+}
+
+/// <summary>
+/// Portable record lifecycle policy for local field packages.
+/// </summary>
+public sealed record FieldRecordLifecyclePolicy
+{
+    /// <summary>Default lifecycle policy for no-cloud local field workflows.</summary>
+    public static FieldRecordLifecyclePolicy Default { get; } = new()
+    {
+        AllowedStatuses =
+        [
+            RecordStatus.Draft,
+            RecordStatus.ReadyToSubmit,
+            RecordStatus.Submitted,
+            RecordStatus.Rejected,
+            RecordStatus.Approved,
+            RecordStatus.Reopened,
+            RecordStatus.Deleted
+        ],
+        AllowedTransitions =
+        [
+            new FieldRecordLifecycleTransition { From = RecordStatus.Draft, To = RecordStatus.ReadyToSubmit },
+            new FieldRecordLifecycleTransition { From = RecordStatus.ReadyToSubmit, To = RecordStatus.Submitted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Draft, To = RecordStatus.Submitted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Submitted, To = RecordStatus.Approved },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Submitted, To = RecordStatus.Rejected },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Submitted, To = RecordStatus.Deleted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Rejected, To = RecordStatus.Reopened },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Reopened, To = RecordStatus.ReadyToSubmit },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Reopened, To = RecordStatus.Submitted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Approved, To = RecordStatus.Reopened },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Draft, To = RecordStatus.Deleted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Rejected, To = RecordStatus.Deleted },
+            new FieldRecordLifecycleTransition { From = RecordStatus.Reopened, To = RecordStatus.Deleted }
+        ]
+    };
+
+    /// <summary>Status values the package expects clients to support.</summary>
+    public IReadOnlyList<RecordStatus> AllowedStatuses { get; init; } = [];
+
+    /// <summary>Allowed status transitions.</summary>
+    public IReadOnlyList<FieldRecordLifecycleTransition> AllowedTransitions { get; init; } = [];
+
+    /// <summary>Whether approved/submitted records should be read-only unless reopened.</summary>
+    public bool ProtectSubmittedRecords { get; init; } = true;
+
+    /// <summary>Whether rejected records may be edited locally.</summary>
+    public bool AllowRejectedEdit { get; init; } = true;
+}
+
+/// <summary>
+/// One allowed field record lifecycle transition.
+/// </summary>
+public sealed record FieldRecordLifecycleTransition
+{
+    /// <summary>Source status.</summary>
+    public RecordStatus From { get; init; }
+
+    /// <summary>Destination status.</summary>
+    public RecordStatus To { get; init; }
+
+    /// <summary>Optional role, group, or policy token required for this transition.</summary>
+    public string? RequiredActorRole { get; init; }
+}
+
+/// <summary>
+/// Local task packet bundled with a field project package.
+/// </summary>
+public sealed record FieldTaskPacket
+{
+    /// <summary>Stable task packet identifier.</summary>
+    public required string TaskPacketId { get; init; }
+
+    /// <summary>Human-readable task packet name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Assignments included in this packet.</summary>
+    public IReadOnlyList<FieldAssignment> Assignments { get; init; } = [];
+}
+
+/// <summary>
+/// Local assignment for a field user or crew.
+/// </summary>
+public sealed record FieldAssignment
+{
+    /// <summary>Stable assignment identifier.</summary>
+    public required string AssignmentId { get; init; }
+
+    /// <summary>Binding this assignment applies to.</summary>
+    public required string BindingId { get; init; }
+
+    /// <summary>Assigned user identifier, when known.</summary>
+    public string? AssigneeUserId { get; init; }
+
+    /// <summary>Assigned crew identifier, when known.</summary>
+    public string? CrewId { get; init; }
+
+    /// <summary>Assignment priority.</summary>
+    public FieldAssignmentPriority Priority { get; init; } = FieldAssignmentPriority.Normal;
+
+    /// <summary>Current assignment status.</summary>
+    public FieldAssignmentStatus Status { get; init; } = FieldAssignmentStatus.NotStarted;
+
+    /// <summary>UTC due date for this assignment.</summary>
+    public DateTimeOffset? DueAtUtc { get; init; }
+
+    /// <summary>Optional source query narrowing the work packet.</summary>
+    public SourceQuery? WorkQuery { get; init; }
+
+    /// <summary>Linked record identifiers, when tasks are pre-created.</summary>
+    public IReadOnlyList<string> RecordIds { get; init; } = [];
+
+    /// <summary>Additional non-UI assignment metadata.</summary>
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Assignment priority values.
+/// </summary>
+public enum FieldAssignmentPriority
+{
+    /// <summary>Low priority.</summary>
+    Low,
+
+    /// <summary>Normal priority.</summary>
+    Normal,
+
+    /// <summary>High priority.</summary>
+    High,
+
+    /// <summary>Urgent priority.</summary>
+    Urgent
+}
+
+/// <summary>
+/// Assignment progress values.
+/// </summary>
+public enum FieldAssignmentStatus
+{
+    /// <summary>Work has not started.</summary>
+    NotStarted,
+
+    /// <summary>Work is currently in progress.</summary>
+    InProgress,
+
+    /// <summary>Work is blocked by a local or field condition.</summary>
+    Blocked,
+
+    /// <summary>Work is complete locally.</summary>
+    Complete,
+
+    /// <summary>Work is canceled or no longer required.</summary>
+    Canceled
+}
+
+/// <summary>
+/// Validation result for field project packages.
+/// </summary>
+public sealed record FieldProjectPackageValidationResult
+{
+    /// <summary>Validation findings.</summary>
+    public IReadOnlyList<FieldProjectPackageValidationIssue> Issues { get; init; } = [];
+
+    /// <summary>Whether the package has no blocking validation errors.</summary>
+    public bool IsValid => Issues.All(issue => issue.Severity != FieldProjectPackageValidationSeverity.Error);
+
+    /// <summary>Whether the package has warning findings.</summary>
+    public bool HasWarnings => Issues.Any(issue => issue.Severity == FieldProjectPackageValidationSeverity.Warning);
+}
+
+/// <summary>
+/// One validation finding for a field project package.
+/// </summary>
+public sealed record FieldProjectPackageValidationIssue
+{
+    /// <summary>Machine-readable validation code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>JSON-style path to the affected value.</summary>
+    public required string Path { get; init; }
+
+    /// <summary>Human-readable validation message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>Finding severity.</summary>
+    public FieldProjectPackageValidationSeverity Severity { get; init; } = FieldProjectPackageValidationSeverity.Error;
+}
+
+/// <summary>
+/// Field project package validation severities.
+/// </summary>
+public enum FieldProjectPackageValidationSeverity
+{
+    /// <summary>Warning that should be shown but does not block local import.</summary>
+    Warning,
+
+    /// <summary>Error that blocks local import.</summary>
+    Error
+}
+
+/// <summary>
+/// Validation codes for field project package manifests.
+/// </summary>
+public static class FieldProjectPackageValidationCodes
+{
+    /// <summary>Manifest schema version is unsupported.</summary>
+    public const string UnsupportedSchemaVersion = "unsupported-schema-version";
+
+    /// <summary>Manifest is missing a required value.</summary>
+    public const string MissingRequiredValue = "missing-required-value";
+
+    /// <summary>Manifest references a missing form, source, binding, or package.</summary>
+    public const string MissingReference = "missing-reference";
+
+    /// <summary>Manifest contains a duplicate identifier.</summary>
+    public const string DuplicateIdentifier = "duplicate-identifier";
+
+    /// <summary>Manifest contains an invalid value.</summary>
+    public const string InvalidValue = "invalid-value";
+}
+
+/// <summary>
+/// Validator for no-cloud field project package manifests.
+/// </summary>
+public static class FieldProjectPackageValidator
+{
+    /// <summary>Validates a field project package manifest.</summary>
+    /// <param name="package">Package to validate.</param>
+    /// <returns>Validation result.</returns>
+    public static FieldProjectPackageValidationResult Validate(FieldProjectPackage package)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        var issues = new List<FieldProjectPackageValidationIssue>();
+
+        Require(issues, package.SchemaVersion, "$.schemaVersion", "Package schemaVersion is required.");
+        if (!string.IsNullOrWhiteSpace(package.SchemaVersion) &&
+            !string.Equals(package.SchemaVersion, FieldProjectPackage.CurrentSchemaVersion, StringComparison.Ordinal))
+        {
+            AddError(
+                issues,
+                FieldProjectPackageValidationCodes.UnsupportedSchemaVersion,
+                "$.schemaVersion",
+                $"Unsupported package schemaVersion '{package.SchemaVersion}'.");
+        }
+
+        Require(issues, package.ProjectId, "$.projectId", "Package projectId is required.");
+        Require(issues, package.Name, "$.name", "Package name is required.");
+
+        ValidateUnique(
+            issues,
+            package.Forms.Select(form => form.FormId),
+            "$.forms",
+            "Form identifiers must be unique.");
+        ValidateUnique(
+            issues,
+            package.Sources.Select(source => source.Id),
+            "$.sources",
+            "Source identifiers must be unique.");
+        ValidateUnique(
+            issues,
+            package.Bindings.Select(binding => binding.BindingId),
+            "$.bindings",
+            "Binding identifiers must be unique.");
+        ValidateUnique(
+            issues,
+            package.OfflinePackages.Select(offlinePackage => offlinePackage.PackageId),
+            "$.offlinePackages",
+            "Offline package identifiers must be unique.");
+
+        var formIds = package.Forms.Select(form => form.FormId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var sourceIds = package.Sources.Select(source => source.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var bindingIds = package.Bindings.Select(binding => binding.BindingId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var offlinePackageIds = package.OfflinePackages.Select(offlinePackage => offlinePackage.PackageId).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < package.Bindings.Count; i++)
+        {
+            var binding = package.Bindings[i];
+            var path = $"$.bindings[{i}]";
+            Require(issues, binding.BindingId, $"{path}.bindingId", "Binding id is required.");
+            Require(issues, binding.FormId, $"{path}.formId", "Binding formId is required.");
+            Require(issues, binding.SourceId, $"{path}.sourceId", "Binding sourceId is required.");
+
+            if (!string.IsNullOrWhiteSpace(binding.FormId) && !formIds.Contains(binding.FormId))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.MissingReference,
+                    $"{path}.formId",
+                    $"Binding references missing form '{binding.FormId}'.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(binding.SourceId) && !sourceIds.Contains(binding.SourceId))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.MissingReference,
+                    $"{path}.sourceId",
+                    $"Binding references missing source '{binding.SourceId}'.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(binding.OfflinePackageId) && !offlinePackageIds.Contains(binding.OfflinePackageId))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.MissingReference,
+                    $"{path}.offlinePackageId",
+                    $"Binding references missing offline package '{binding.OfflinePackageId}'.");
+            }
+        }
+
+        for (var i = 0; i < package.OfflinePackages.Count; i++)
+        {
+            var offlinePackage = package.OfflinePackages[i];
+            var path = $"$.offlinePackages[{i}]";
+            Require(issues, offlinePackage.PackageId, $"{path}.packageId", "Offline package id is required.");
+            foreach (var sourceId in offlinePackage.SourceIds)
+            {
+                if (!sourceIds.Contains(sourceId))
+                {
+                    AddError(
+                        issues,
+                        FieldProjectPackageValidationCodes.MissingReference,
+                        $"{path}.sourceIds",
+                        $"Offline package references missing source '{sourceId}'.");
+                }
+            }
+
+            if (offlinePackage.SizeBytes is < 0)
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.InvalidValue,
+                    $"{path}.sizeBytes",
+                    "Offline package sizeBytes must be zero or greater.");
+            }
+        }
+
+        for (var i = 0; i < package.MediaPolicy.Requirements.Count; i++)
+        {
+            var requirement = package.MediaPolicy.Requirements[i];
+            var path = $"$.mediaPolicy.requirements[{i}]";
+            Require(issues, requirement.FormId, $"{path}.formId", "Media requirement formId is required.");
+            Require(issues, requirement.FieldId, $"{path}.fieldId", "Media requirement fieldId is required.");
+
+            if (!string.IsNullOrWhiteSpace(requirement.FormId) && !formIds.Contains(requirement.FormId))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.MissingReference,
+                    $"{path}.formId",
+                    $"Media requirement references missing form '{requirement.FormId}'.");
+            }
+
+            if (requirement.MinCount is < 0 || requirement.MaxCount is < 0)
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.InvalidValue,
+                    path,
+                    "Media requirement counts must be zero or greater.");
+            }
+
+            if (requirement.MinCount is { } min && requirement.MaxCount is { } max && min > max)
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.InvalidValue,
+                    path,
+                    "Media requirement minCount cannot exceed maxCount.");
+            }
+        }
+
+        for (var i = 0; i < package.TaskPackets.Count; i++)
+        {
+            var packet = package.TaskPackets[i];
+            var path = $"$.taskPackets[{i}]";
+            Require(issues, packet.TaskPacketId, $"{path}.taskPacketId", "Task packet id is required.");
+
+            for (var j = 0; j < packet.Assignments.Count; j++)
+            {
+                var assignment = packet.Assignments[j];
+                var assignmentPath = $"{path}.assignments[{j}]";
+                Require(issues, assignment.AssignmentId, $"{assignmentPath}.assignmentId", "Assignment id is required.");
+                Require(issues, assignment.BindingId, $"{assignmentPath}.bindingId", "Assignment bindingId is required.");
+
+                if (!string.IsNullOrWhiteSpace(assignment.BindingId) && !bindingIds.Contains(assignment.BindingId))
+                {
+                    AddError(
+                        issues,
+                        FieldProjectPackageValidationCodes.MissingReference,
+                        $"{assignmentPath}.bindingId",
+                        $"Assignment references missing binding '{assignment.BindingId}'.");
+                }
+            }
+        }
+
+        ValidateLifecyclePolicy(issues, package.LifecyclePolicy);
+
+        return new FieldProjectPackageValidationResult { Issues = issues };
+    }
+
+    private static void ValidateLifecyclePolicy(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        FieldRecordLifecyclePolicy lifecyclePolicy)
+    {
+        var statuses = lifecyclePolicy.AllowedStatuses.Count > 0
+            ? lifecyclePolicy.AllowedStatuses.ToHashSet()
+            : Enum.GetValues<RecordStatus>().ToHashSet();
+
+        for (var i = 0; i < lifecyclePolicy.AllowedTransitions.Count; i++)
+        {
+            var transition = lifecyclePolicy.AllowedTransitions[i];
+            var path = $"$.lifecyclePolicy.allowedTransitions[{i}]";
+            if (!statuses.Contains(transition.From))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.InvalidValue,
+                    $"{path}.from",
+                    $"Transition source status '{transition.From}' is not allowed by the lifecycle policy.");
+            }
+
+            if (!statuses.Contains(transition.To))
+            {
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.InvalidValue,
+                    $"{path}.to",
+                    $"Transition destination status '{transition.To}' is not allowed by the lifecycle policy.");
+            }
+        }
+    }
+
+    private static void ValidateUnique(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        IEnumerable<string?> values,
+        string path,
+        string message)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var value in values.Where(value => !string.IsNullOrWhiteSpace(value)))
+        {
+            if (!seen.Add(value!))
+            {
+                AddError(issues, FieldProjectPackageValidationCodes.DuplicateIdentifier, path, message);
+                return;
+            }
+        }
+    }
+
+    private static void Require(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        string? value,
+        string path,
+        string message)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            AddError(issues, FieldProjectPackageValidationCodes.MissingRequiredValue, path, message);
+        }
+    }
+
+    private static void AddError(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        string code,
+        string path,
+        string message)
+        => issues.Add(new FieldProjectPackageValidationIssue
+        {
+            Code = code,
+            Path = path,
+            Message = message,
+            Severity = FieldProjectPackageValidationSeverity.Error
+        });
+}
+
+internal static class FieldProjectPackageJson
+{
+    public static JsonSerializerOptions Options { get; } = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() },
+        WriteIndented = true
+    };
+}

--- a/src/Honua.Sdk.Field/Projects/FieldProjectPackage.cs
+++ b/src/Honua.Sdk.Field/Projects/FieldProjectPackage.cs
@@ -452,6 +452,24 @@ public static class FieldProjectPackageValidator
 
         var issues = new List<FieldProjectPackageValidationIssue>();
 
+        ValidatePackageIdentity(issues, package);
+        ValidatePackageIdentifiers(issues, package);
+
+        var identifiers = FieldProjectPackageIdentifierSets.Create(package);
+
+        ValidateBindings(issues, package.Bindings, identifiers);
+        ValidateOfflinePackages(issues, package.OfflinePackages, identifiers.SourceIds);
+        ValidateMediaPolicy(issues, package.MediaPolicy, identifiers.FormIds);
+        ValidateTaskPackets(issues, package.TaskPackets, identifiers.BindingIds);
+        ValidateLifecyclePolicy(issues, package.LifecyclePolicy);
+
+        return new FieldProjectPackageValidationResult { Issues = issues };
+    }
+
+    private static void ValidatePackageIdentity(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        FieldProjectPackage package)
+    {
         Require(issues, package.SchemaVersion, "$.schemaVersion", "Package schemaVersion is required.");
         if (!string.IsNullOrWhiteSpace(package.SchemaVersion) &&
             !string.Equals(package.SchemaVersion, FieldProjectPackage.CurrentSchemaVersion, StringComparison.Ordinal))
@@ -465,6 +483,20 @@ public static class FieldProjectPackageValidator
 
         Require(issues, package.ProjectId, "$.projectId", "Package projectId is required.");
         Require(issues, package.Name, "$.name", "Package name is required.");
+    }
+
+    private static void ValidatePackageIdentifiers(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        FieldProjectPackage package)
+    {
+        RequireAll(
+            issues,
+            package.Forms.Select((form, index) => (Value: form.FormId, Path: $"$.forms[{index}].formId")),
+            "Form id is required.");
+        RequireAll(
+            issues,
+            package.Sources.Select((source, index) => (Value: source.Id, Path: $"$.sources[{index}].id")),
+            "Source id is required.");
 
         ValidateUnique(
             issues,
@@ -486,21 +518,22 @@ public static class FieldProjectPackageValidator
             package.OfflinePackages.Select(offlinePackage => offlinePackage.PackageId),
             "$.offlinePackages",
             "Offline package identifiers must be unique.");
+    }
 
-        var formIds = package.Forms.Select(form => form.FormId).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var sourceIds = package.Sources.Select(source => source.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var bindingIds = package.Bindings.Select(binding => binding.BindingId).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var offlinePackageIds = package.OfflinePackages.Select(offlinePackage => offlinePackage.PackageId).ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        for (var i = 0; i < package.Bindings.Count; i++)
+    private static void ValidateBindings(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        IReadOnlyList<FieldProjectBinding> bindings,
+        FieldProjectPackageIdentifierSets identifiers)
+    {
+        for (var i = 0; i < bindings.Count; i++)
         {
-            var binding = package.Bindings[i];
+            var binding = bindings[i];
             var path = $"$.bindings[{i}]";
             Require(issues, binding.BindingId, $"{path}.bindingId", "Binding id is required.");
             Require(issues, binding.FormId, $"{path}.formId", "Binding formId is required.");
             Require(issues, binding.SourceId, $"{path}.sourceId", "Binding sourceId is required.");
 
-            if (!string.IsNullOrWhiteSpace(binding.FormId) && !formIds.Contains(binding.FormId))
+            if (!string.IsNullOrWhiteSpace(binding.FormId) && !identifiers.FormIds.Contains(binding.FormId))
             {
                 AddError(
                     issues,
@@ -509,7 +542,7 @@ public static class FieldProjectPackageValidator
                     $"Binding references missing form '{binding.FormId}'.");
             }
 
-            if (!string.IsNullOrWhiteSpace(binding.SourceId) && !sourceIds.Contains(binding.SourceId))
+            if (!string.IsNullOrWhiteSpace(binding.SourceId) && !identifiers.SourceIds.Contains(binding.SourceId))
             {
                 AddError(
                     issues,
@@ -518,7 +551,8 @@ public static class FieldProjectPackageValidator
                     $"Binding references missing source '{binding.SourceId}'.");
             }
 
-            if (!string.IsNullOrWhiteSpace(binding.OfflinePackageId) && !offlinePackageIds.Contains(binding.OfflinePackageId))
+            if (!string.IsNullOrWhiteSpace(binding.OfflinePackageId) &&
+                !identifiers.OfflinePackageIds.Contains(binding.OfflinePackageId))
             {
                 AddError(
                     issues,
@@ -527,22 +561,25 @@ public static class FieldProjectPackageValidator
                     $"Binding references missing offline package '{binding.OfflinePackageId}'.");
             }
         }
+    }
 
-        for (var i = 0; i < package.OfflinePackages.Count; i++)
+    private static void ValidateOfflinePackages(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        IReadOnlyList<FieldOfflinePackageReference> offlinePackages,
+        IReadOnlySet<string> sourceIds)
+    {
+        for (var i = 0; i < offlinePackages.Count; i++)
         {
-            var offlinePackage = package.OfflinePackages[i];
+            var offlinePackage = offlinePackages[i];
             var path = $"$.offlinePackages[{i}]";
             Require(issues, offlinePackage.PackageId, $"{path}.packageId", "Offline package id is required.");
-            foreach (var sourceId in offlinePackage.SourceIds)
+            foreach (var sourceId in offlinePackage.SourceIds.Where(sourceId => !sourceIds.Contains(sourceId)))
             {
-                if (!sourceIds.Contains(sourceId))
-                {
-                    AddError(
-                        issues,
-                        FieldProjectPackageValidationCodes.MissingReference,
-                        $"{path}.sourceIds",
-                        $"Offline package references missing source '{sourceId}'.");
-                }
+                AddError(
+                    issues,
+                    FieldProjectPackageValidationCodes.MissingReference,
+                    $"{path}.sourceIds",
+                    $"Offline package references missing source '{sourceId}'.");
             }
 
             if (offlinePackage.SizeBytes is < 0)
@@ -554,10 +591,16 @@ public static class FieldProjectPackageValidator
                     "Offline package sizeBytes must be zero or greater.");
             }
         }
+    }
 
-        for (var i = 0; i < package.MediaPolicy.Requirements.Count; i++)
+    private static void ValidateMediaPolicy(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        FieldProjectMediaPolicy mediaPolicy,
+        IReadOnlySet<string> formIds)
+    {
+        for (var i = 0; i < mediaPolicy.Requirements.Count; i++)
         {
-            var requirement = package.MediaPolicy.Requirements[i];
+            var requirement = mediaPolicy.Requirements[i];
             var path = $"$.mediaPolicy.requirements[{i}]";
             Require(issues, requirement.FormId, $"{path}.formId", "Media requirement formId is required.");
             Require(issues, requirement.FieldId, $"{path}.fieldId", "Media requirement fieldId is required.");
@@ -589,10 +632,16 @@ public static class FieldProjectPackageValidator
                     "Media requirement minCount cannot exceed maxCount.");
             }
         }
+    }
 
-        for (var i = 0; i < package.TaskPackets.Count; i++)
+    private static void ValidateTaskPackets(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        IReadOnlyList<FieldTaskPacket> taskPackets,
+        IReadOnlySet<string> bindingIds)
+    {
+        for (var i = 0; i < taskPackets.Count; i++)
         {
-            var packet = package.TaskPackets[i];
+            var packet = taskPackets[i];
             var path = $"$.taskPackets[{i}]";
             Require(issues, packet.TaskPacketId, $"{path}.taskPacketId", "Task packet id is required.");
 
@@ -613,10 +662,6 @@ public static class FieldProjectPackageValidator
                 }
             }
         }
-
-        ValidateLifecyclePolicy(issues, package.LifecyclePolicy);
-
-        return new FieldProjectPackageValidationResult { Issues = issues };
     }
 
     private static void ValidateLifecyclePolicy(
@@ -657,14 +702,26 @@ public static class FieldProjectPackageValidator
         string path,
         string message)
     {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var value in values.Where(value => !string.IsNullOrWhiteSpace(value)))
+        var hasDuplicate = values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .GroupBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .Any(group => group.Skip(1).Any());
+
+        if (hasDuplicate)
         {
-            if (!seen.Add(value!))
-            {
-                AddError(issues, FieldProjectPackageValidationCodes.DuplicateIdentifier, path, message);
-                return;
-            }
+            AddError(issues, FieldProjectPackageValidationCodes.DuplicateIdentifier, path, message);
+        }
+    }
+
+    private static void RequireAll(
+        ICollection<FieldProjectPackageValidationIssue> issues,
+        IEnumerable<(string Value, string Path)> values,
+        string message)
+    {
+        foreach (var value in values.Where(value => string.IsNullOrWhiteSpace(value.Value)))
+        {
+            AddError(issues, FieldProjectPackageValidationCodes.MissingRequiredValue, value.Path, message);
         }
     }
 
@@ -692,6 +749,26 @@ public static class FieldProjectPackageValidator
             Message = message,
             Severity = FieldProjectPackageValidationSeverity.Error
         });
+
+    private sealed record FieldProjectPackageIdentifierSets(
+        IReadOnlySet<string> FormIds,
+        IReadOnlySet<string> SourceIds,
+        IReadOnlySet<string> BindingIds,
+        IReadOnlySet<string> OfflinePackageIds)
+    {
+        public static FieldProjectPackageIdentifierSets Create(FieldProjectPackage package)
+            => new(
+                CreateSet(package.Forms.Select(form => form.FormId)),
+                CreateSet(package.Sources.Select(source => source.Id)),
+                CreateSet(package.Bindings.Select(binding => binding.BindingId)),
+                CreateSet(package.OfflinePackages.Select(offlinePackage => offlinePackage.PackageId)));
+
+        private static HashSet<string> CreateSet(IEnumerable<string?> values)
+            => values
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .Select(value => value!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
 }
 
 internal static class FieldProjectPackageJson

--- a/src/Honua.Sdk.Field/README.md
+++ b/src/Honua.Sdk.Field/README.md
@@ -67,6 +67,29 @@ if (result.IsValid)
 }
 ```
 
+## Local project packages
+
+`Honua.Sdk.Field.Projects.FieldProjectPackage` is the portable no-cloud
+handoff model for field project packages. It groups SDK source descriptors,
+forms, source/form bindings, offline artifact references, media policy, record
+lifecycle policy, and local task packets so mobile or desktop runtimes can
+import a project from local files without cloud discovery or a hosted designer.
+
+```csharp
+using Honua.Sdk.Field.Projects;
+
+var package = FieldProjectPackage.ParseJson(File.ReadAllText("field-project.json"));
+var validation = package.Validate();
+
+if (!validation.IsValid)
+{
+    foreach (var issue in validation.Issues)
+    {
+        Console.WriteLine($"{issue.Path}: {issue.Message}");
+    }
+}
+```
+
 ## Documentation
 
 - [Quickstart](https://github.com/honua-io/honua-sdk-dotnet/blob/trunk/docs/quickstart.md)

--- a/src/Honua.Sdk.Field/Records/FieldRecord.cs
+++ b/src/Honua.Sdk.Field/Records/FieldRecord.cs
@@ -73,8 +73,101 @@ public sealed record FieldMediaAttachment
     /// <summary>UTC time the media was captured.</summary>
     public DateTimeOffset CapturedAtUtc { get; init; } = DateTimeOffset.UtcNow;
 
+    /// <summary>Media duration for audio/video attachments.</summary>
+    public TimeSpan? Duration { get; init; }
+
+    /// <summary>Optional GPS track reference for timed media.</summary>
+    public FieldGpsTrackReference? GpsTrack { get; init; }
+
+    /// <summary>Lowercase hexadecimal SHA-256 digest, when known.</summary>
+    public string? Sha256 { get; init; }
+
     /// <summary>Whether the host should blur faces before upload or export.</summary>
     public bool RequiresFaceBlur { get; init; }
+}
+
+/// <summary>
+/// Portable structured address value.
+/// </summary>
+public sealed record FieldAddressValue
+{
+    /// <summary>Single-line formatted address.</summary>
+    public string? Formatted { get; init; }
+
+    /// <summary>Street address lines.</summary>
+    public IReadOnlyList<string> Lines { get; init; } = [];
+
+    /// <summary>City or locality.</summary>
+    public string? Locality { get; init; }
+
+    /// <summary>State, province, or region.</summary>
+    public string? Region { get; init; }
+
+    /// <summary>Postal or ZIP code.</summary>
+    public string? PostalCode { get; init; }
+
+    /// <summary>Country code or country name.</summary>
+    public string? Country { get; init; }
+
+    /// <summary>Geocoded location for the address, when available.</summary>
+    public FieldGeoPoint? Location { get; init; }
+}
+
+/// <summary>
+/// Portable record-link value.
+/// </summary>
+public sealed record FieldRecordLinkValue
+{
+    /// <summary>Referenced form identifier.</summary>
+    public string? FormId { get; init; }
+
+    /// <summary>Referenced source identifier.</summary>
+    public string? SourceId { get; init; }
+
+    /// <summary>Referenced record identifier.</summary>
+    public required string RecordId { get; init; }
+
+    /// <summary>Display label captured at link time.</summary>
+    public string? Label { get; init; }
+}
+
+/// <summary>
+/// Portable barcode or QR scan value.
+/// </summary>
+public sealed record FieldBarcodeValue
+{
+    /// <summary>Decoded barcode or QR value.</summary>
+    public required string Value { get; init; }
+
+    /// <summary>Barcode format, such as QR_CODE or CODE_128, when known.</summary>
+    public string? Format { get; init; }
+
+    /// <summary>UTC scan time.</summary>
+    public DateTimeOffset ScannedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// Portable GPS track reference associated with audio or video capture.
+/// </summary>
+public sealed record FieldGpsTrackReference
+{
+    /// <summary>Stable track identifier.</summary>
+    public required string TrackId { get; init; }
+
+    /// <summary>Track file name without host-specific local path.</summary>
+    public string? FileName { get; init; }
+
+    /// <summary>Track content type, for example application/geo+json or application/gpx+xml.</summary>
+    public string? ContentType { get; init; }
+
+    /// <summary>Number of positions in the track, when known.</summary>
+    public int? PointCount { get; init; }
+
+    /// <summary>UTC track start time.</summary>
+    public DateTimeOffset? StartedAtUtc { get; init; }
+
+    /// <summary>UTC track end time.</summary>
+    public DateTimeOffset? EndedAtUtc { get; init; }
 }
 
 /// <summary>
@@ -117,6 +210,9 @@ public enum RecordStatus
     /// <summary>Record is being edited.</summary>
     Draft,
 
+    /// <summary>Record is valid locally and ready to submit or sync.</summary>
+    ReadyToSubmit,
+
     /// <summary>Record has been submitted for review or sync.</summary>
     Submitted,
 
@@ -124,5 +220,11 @@ public enum RecordStatus
     Approved,
 
     /// <summary>Record has been rejected and may be resubmitted.</summary>
-    Rejected
+    Rejected,
+
+    /// <summary>Record has been reopened after review.</summary>
+    Reopened,
+
+    /// <summary>Record has been locally deleted or marked for delete sync.</summary>
+    Deleted
 }

--- a/src/Honua.Sdk.Field/Records/RecordWorkflow.cs
+++ b/src/Honua.Sdk.Field/Records/RecordWorkflow.cs
@@ -18,10 +18,19 @@ public static class RecordWorkflow
     {
         return (from, to) switch
         {
+            (RecordStatus.Draft, RecordStatus.ReadyToSubmit) => true,
             (RecordStatus.Draft, RecordStatus.Submitted) => true,
+            (RecordStatus.ReadyToSubmit, RecordStatus.Submitted) => true,
             (RecordStatus.Submitted, RecordStatus.Approved) => true,
             (RecordStatus.Submitted, RecordStatus.Rejected) => true,
+            (RecordStatus.Submitted, RecordStatus.Deleted) => true,
+            (RecordStatus.Approved, RecordStatus.Reopened) => true,
             (RecordStatus.Rejected, RecordStatus.Submitted) => true,
+            (RecordStatus.Rejected, RecordStatus.Reopened) => true,
+            (RecordStatus.Rejected, RecordStatus.Deleted) => true,
+            (RecordStatus.Reopened, RecordStatus.ReadyToSubmit) => true,
+            (RecordStatus.Reopened, RecordStatus.Submitted) => true,
+            (RecordStatus.Reopened, RecordStatus.Deleted) => true,
             _ when from == to => true,
             _ => false,
         };
@@ -51,9 +60,14 @@ public static class RecordWorkflow
             record.CompletedAtUtc = null;
         }
 
-        if (targetStatus is RecordStatus.Approved or RecordStatus.Rejected)
+        if (targetStatus is RecordStatus.Approved or RecordStatus.Rejected or RecordStatus.Deleted)
         {
             record.CompletedAtUtc = now;
+        }
+
+        if (targetStatus is RecordStatus.Reopened or RecordStatus.ReadyToSubmit)
+        {
+            record.CompletedAtUtc = null;
         }
     }
 }

--- a/src/Honua.Sdk.Field/Records/RecordWorkflow.cs
+++ b/src/Honua.Sdk.Field/Records/RecordWorkflow.cs
@@ -20,6 +20,7 @@ public static class RecordWorkflow
         {
             (RecordStatus.Draft, RecordStatus.ReadyToSubmit) => true,
             (RecordStatus.Draft, RecordStatus.Submitted) => true,
+            (RecordStatus.Draft, RecordStatus.Deleted) => true,
             (RecordStatus.ReadyToSubmit, RecordStatus.Submitted) => true,
             (RecordStatus.Submitted, RecordStatus.Approved) => true,
             (RecordStatus.Submitted, RecordStatus.Rejected) => true,

--- a/tests/Honua.Sdk.Field.Tests/FieldProjectPackageTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/FieldProjectPackageTests.cs
@@ -1,0 +1,114 @@
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Field.Projects;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Sdk.Field.Tests;
+
+public sealed class FieldProjectPackageTests
+{
+    [Fact]
+    public void Fixture_DeserializesAndValidatesLocalPackageModel()
+    {
+        var package = FieldProjectPackage.ParseJson(ReadFixture("field-project-package.v1.json"));
+
+        Assert.Equal(FieldProjectPackage.CurrentSchemaVersion, package.SchemaVersion);
+        Assert.Equal("local-inspection-demo", package.ProjectId);
+        Assert.Equal(2, package.Forms.Count);
+        Assert.Equal(2, package.Sources.Count);
+        Assert.Equal(2, package.Bindings.Count);
+        Assert.Equal(2, package.TaskPackets[0].Assignments.Count);
+
+        var validation = package.Validate();
+
+        Assert.True(validation.IsValid, string.Join(Environment.NewLine, validation.Issues.Select(issue => issue.Message)));
+        Assert.Contains(package.LifecyclePolicy.AllowedStatuses, status => status == RecordStatus.ReadyToSubmit);
+        Assert.Contains(package.LifecyclePolicy.AllowedTransitions, transition =>
+            transition.From == RecordStatus.Rejected && transition.To == RecordStatus.Reopened);
+    }
+
+    [Fact]
+    public void ToJson_RoundTripsWithStableCamelCaseShape()
+    {
+        var package = FieldProjectPackage.ParseJson(ReadFixture("field-project-package.v1.json"));
+
+        var json = package.ToJson();
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.True(root.TryGetProperty("schemaVersion", out _));
+        Assert.True(root.TryGetProperty("projectId", out _));
+        Assert.True(root.TryGetProperty("mediaPolicy", out var mediaPolicy));
+        Assert.True(mediaPolicy.TryGetProperty("captureGpsTrackForTimedMedia", out _));
+        Assert.Equal("ReadyToSubmit", root
+            .GetProperty("lifecyclePolicy")
+            .GetProperty("allowedStatuses")[1]
+            .GetString());
+    }
+
+    [Fact]
+    public void Validate_ReturnsReferenceDiagnosticsForInvalidPackage()
+    {
+        var package = FieldProjectPackage.ParseJson(ReadFixture("field-project-package.v1.json")) with
+        {
+            Bindings =
+            [
+                new FieldProjectBinding
+                {
+                    BindingId = "broken",
+                    FormId = "missing-form",
+                    SourceId = "missing-source",
+                    OfflinePackageId = "missing-offline-package",
+                }
+            ],
+            TaskPackets =
+            [
+                new FieldTaskPacket
+                {
+                    TaskPacketId = "tasks",
+                    Assignments =
+                    [
+                        new FieldAssignment
+                        {
+                            AssignmentId = "assignment-1",
+                            BindingId = "missing-binding",
+                        }
+                    ],
+                },
+            ],
+        };
+
+        var result = package.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, issue => issue.Path == "$.bindings[0].formId");
+        Assert.Contains(result.Issues, issue => issue.Path == "$.bindings[0].sourceId");
+        Assert.Contains(result.Issues, issue => issue.Path == "$.bindings[0].offlinePackageId");
+        Assert.Contains(result.Issues, issue => issue.Path == "$.taskPackets[0].assignments[0].bindingId");
+    }
+
+    [Fact]
+    public void RecordWorkflow_AllowsNoCloudLifecycleTransitions()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-05-23T08:00:00Z", CultureInfo.InvariantCulture);
+        var record = new FieldRecord
+        {
+            RecordId = "record-local-1",
+            FormId = "inspection",
+            CreatedAtUtc = createdAt,
+        };
+
+        RecordWorkflow.Transition(record, RecordStatus.ReadyToSubmit, createdAt.AddMinutes(10));
+        RecordWorkflow.Transition(record, RecordStatus.Submitted, createdAt.AddMinutes(20));
+        RecordWorkflow.Transition(record, RecordStatus.Rejected, createdAt.AddMinutes(30));
+        RecordWorkflow.Transition(record, RecordStatus.Reopened, createdAt.AddMinutes(40));
+
+        Assert.Equal(RecordStatus.Reopened, record.Status);
+        Assert.Equal(createdAt.AddMinutes(20), record.SubmittedAtUtc);
+        Assert.Null(record.CompletedAtUtc);
+        Assert.True(RecordWorkflow.CanTransition(RecordStatus.Reopened, RecordStatus.Deleted));
+    }
+
+    private static string ReadFixture(string name)
+        => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Json", name));
+}

--- a/tests/Honua.Sdk.Field.Tests/FieldProjectPackageTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/FieldProjectPackageTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Honua.Sdk.Field.Forms;
 using Honua.Sdk.Field.Projects;
 using Honua.Sdk.Field.Records;
 
@@ -88,6 +89,32 @@ public sealed class FieldProjectPackageTests
     }
 
     [Fact]
+    public void Validate_ReturnsRequiredValueDiagnosticForBlankFormId()
+    {
+        var package = new FieldProjectPackage
+        {
+            SchemaVersion = FieldProjectPackage.CurrentSchemaVersion,
+            ProjectId = "blank-form-demo",
+            Name = "Blank form demo",
+            Forms =
+            [
+                new FormDefinition
+                {
+                    FormId = " ",
+                    Name = "Inspection",
+                },
+            ],
+        };
+
+        var result = package.Validate();
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, issue =>
+            issue.Code == FieldProjectPackageValidationCodes.MissingRequiredValue &&
+            issue.Path == "$.forms[0].formId");
+    }
+
+    [Fact]
     public void RecordWorkflow_AllowsNoCloudLifecycleTransitions()
     {
         var createdAt = DateTimeOffset.Parse("2026-05-23T08:00:00Z", CultureInfo.InvariantCulture);
@@ -110,5 +137,5 @@ public sealed class FieldProjectPackageTests
     }
 
     private static string ReadFixture(string name)
-        => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Json", name));
+        => File.ReadAllText(Path.Join(AppContext.BaseDirectory, "Fixtures", "Json", name));
 }

--- a/tests/Honua.Sdk.Field.Tests/Fixtures/Json/field-project-package.v1.json
+++ b/tests/Honua.Sdk.Field.Tests/Fixtures/Json/field-project-package.v1.json
@@ -1,0 +1,333 @@
+{
+  "schemaVersion": "honua.field-project-package.v1",
+  "projectId": "local-inspection-demo",
+  "name": "Local Inspection Demo",
+  "version": "2026.05",
+  "description": "No-cloud package fixture for Fulcrum and Survey123 parity workflows.",
+  "generatedAtUtc": "2026-05-23T08:00:00Z",
+  "sources": [
+    {
+      "id": "assets",
+      "protocol": "FeatureServer",
+      "locator": {
+        "serviceId": "mobile_offline_demo",
+        "layerId": 68910
+      },
+      "capabilities": [
+        "query",
+        "edit",
+        "attachments"
+      ],
+      "schema": {
+        "primaryKey": "globalid",
+        "objectIdField": "objectid",
+        "globalIdField": "globalid",
+        "geometryType": "Point",
+        "spatialReference": "EPSG:4326"
+      }
+    },
+    {
+      "id": "zones",
+      "protocol": "FeatureServer",
+      "locator": {
+        "serviceId": "mobile_offline_demo",
+        "layerId": 68920
+      },
+      "capabilities": [
+        "query"
+      ],
+      "schema": {
+        "primaryKey": "globalid",
+        "objectIdField": "objectid",
+        "globalIdField": "globalid",
+        "geometryType": "Polygon",
+        "spatialReference": "EPSG:4326"
+      }
+    }
+  ],
+  "forms": [
+    {
+      "formId": "asset-inspection",
+      "name": "Asset Inspection",
+      "version": "2026.05",
+      "target": {
+        "sourceId": "assets",
+        "serviceId": "mobile_offline_demo",
+        "layerId": 68910
+      },
+      "sections": [
+        {
+          "sectionId": "main",
+          "label": "Main",
+          "fields": [
+            {
+              "fieldId": "asset_id",
+              "label": "Asset ID",
+              "type": "Text",
+              "required": true
+            },
+            {
+              "fieldId": "condition",
+              "label": "Condition",
+              "type": "SingleChoice",
+              "required": true,
+              "choices": [
+                {
+                  "value": "good",
+                  "label": "Good"
+                },
+                {
+                  "value": "needsRepair",
+                  "label": "Needs repair"
+                }
+              ]
+            },
+            {
+              "fieldId": "repair_notes",
+              "label": "Repair notes",
+              "type": "Text",
+              "required": true,
+              "visibilityRule": {
+                "dependsOnFieldId": "condition",
+                "operator": "Equals",
+                "matchValue": "needsRepair"
+              }
+            },
+            {
+              "fieldId": "photos",
+              "label": "Photos",
+              "type": "Photo",
+              "required": true,
+              "validation": {
+                "minMediaCount": 2
+              }
+            },
+            {
+              "fieldId": "signature",
+              "label": "Inspector signature",
+              "type": "Signature",
+              "required": true,
+              "validation": {
+                "minMediaCount": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "formId": "incident-report",
+      "name": "Incident Report",
+      "version": "2026.05",
+      "target": {
+        "sourceId": "assets",
+        "serviceId": "mobile_offline_demo",
+        "layerId": 68910
+      },
+      "sections": [
+        {
+          "sectionId": "main",
+          "label": "Main",
+          "fields": [
+            {
+              "fieldId": "summary",
+              "label": "Summary",
+              "type": "Text",
+              "required": true
+            },
+            {
+              "fieldId": "priority",
+              "label": "Priority",
+              "type": "SingleChoice",
+              "required": true,
+              "choices": [
+                {
+                  "value": "normal",
+                  "label": "Normal"
+                },
+                {
+                  "value": "urgent",
+                  "label": "Urgent"
+                }
+              ]
+            },
+            {
+              "fieldId": "audio_note",
+              "label": "Audio note",
+              "type": "Audio"
+            },
+            {
+              "fieldId": "barcode",
+              "label": "Asset barcode",
+              "type": "Barcode"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "bindings": [
+    {
+      "bindingId": "asset-inspection-assets",
+      "formId": "asset-inspection",
+      "sourceId": "assets",
+      "offlinePackageId": "pkg-assets",
+      "requiresGeometry": true,
+      "editable": true,
+      "displayFieldId": "asset_id",
+      "duplicateKeyFieldId": "asset_id",
+      "sourceQuery": {
+        "where": "1=1",
+        "outFields": [
+          "objectid",
+          "globalid",
+          "asset_id",
+          "condition"
+        ],
+        "returnGeometry": true
+      }
+    },
+    {
+      "bindingId": "incident-assets",
+      "formId": "incident-report",
+      "sourceId": "assets",
+      "offlinePackageId": "pkg-assets",
+      "requiresGeometry": true,
+      "editable": true,
+      "displayFieldId": "summary"
+    }
+  ],
+  "offlinePackages": [
+    {
+      "packageId": "pkg-assets",
+      "kind": "FeatureData",
+      "relativePath": "data/assets.gpkg",
+      "contentType": "application/geopackage+sqlite3",
+      "sizeBytes": 2048,
+      "sha256": "d16b41d85f4b7f7fb8b95f861db7e3f7f00a5fb57ef5ef63b9f93d89f5e0fbe4",
+      "sourceIds": [
+        "assets",
+        "zones"
+      ],
+      "staleAfterUtc": "2026-06-23T08:00:00Z",
+      "offlineUseExpiresAtUtc": "2026-07-23T08:00:00Z"
+    }
+  ],
+  "mediaPolicy": {
+    "allowedContentTypes": [
+      "image/jpeg",
+      "image/png",
+      "audio/mp4",
+      "video/mp4",
+      "application/pdf"
+    ],
+    "maxAttachmentBytes": 52428800,
+    "requiresFaceBlurByDefault": true,
+    "captureLocationByDefault": true,
+    "captureGpsTrackForTimedMedia": true,
+    "requirements": [
+      {
+        "formId": "asset-inspection",
+        "fieldId": "photos",
+        "mediaType": "Photo",
+        "minCount": 2,
+        "maxCount": 12,
+        "allowedContentTypes": [
+          "image/jpeg",
+          "image/png"
+        ]
+      },
+      {
+        "formId": "asset-inspection",
+        "fieldId": "signature",
+        "mediaType": "Signature",
+        "minCount": 1,
+        "maxCount": 1
+      }
+    ]
+  },
+  "lifecyclePolicy": {
+    "allowedStatuses": [
+      "Draft",
+      "ReadyToSubmit",
+      "Submitted",
+      "Rejected",
+      "Approved",
+      "Reopened",
+      "Deleted"
+    ],
+    "allowedTransitions": [
+      {
+        "from": "Draft",
+        "to": "ReadyToSubmit"
+      },
+      {
+        "from": "ReadyToSubmit",
+        "to": "Submitted"
+      },
+      {
+        "from": "Submitted",
+        "to": "Approved"
+      },
+      {
+        "from": "Submitted",
+        "to": "Rejected"
+      },
+      {
+        "from": "Submitted",
+        "to": "Deleted"
+      },
+      {
+        "from": "Rejected",
+        "to": "Reopened"
+      },
+      {
+        "from": "Reopened",
+        "to": "ReadyToSubmit"
+      },
+      {
+        "from": "Reopened",
+        "to": "Deleted"
+      }
+    ],
+    "protectSubmittedRecords": true,
+    "allowRejectedEdit": true
+  },
+  "taskPackets": [
+    {
+      "taskPacketId": "crew-a-day-1",
+      "name": "Crew A day 1",
+      "assignments": [
+        {
+          "assignmentId": "task-asset-100",
+          "bindingId": "asset-inspection-assets",
+          "assigneeUserId": "field-user-1",
+          "priority": "High",
+          "status": "NotStarted",
+          "dueAtUtc": "2026-05-24T03:00:00Z",
+          "recordIds": [
+            "asset-100"
+          ],
+          "metadata": {
+            "route": "north"
+          }
+        },
+        {
+          "assignmentId": "task-incident-sweep",
+          "bindingId": "incident-assets",
+          "crewId": "crew-a",
+          "priority": "Normal",
+          "status": "NotStarted",
+          "workQuery": {
+            "where": "priority IN ('normal','urgent')",
+            "returnGeometry": true
+          }
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "fixtureOwner": "honua-sdk-dotnet",
+    "parityScope": "no-cloud-no-ui-design"
+  }
+}

--- a/tests/Honua.Sdk.Field.Tests/FormValidatorTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/FormValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Honua.Sdk.Field.Forms;
 using Honua.Sdk.Field.Records;
 
@@ -332,5 +333,115 @@ public sealed class FormValidatorTests
 
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, error => error.FieldId == "photos");
+    }
+
+    [Fact]
+    public void Validate_MediaFieldRejectsTooManyAttachments()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "inspection",
+            Name = "Inspection",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField
+                        {
+                            FieldId = "photos",
+                            Label = "Photos",
+                            Type = FormFieldType.Photo,
+                            Validation = new FieldValidationRule { MinMediaCount = 1, MaxMediaCount = 2 },
+                            MediaPolicy = new FieldMediaCapturePolicy
+                            {
+                                AllowedContentTypes = ["image/jpeg"],
+                                MaxAttachmentBytes = 5_000_000,
+                                RequiresFaceBlur = true,
+                                CaptureLocation = true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord
+        {
+            RecordId = "r-media",
+            FormId = "inspection",
+            Media =
+            [
+                new FieldMediaAttachment { AttachmentId = "p1", FieldId = "photos", MediaType = FieldMediaType.Photo },
+                new FieldMediaAttachment { AttachmentId = "p2", FieldId = "photos", MediaType = FieldMediaType.Photo },
+                new FieldMediaAttachment { AttachmentId = "p3", FieldId = "photos", MediaType = FieldMediaType.Photo },
+            ],
+        };
+
+        var result = FormValidator.Validate(form, record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.FieldId == "photos" && error.Message.Contains("at most 2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FieldRecord_PortableAdvancedValues_CanBeStoredInRecord()
+    {
+        var scannedAt = DateTimeOffset.Parse("2026-05-23T08:00:00Z", CultureInfo.InvariantCulture);
+        var record = new FieldRecord
+        {
+            RecordId = "r-advanced",
+            FormId = "incident",
+            Values =
+            {
+                ["address"] = new FieldAddressValue
+                {
+                    Formatted = "100 Main St, Honolulu, HI 96813",
+                    Locality = "Honolulu",
+                    Region = "HI",
+                    PostalCode = "96813",
+                    Location = new FieldGeoPoint(21.3069, -157.8583, 3),
+                },
+                ["asset_link"] = new FieldRecordLinkValue
+                {
+                    FormId = "asset-inspection",
+                    SourceId = "assets",
+                    RecordId = "asset-100",
+                    Label = "Asset 100",
+                },
+                ["barcode"] = new FieldBarcodeValue
+                {
+                    Value = "ASSET-100",
+                    Format = "QR_CODE",
+                    ScannedAtUtc = scannedAt,
+                },
+            },
+            Media =
+            [
+                new FieldMediaAttachment
+                {
+                    AttachmentId = "video-1",
+                    FieldId = "walkthrough",
+                    MediaType = FieldMediaType.Video,
+                    Duration = TimeSpan.FromSeconds(15),
+                    GpsTrack = new FieldGpsTrackReference
+                    {
+                        TrackId = "track-1",
+                        FileName = "track.geojson",
+                        ContentType = "application/geo+json",
+                        PointCount = 12,
+                    },
+                    Sha256 = "0123456789abcdef",
+                },
+            ],
+        };
+
+        Assert.IsType<FieldAddressValue>(record.Values["address"]);
+        Assert.IsType<FieldRecordLinkValue>(record.Values["asset_link"]);
+        Assert.Equal(scannedAt, Assert.IsType<FieldBarcodeValue>(record.Values["barcode"]).ScannedAtUtc);
+        Assert.Equal("track-1", record.Media[0].GpsTrack?.TrackId);
     }
 }

--- a/tests/Honua.Sdk.Field.Tests/RecordWorkflowTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/RecordWorkflowTests.cs
@@ -90,4 +90,23 @@ public sealed class RecordWorkflowTests
         Assert.Null(record.CompletedAtUtc);
         Assert.Null(record.Duration);
     }
+
+    [Fact]
+    public void Transition_AllowsDraftRecordDelete()
+    {
+        var createdAt = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var deletedAt = createdAt.AddMinutes(5);
+        var record = new FieldRecord
+        {
+            RecordId = "record-draft-delete",
+            FormId = "inspection",
+            CreatedAtUtc = createdAt,
+        };
+
+        RecordWorkflow.Transition(record, RecordStatus.Deleted, deletedAt);
+
+        Assert.Equal(RecordStatus.Deleted, record.Status);
+        Assert.Equal(deletedAt, record.CompletedAtUtc);
+        Assert.True(RecordWorkflow.CanTransition(RecordStatus.Draft, RecordStatus.Deleted));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `FieldProjectPackage` as the portable no-cloud project handoff contract for local field imports.
- Adds local bindings, offline artifact references, media policy, lifecycle policy, task packets, assignments, and package validation diagnostics.
- Extends form and record contracts for no-cloud parity values: choice sets, media policy, record links, structured addresses, barcodes, GPS track references, SHA-256 media metadata, and expanded lifecycle statuses.
- Adds a golden JSON fixture plus validation, serialization, media-count, advanced-value, and lifecycle tests.

## Linked issues

- Closes #160
- Closes #161

## Validation

- `dotnet test tests/Honua.Sdk.Field.Tests/Honua.Sdk.Field.Tests.csproj --verbosity minimal`
- `dotnet build src/Honua.Sdk.Field/Honua.Sdk.Field.csproj --no-restore -p:TreatWarningsAsErrors=true --verbosity minimal`
- `dotnet format src/Honua.Sdk.Field/Honua.Sdk.Field.csproj --verify-no-changes --no-restore --verbosity minimal`
- `dotnet format tests/Honua.Sdk.Field.Tests/Honua.Sdk.Field.Tests.csproj --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check`
