### PR TITLE
ci: fix WFS namespace in publish smoke

### DIFF
--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -405,9 +405,9 @@ jobs:
           using Honua.Sdk.Catalogs.Stac;
           using Honua.Sdk.Catalogs.Stac.Extensions;
           using Honua.Sdk.Catalogs.Stac.Models;
-          using Honua.Sdk.Wfs;
-          using Honua.Sdk.Wfs.Extensions;
-          using Honua.Sdk.Wfs.Models;
+          using Honua.Sdk.OgcFeatures.Wfs;
+          using Honua.Sdk.OgcFeatures.Wfs.Extensions;
+          using Honua.Sdk.OgcFeatures.Wfs.Models;
           using Microsoft.Extensions.DependencyInjection;
           using Microsoft.Extensions.Hosting;
 


### PR DESCRIPTION
## Summary
- update publish install smoke to import WFS types from Honua.Sdk.OgcFeatures.Wfs namespaces

## Validation
- git diff --check