### PR TITLE
ci: repair SDK release workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,15 +61,16 @@ jobs:
           docfx docs/docfx.json
 
       - name: Configure GitHub Pages
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/configure-pages@v5
 
       - name: Upload DocFX site artifact
+        if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -251,6 +251,21 @@ jobs:
           dotnet tool update --global CycloneDX --version 4.* >/dev/null
           export PATH="$PATH:$HOME/.dotnet/tools"
 
+          projects=(
+            "src/Honua.Sdk.Abstractions/Honua.Sdk.Abstractions.csproj"
+            "src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj"
+            "src/Honua.Sdk.Geometry/Honua.Sdk.Geometry.csproj"
+            "src/Honua.Sdk.Spec/Honua.Sdk.Spec.csproj"
+            "src/Honua.Sdk.Grpc/Honua.Sdk.Grpc.csproj"
+            "src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj"
+            "src/Honua.Sdk.Scenes/Honua.Sdk.Scenes.csproj"
+            "src/Honua.Sdk.Field/Honua.Sdk.Field.csproj"
+            "src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj"
+            "src/Honua.Sdk.Catalogs/Honua.Sdk.Catalogs.csproj"
+            "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
+            "src/Honua.Sdk/Honua.Sdk.csproj"
+          )
+
           for project in "${projects[@]}"; do
             pkg_id="$(basename "$(dirname "${project}")")"
             dotnet CycloneDX "${project}" \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "dotnet",
+      "release-type": "simple",
       "component": "dotnet-sdk",
       "tag-separator": "-",
       "include-component-in-tag": true,


### PR DESCRIPTION
## Summary
- use Release Please's supported simple release strategy for the SDK manifest
- avoid GitHub Pages deployment when Pages is not explicitly enabled
- define the SDK project list in the SBOM generation step so publish artifacts are produced

## Validation
- python3 -m json.tool release-please-config.json
- git diff --check