### PR TITLE
test(geoservices): contract tests for ImageServer/GeometryServer + skipped gap tests

### DIFF
--- a/tests/Honua.Sdk.GeoServices.Tests/GeoServices/GeoServicesSpecTierContractTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/GeoServices/GeoServicesSpecTierContractTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.GeoServices.Tests.GeoServices;
+
+/// <summary>
+/// Contract tests for the GeoServices ImageServer, GeometryServer, and
+/// raster <c>exportImage</c> surfaces.
+///
+/// These surfaces are currently spec-tier only: the canonical protocol
+/// identifiers and capability sets are declared in <see cref="FeatureProtocolIds"/>
+/// and <see cref="FeatureProtocolCapabilities"/>, but no .NET client implements
+/// them yet (compare with the implemented FeatureServer and NAServer routing
+/// clients). These tests lock down the published protocol/capability contract so
+/// the wiring stays stable while the clients are built. The expected client
+/// behavior for the unimplemented operations is documented in
+/// <c>GeoServicesSpecTierGapTests</c> as clearly-marked skipped tests.
+/// </summary>
+public sealed class GeoServicesSpecTierContractTests
+{
+    // -- ImageServer protocol id + aliases ------------------------------------
+
+    [Fact]
+    public void ImageService_CanonicalProtocolId_IsStable()
+    {
+        Assert.Equal("geoservices-image-service", FeatureProtocolIds.GeoServicesImageService);
+        Assert.Contains(FeatureProtocolIds.GeoServicesImageService, FeatureProtocolIds.All);
+    }
+
+    [Theory]
+    [InlineData("geoservices-image-service")]
+    [InlineData("image-server")]
+    [InlineData("imageserver")]
+    [InlineData("IMAGESERVER")]
+    public void ImageService_Aliases_NormalizeToCanonicalId(string alias)
+    {
+        Assert.Equal(
+            FeatureProtocolIds.GeoServicesImageService,
+            FeatureProtocolIds.Normalize(alias));
+        Assert.True(FeatureProtocolIds.Matches(alias, FeatureProtocolIds.GeoServicesImageService));
+    }
+
+    [Fact]
+    public void ImageService_AliasesFor_IncludesKnownProviderNames()
+    {
+        var aliases = FeatureProtocolIds.AliasesFor(FeatureProtocolIds.GeoServicesImageService);
+
+        Assert.Contains(FeatureProtocolIds.GeoServicesImageService, aliases);
+        Assert.Contains("image-server", aliases);
+        Assert.Contains("imageserver", aliases);
+    }
+
+    [Fact]
+    public void ImageService_DefaultCapabilities_AdvertiseImageRenderAndTiles()
+    {
+        var capabilities = FeatureProtocolCapabilities.DefaultsFor(
+            FeatureProtocolIds.GeoServicesImageService);
+
+        Assert.Contains(FeatureCapabilities.Image, capabilities);
+        Assert.Contains(FeatureCapabilities.Render, capabilities);
+        Assert.Contains(FeatureCapabilities.Tiles, capabilities);
+        Assert.Contains(FeatureCapabilities.Query, capabilities);
+        Assert.Contains(FeatureCapabilities.QueryExtent, capabilities);
+        Assert.Contains(FeatureCapabilities.QueryObjectIds, capabilities);
+        Assert.Contains(FeatureCapabilities.Connect, capabilities);
+    }
+
+    // -- GeometryServer protocol id + aliases ---------------------------------
+
+    [Fact]
+    public void GeometryService_CanonicalProtocolId_IsStable()
+    {
+        Assert.Equal("geoservices-geometry-service", FeatureProtocolIds.GeoServicesGeometryService);
+        Assert.Contains(FeatureProtocolIds.GeoServicesGeometryService, FeatureProtocolIds.All);
+    }
+
+    [Theory]
+    [InlineData("geoservices-geometry-service")]
+    [InlineData("geometry-server")]
+    [InlineData("geometryserver")]
+    [InlineData("GeometryServer")]
+    public void GeometryService_Aliases_NormalizeToCanonicalId(string alias)
+    {
+        Assert.Equal(
+            FeatureProtocolIds.GeoServicesGeometryService,
+            FeatureProtocolIds.Normalize(alias));
+        Assert.True(FeatureProtocolIds.Matches(alias, FeatureProtocolIds.GeoServicesGeometryService));
+    }
+
+    [Fact]
+    public void GeometryService_AliasesFor_IncludesKnownProviderNames()
+    {
+        var aliases = FeatureProtocolIds.AliasesFor(FeatureProtocolIds.GeoServicesGeometryService);
+
+        Assert.Contains(FeatureProtocolIds.GeoServicesGeometryService, aliases);
+        Assert.Contains("geometry-server", aliases);
+        Assert.Contains("geometryserver", aliases);
+    }
+
+    [Fact]
+    public void GeometryService_DefaultCapabilities_AdvertiseGeometryAndConnect()
+    {
+        var capabilities = FeatureProtocolCapabilities.DefaultsFor(
+            FeatureProtocolIds.GeoServicesGeometryService);
+
+        Assert.Contains(FeatureCapabilities.Geometry, capabilities);
+        Assert.Contains(FeatureCapabilities.Connect, capabilities);
+    }
+
+    // -- exportImage (MapServer / ImageServer raster export) ------------------
+
+    [Fact]
+    public void MapService_DefaultCapabilities_AdvertiseRenderForExportImage()
+    {
+        // exportImage is a raster export operation exposed by GeoServices
+        // MapServer and ImageServer endpoints. It is surfaced through the
+        // `render` (and, for ImageServer, `image`) capability rather than a
+        // dedicated capability id.
+        var mapCapabilities = FeatureProtocolCapabilities.DefaultsFor(
+            FeatureProtocolIds.GeoServicesMapService);
+        var imageCapabilities = FeatureProtocolCapabilities.DefaultsFor(
+            FeatureProtocolIds.GeoServicesImageService);
+
+        Assert.Contains(FeatureCapabilities.Render, mapCapabilities);
+        Assert.Contains(FeatureCapabilities.Render, imageCapabilities);
+        Assert.Contains(FeatureCapabilities.Image, imageCapabilities);
+    }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/GeoServices/GeoServicesSpecTierGapTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/GeoServices/GeoServicesSpecTierGapTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.GeoServices.Tests.GeoServices;
+
+/// <summary>
+/// Spec-tier coverage gaps for GeoServices ImageServer, GeometryServer, and the
+/// raster <c>exportImage</c> operation.
+///
+/// Unlike the implemented FeatureServer (<c>HonuaFeatureServerClient</c>) and
+/// NAServer routing (<c>HonuaRoutingClient</c>) clients, there is currently no
+/// .NET client for these surfaces — only the protocol identifiers and capability
+/// sets exist (locked down by <c>GeoServicesSpecTierContractTests</c>).
+///
+/// Each test below is intentionally <c>Skip</c>-marked. The skip reason names the
+/// missing type/operation, and the body documents the GeoServices REST contract
+/// the future client is expected to honor (endpoint path, request parameters, and
+/// response shape) using the same MockHttpHandler/form-capture pattern used by the
+/// routing tests. When a client is implemented, remove the <c>Skip</c> and wire the
+/// assertions to the real client — the documented contract should not need to
+/// change.
+///
+/// Keeping these as discoverable skipped tests (rather than omitting them) makes
+/// the coverage gap visible in test runs and prevents "invented" behavior from
+/// silently shipping.
+/// </summary>
+public sealed class GeoServicesSpecTierGapTests
+{
+    private const string ImageServerGap =
+        "GeoServices ImageServer client is not implemented yet (spec-tier only: " +
+        "FeatureProtocolIds.GeoServicesImageService exists, no HonuaImageServerClient). " +
+        "Tracked under honua-sdk-dotnet#166.";
+
+    private const string GeometryServerGap =
+        "GeoServices GeometryServer client is not implemented yet (spec-tier only: " +
+        "FeatureProtocolIds.GeoServicesGeometryService exists, no HonuaGeometryServerClient). " +
+        "Tracked under honua-sdk-dotnet#166.";
+
+    private const string ExportImageGap =
+        "GeoServices MapServer/ImageServer exportImage operation is not implemented yet " +
+        "(spec-tier only: advertised via the 'render'/'image' capabilities, no export client). " +
+        "Tracked under honua-sdk-dotnet#166.";
+
+    // -- ImageServer ----------------------------------------------------------
+
+    [Fact(Skip = ImageServerGap)]
+    public void ImageServer_GetServiceMetadata_ContractIsDocumented()
+    {
+        // Expected contract for the future HonuaImageServerClient:
+        //
+        //   GET /rest/services/{serviceId}/ImageServer?f=json
+        //
+        // Parses the ImageServer service description into a metadata model:
+        //   - serviceDescription, name, pixelType
+        //   - extent (xmin/ymin/xmax/ymax + spatialReference)
+        //   - bandCount, minValues/maxValues per band
+        //   - supportedQueryFormats, supportedImageFormatTypes (e.g. "PNG,JPG,...")
+        //   - allowedMosaicMethods, defaultMosaicMethod
+        //   - hasRasterAttributeTable, hasHistograms
+        //
+        // Errors surface as HonuaFeatureServerException (GeoServices `error`
+        // envelope: { error: { code, message, details[] } }).
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented ImageServer metadata.");
+    }
+
+    [Fact(Skip = ImageServerGap)]
+    public void ImageServer_ExportImage_ContractIsDocumented()
+    {
+        // Expected contract:
+        //
+        //   GET (or POST form) /rest/services/{serviceId}/ImageServer/exportImage
+        //   Parameters:
+        //     bbox            "<xmin>,<ymin>,<xmax>,<ymax>"
+        //     bboxSR / imageSR spatial reference wkids
+        //     size            "<width>,<height>"
+        //     format          png | png8 | png24 | jpg | tiff | ...
+        //     pixelType       (optional override)
+        //     noData, noDataInterpretation
+        //     interpolation   RSP_BilinearInterpolation | RSP_NearestNeighbor | ...
+        //     mosaicRule, renderingRule (JSON)
+        //     f               image | json (json returns href + extent metadata)
+        //
+        // With f=image the response body is the raw raster stream
+        // (Content-Type image/png etc.) — the client should expose it as a
+        // ResponseOwningStream so the caller owns disposal, mirroring how
+        // FeatureServer streams vector tile/PBF payloads.
+        //
+        // With f=json the response is { href, width, height, extent, scale }.
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented ImageServer exportImage.");
+    }
+
+    [Fact(Skip = ImageServerGap)]
+    public void ImageServer_IdentifyPixel_ContractIsDocumented()
+    {
+        // Expected contract:
+        //
+        //   GET /rest/services/{serviceId}/ImageServer/identify
+        //   Parameters: geometry (point), geometryType=esriGeometryPoint,
+        //               mosaicRule, renderingRule, pixelSize, f=json
+        //   Response:   { objectId, name, value, location, catalogItems, ... }
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented ImageServer identify.");
+    }
+
+    // -- GeometryServer -------------------------------------------------------
+
+    [Fact(Skip = GeometryServerGap)]
+    public void GeometryServer_Project_ContractIsDocumented()
+    {
+        // Expected contract for the future HonuaGeometryServerClient:
+        //
+        //   POST /rest/services/Geometry/GeometryServer/project (form-encoded)
+        //   Parameters:
+        //     geometries     { geometryType, geometries: [...] }
+        //     inSR           input spatial reference wkid
+        //     outSR          output spatial reference wkid
+        //     transformation (optional datum transformation id)
+        //     f              json
+        //   Response: { geometries: [ projected geometries ] }
+        //
+        // NOTE: per AGENTS.md, CRS transforms should be performed via ProjNet
+        // locally where possible; this client is the remote fallback that
+        // delegates to the server GeometryServer for transformations the SDK
+        // cannot perform offline.
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented GeometryServer project.");
+    }
+
+    [Fact(Skip = GeometryServerGap)]
+    public void GeometryServer_Buffer_ContractIsDocumented()
+    {
+        // Expected contract:
+        //
+        //   POST /rest/services/Geometry/GeometryServer/buffer (form-encoded)
+        //   Parameters:
+        //     geometries, inSR, outSR, bufferSR
+        //     distances      comma-separated list
+        //     unit           esriSRUnit_* / esriSRUnit2_*
+        //     unionResults   true | false
+        //     geodesic       true | false
+        //     f              json
+        //   Response: { geometries: [ polygon geometries ] }
+        //
+        // NOTE: per AGENTS.md, planar buffers belong in NetTopologySuite; this
+        // client is for server-side / geodesic buffering the local engine does
+        // not cover.
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented GeometryServer buffer.");
+    }
+
+    [Fact(Skip = GeometryServerGap)]
+    public void GeometryServer_LengthsAndAreas_ContractIsDocumented()
+    {
+        // Expected contract:
+        //
+        //   POST /rest/services/Geometry/GeometryServer/lengths
+        //   POST /rest/services/Geometry/GeometryServer/areasAndLengths
+        //   Parameters: polylines/polygons, sr, lengthUnit, areaUnit,
+        //               calculationType (planar | geodesic | preserveShape), f=json
+        //   Response (lengths):         { lengths: [ ... ] }
+        //   Response (areasAndLengths): { areas: [ ... ], lengths: [ ... ] }
+        Assert.Fail("Unreachable: documentation-only contract for unimplemented GeometryServer measurements.");
+    }
+
+    // -- exportImage error contract -------------------------------------------
+
+    [Fact(Skip = ExportImageGap)]
+    public void ExportImage_GeoServicesError_SurfacesAsHonuaFeatureServerException()
+    {
+        // The exportImage and GeometryServer operations must surface GeoServices
+        // error envelopes ({ error: { code, message, details[] } }) returned with
+        // HTTP 200 as HonuaFeatureServerException, identical to the routing and
+        // FeatureServer clients (see HonuaRoutingClient.TryExtractGeoServicesError).
+        // The HTTP status on the exception should map from error.code.
+        Assert.Fail("Unreachable: documentation-only error contract for unimplemented export/geometry operations.");
+    }
+}


### PR DESCRIPTION
## Summary
Adds contract tests for the ImageServer and GeometryServer geoservices clients, plus skipped placeholder tests documenting gaps where clients are not yet built.

This work unblocks honua-console (#166) by validating the geoservices client surface the console depends on.

## Test plan
- Contract tests for ImageServer and GeometryServer pass.
- Gap tests are marked skipped pending the corresponding clients being implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)