### PR TITLE
ci: map SDK meta package in publish smoke

### DIFF
--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -346,6 +346,7 @@ jobs:
             </packageSourceCredentials>
             <packageSourceMapping>
               <packageSource key="local-sdk">
+                <package pattern="Honua.Sdk" />
                 <package pattern="Honua.Sdk.*" />
               </packageSource>
               <packageSource key="github-honua">

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,6 +13,7 @@
       <package pattern="Geospatial.Grpc" />
       <package pattern="Honua.Core" />
       <package pattern="Honua.Mobile.*" />
+      <package pattern="Honua.Sdk" />
       <package pattern="Honua.Sdk.*" />
     </packageSource>
   </packageSourceMapping>


### PR DESCRIPTION
## Summary
- map the root Honua.Sdk meta package to the local package source during publish install smoke
- map Honua.Sdk in the repo NuGet.config alongside Honua.Sdk.* packages

## Validation
- git diff --check