### PR TITLE
ci: fix grpc options in publish smoke

### DIFF
--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -434,7 +434,7 @@ jobs:
           builder.Services.AddHonuaAdmin(options => options.BaseAddress = baseUri);
           builder.Services.AddHonuaGeocoding(options => options.BaseAddress = baseUri);
           builder.Services.AddHonuaSpec(options => options.BaseAddress = baseUri);
-          builder.Services.AddHonuaGrpc(options => options.Address = baseUri.ToString());
+          builder.Services.AddHonuaGrpc(options => options.BaseAddress = baseUri);
           builder.Services.AddHonuaWfs(options => options.BaseAddress = baseUri);
           builder.Services.AddHonuaFeatureServer(options => options.BaseAddress = baseUri);
           builder.Services.AddHonuaScenes(options => options.BaseAddress = baseUri);


### PR DESCRIPTION
## Summary
- update the publish package install smoke to use HonuaGrpcClientOptions.BaseAddress
- validates the extracted smoke Program.cs against the current source API locally

## Validation
- dotnet build /tmp/honua-sdk-publish-smoke --configuration Release
- git diff --check