### PR TITLE
feat(geoservices): implement ImageServer and GeometryServer clients

### DIFF
--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.GeoServices.GeometryServer;
+using Honua.Sdk.GeoServices.ImageServer;
 using Honua.Sdk.GeoServices.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -87,6 +89,70 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
+
+        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Honua GeoServices ImageServer client with the DI container.
+    /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    /// <param name="configure">Configuration delegate for client options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaImageServer(
+        this IServiceCollection services,
+        Action<HonuaGeoServicesClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var snapshot = new HonuaGeoServicesClientOptions();
+        configure(snapshot);
+        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
+        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+
+        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
+        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = services.AddHttpClient<HonuaImageServerClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
+            client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
+        })
+        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+
+        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the Honua GeoServices GeometryServer client with the DI container.
+    /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    /// <param name="configure">Configuration delegate for client options.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddHonuaGeometryServer(
+        this IServiceCollection services,
+        Action<HonuaGeoServicesClientOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var snapshot = new HonuaGeoServicesClientOptions();
+        configure(snapshot);
+        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
+        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+
+        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
+        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = services.AddHttpClient<HonuaGeometryServerClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
+            client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
+        })
+        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
 
         ApplyHandlerAndResilience(httpBuilder, snapshot);
         return services;

--- a/src/Honua.Sdk.GeoServices/GeoServicesHttp.cs
+++ b/src/Honua.Sdk.GeoServices/GeoServicesHttp.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
+
+namespace Honua.Sdk.GeoServices;
+
+/// <summary>
+/// Shared GeoServices HTTP helpers: form-POST, GET, and the GeoServices
+/// <c>{ error: { code, message, details[] } }</c> envelope handling used by all
+/// GeoServices clients (FeatureServer, NAServer routing, ImageServer, GeometryServer).
+/// </summary>
+internal static class GeoServicesHttp
+{
+    internal static async Task<string> GetStringAsync(
+        HttpClient http, string url, CancellationToken cancellationToken)
+    {
+        using var response = await http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return body;
+    }
+
+    internal static async Task<string> PostFormAsync(
+        HttpClient http,
+        string path,
+        IEnumerable<(string Key, string? Value)> parameters,
+        CancellationToken cancellationToken)
+    {
+        using var content = new FormUrlEncodedContent(
+            parameters
+                .Where(parameter => !string.IsNullOrWhiteSpace(parameter.Value))
+                .Select(parameter => new KeyValuePair<string, string>(parameter.Key, parameter.Value!)));
+
+        using var response = await http.PostAsync(CreateRequestUri(path), content, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return body;
+    }
+
+    internal static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
+
+    internal static void EnsureSuccess(HttpResponseMessage response, string body)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            if (!string.IsNullOrWhiteSpace(body) && TryExtractGeoServicesError(body, response.StatusCode) is { } error)
+            {
+                throw error;
+            }
+
+            return;
+        }
+
+        var errorMessage = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "GeoServices request failed";
+        throw new HonuaFeatureServerException(response.StatusCode, errorMessage, body);
+    }
+
+    internal static HonuaFeatureServerException? TryExtractGeoServicesError(string body, HttpStatusCode fallbackStatus)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (!doc.RootElement.TryGetProperty("error", out var errorElement) ||
+                errorElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var message = "GeoServices returned an error.";
+            int? geoServicesCode = null;
+            IReadOnlyList<string>? details = null;
+            var httpCode = fallbackStatus;
+            if (errorElement.TryGetProperty("message", out var msgProp) &&
+                msgProp.ValueKind == JsonValueKind.String)
+            {
+                message = msgProp.GetString() ?? message;
+            }
+
+            if (errorElement.TryGetProperty("code", out var codeProp) &&
+                codeProp.TryGetInt32(out var errorCode))
+            {
+                geoServicesCode = errorCode;
+                httpCode = (HttpStatusCode)errorCode;
+            }
+
+            if (errorElement.TryGetProperty("details", out var detailsProp) &&
+                detailsProp.ValueKind == JsonValueKind.Array)
+            {
+                var detailList = new List<string>();
+                foreach (var item in detailsProp.EnumerateArray())
+                {
+                    if (item.ValueKind == JsonValueKind.String)
+                    {
+                        detailList.Add(item.GetString()!);
+                    }
+                }
+
+                details = detailList;
+            }
+
+            return new HonuaFeatureServerException(httpCode, message, body, geoServicesCode, details);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? TryExtractErrorMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
+                errorElement.ValueKind == JsonValueKind.Object &&
+                errorElement.TryGetProperty("message", out var msg) &&
+                msg.ValueKind == JsonValueKind.String)
+            {
+                return msg.GetString();
+            }
+
+            if (doc.RootElement.TryGetProperty("message", out var topMsg) &&
+                topMsg.ValueKind == JsonValueKind.String)
+            {
+                return topMsg.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/Honua.Sdk.GeoServices/GeometryServer/HonuaGeometryServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/GeometryServer/HonuaGeometryServerClient.cs
@@ -1,0 +1,279 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Buffers;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.GeoServices.GeometryServer;
+
+/// <summary>
+/// GeoServices GeometryServer client: <c>project</c>, <c>buffer</c>, <c>lengths</c>, and
+/// <c>areasAndLengths</c>.
+///
+/// Per AGENTS.md this is the remote fallback for transforms/buffers/geodesic measurement the
+/// local NetTopologySuite/ProjNet engine cannot perform offline; prefer local computation where
+/// possible.
+/// </summary>
+public sealed class HonuaGeometryServerClient
+{
+    private readonly HttpClient _http;
+    private readonly HonuaGeoServicesClientOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaGeometryServerClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    /// <param name="options">GeoServices options used for the default GeometryServer service id.</param>
+    [ActivatorUtilitiesConstructor]
+    public HonuaGeometryServerClient(HttpClient httpClient, IOptions<HonuaGeoServicesClientOptions> options)
+        : this(httpClient, GetOptionsValue(options))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaGeometryServerClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    /// <param name="options">GeoServices options used for the default GeometryServer service id.</param>
+    public HonuaGeometryServerClient(HttpClient httpClient, HonuaGeoServicesClientOptions options)
+    {
+        _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    /// Projects geometries between spatial references (<c>POST .../GeometryServer/project</c>).
+    /// </summary>
+    /// <param name="request">Project parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The projected geometries.</returns>
+    public async Task<GeometryCollectionResult> ProjectAsync(
+        ProjectGeometriesRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Geometries);
+
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("geometries", SerializeGeometries(request.GeometryType, request.Geometries)),
+            ("inSR", request.InSpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("outSR", request.OutSpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("transformation", request.Transformation),
+        };
+
+        var body = await PostAsync("project", request.ServiceId, form, cancellationToken).ConfigureAwait(false);
+        return ParseGeometryCollection(body);
+    }
+
+    /// <summary>
+    /// Buffers geometries (<c>POST .../GeometryServer/buffer</c>).
+    /// </summary>
+    /// <param name="request">Buffer parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The buffer polygons.</returns>
+    public async Task<GeometryCollectionResult> BufferAsync(
+        BufferGeometriesRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Geometries);
+        ArgumentNullException.ThrowIfNull(request.Distances);
+        if (request.Distances.Count == 0)
+        {
+            throw new ArgumentException("At least one buffer distance is required.", nameof(request));
+        }
+
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("geometries", SerializeGeometries(request.GeometryType, request.Geometries)),
+            ("inSR", request.InSpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("outSR", request.OutSpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("bufferSR", request.BufferSpatialReference?.ToString(CultureInfo.InvariantCulture)),
+            ("distances", string.Join(',', request.Distances.Select(d => d.ToString("R", CultureInfo.InvariantCulture)))),
+            ("unit", request.Unit),
+            ("unionResults", request.UnionResults ? "true" : "false"),
+            ("geodesic", request.Geodesic ? "true" : "false"),
+        };
+
+        var body = await PostAsync("buffer", request.ServiceId, form, cancellationToken).ConfigureAwait(false);
+        return ParseGeometryCollection(body);
+    }
+
+    /// <summary>
+    /// Computes polyline lengths (<c>POST .../GeometryServer/lengths</c>).
+    /// </summary>
+    /// <param name="request">Lengths parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The computed lengths.</returns>
+    public async Task<LengthsResult> LengthsAsync(
+        LengthsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Polylines);
+
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("polylines", SerializeGeometryArray(request.Polylines)),
+            ("sr", request.SpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("lengthUnit", request.LengthUnit),
+            ("calculationType", request.CalculationType),
+        };
+
+        var body = await PostAsync("lengths", request.ServiceId, form, cancellationToken).ConfigureAwait(false);
+        using var document = JsonDocument.Parse(body);
+        return new LengthsResult
+        {
+            Lengths = ReadDoubleArray(document.RootElement, "lengths"),
+            RawResponse = document.RootElement.Clone(),
+        };
+    }
+
+    /// <summary>
+    /// Computes polygon areas and perimeter lengths (<c>POST .../GeometryServer/areasAndLengths</c>).
+    /// </summary>
+    /// <param name="request">Areas-and-lengths parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The computed areas and lengths.</returns>
+    public async Task<AreasAndLengthsResult> AreasAndLengthsAsync(
+        AreasAndLengthsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Polygons);
+
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("polygons", SerializeGeometryArray(request.Polygons)),
+            ("sr", request.SpatialReference.ToString(CultureInfo.InvariantCulture)),
+            ("lengthUnit", request.LengthUnit),
+            ("areaUnit", request.AreaUnit),
+            ("calculationType", request.CalculationType),
+        };
+
+        var body = await PostAsync("areasAndLengths", request.ServiceId, form, cancellationToken).ConfigureAwait(false);
+        using var document = JsonDocument.Parse(body);
+        return new AreasAndLengthsResult
+        {
+            Areas = ReadDoubleArray(document.RootElement, "areas"),
+            Lengths = ReadDoubleArray(document.RootElement, "lengths"),
+            RawResponse = document.RootElement.Clone(),
+        };
+    }
+
+    private Task<string> PostAsync(
+        string operation,
+        string? serviceId,
+        List<(string Key, string? Value)> form,
+        CancellationToken cancellationToken)
+    {
+        var resolved = string.IsNullOrWhiteSpace(serviceId) ? _options.GeometryServiceId : serviceId;
+        if (string.IsNullOrWhiteSpace(resolved))
+        {
+            throw new InvalidOperationException("Honua GeoServices GeometryServer service id must be configured.");
+        }
+
+        var path = $"/rest/services/{Uri.EscapeDataString(resolved)}/GeometryServer/{operation}";
+        return GeoServicesHttp.PostFormAsync(_http, path, form, cancellationToken);
+    }
+
+    private static HonuaGeoServicesClientOptions GetOptionsValue(IOptions<HonuaGeoServicesClientOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return options.Value;
+    }
+
+    private static string SerializeGeometries(string geometryType, IReadOnlyList<JsonElement> geometries)
+    {
+        if (string.IsNullOrWhiteSpace(geometryType))
+        {
+            throw new ArgumentException("Geometry type is required.", nameof(geometryType));
+        }
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("geometryType", geometryType);
+            writer.WritePropertyName("geometries");
+            writer.WriteStartArray();
+            foreach (var geometry in geometries)
+            {
+                geometry.WriteTo(writer);
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static string SerializeGeometryArray(IReadOnlyList<JsonElement> geometries)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var geometry in geometries)
+            {
+                geometry.WriteTo(writer);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    private static GeometryCollectionResult ParseGeometryCollection(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        var geometries = new List<JsonElement>();
+        if (root.ValueKind == JsonValueKind.Object &&
+            root.TryGetProperty("geometries", out var array) &&
+            array.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in array.EnumerateArray())
+            {
+                geometries.Add(item.Clone());
+            }
+        }
+
+        return new GeometryCollectionResult
+        {
+            Geometries = geometries,
+            RawResponse = root.Clone(),
+        };
+    }
+
+    private static List<double> ReadDoubleArray(JsonElement element, string name)
+    {
+        var list = new List<double>();
+        if (element.ValueKind == JsonValueKind.Object &&
+            element.TryGetProperty(name, out var array) &&
+            array.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in array.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.Number && item.TryGetDouble(out var number))
+                {
+                    list.Add(number);
+                }
+                else if (item.ValueKind == JsonValueKind.String &&
+                         double.TryParse(item.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out number))
+                {
+                    list.Add(number);
+                }
+            }
+        }
+
+        return list;
+    }
+}

--- a/src/Honua.Sdk.GeoServices/GeometryServer/Models/GeometryServerModels.cs
+++ b/src/Honua.Sdk.GeoServices/GeometryServer/Models/GeometryServerModels.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.GeoServices.GeometryServer;
+
+/// <summary>
+/// A request to project geometries between spatial references (GeometryServer <c>project</c>).
+/// </summary>
+public sealed class ProjectGeometriesRequest
+{
+    /// <summary>Optional service id override; falls back to the configured GeometryServer id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>
+    /// GeoServices geometry type (e.g. <c>esriGeometryPoint</c>, <c>esriGeometryPolyline</c>,
+    /// <c>esriGeometryPolygon</c>). Required.
+    /// </summary>
+    public required string GeometryType { get; init; }
+
+    /// <summary>
+    /// The geometries to project, as GeoServices JSON objects (each entry is one geometry object
+    /// such as <c>{ "x": .., "y": .. }</c> or <c>{ "rings": [...] }</c>). Required.
+    /// </summary>
+    public required IReadOnlyList<JsonElement> Geometries { get; init; }
+
+    /// <summary>Input spatial reference wkid. Required.</summary>
+    public required int InSpatialReference { get; init; }
+
+    /// <summary>Output spatial reference wkid. Required.</summary>
+    public required int OutSpatialReference { get; init; }
+
+    /// <summary>Optional datum transformation id.</summary>
+    public string? Transformation { get; init; }
+}
+
+/// <summary>
+/// A request to buffer geometries (GeometryServer <c>buffer</c>).
+/// </summary>
+public sealed class BufferGeometriesRequest
+{
+    /// <summary>Optional service id override; falls back to the configured GeometryServer id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>GeoServices geometry type. Required.</summary>
+    public required string GeometryType { get; init; }
+
+    /// <summary>The geometries to buffer, as GeoServices JSON objects. Required.</summary>
+    public required IReadOnlyList<JsonElement> Geometries { get; init; }
+
+    /// <summary>Input spatial reference wkid. Required.</summary>
+    public required int InSpatialReference { get; init; }
+
+    /// <summary>Output spatial reference wkid. Required.</summary>
+    public required int OutSpatialReference { get; init; }
+
+    /// <summary>Spatial reference wkid in which the buffer distances are expressed.</summary>
+    public int? BufferSpatialReference { get; init; }
+
+    /// <summary>Buffer distances (one or more). Required.</summary>
+    public required IReadOnlyList<double> Distances { get; init; }
+
+    /// <summary>Linear unit (e.g. <c>esriSRUnit_Meter</c>).</summary>
+    public string? Unit { get; init; }
+
+    /// <summary>Whether to union the resulting buffers.</summary>
+    public bool UnionResults { get; init; }
+
+    /// <summary>Whether to compute geodesic buffers.</summary>
+    public bool Geodesic { get; init; }
+}
+
+/// <summary>
+/// Result of a GeometryServer operation that returns a <c>geometries</c> array (project, buffer).
+/// </summary>
+public sealed class GeometryCollectionResult
+{
+    /// <summary>The returned geometries as raw GeoServices JSON objects.</summary>
+    public required IReadOnlyList<JsonElement> Geometries { get; init; }
+
+    /// <summary>Raw JSON response.</summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// A request to compute polyline lengths (GeometryServer <c>lengths</c>).
+/// </summary>
+public sealed class LengthsRequest
+{
+    /// <summary>Optional service id override; falls back to the configured GeometryServer id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>The polylines, as GeoServices JSON objects. Required.</summary>
+    public required IReadOnlyList<JsonElement> Polylines { get; init; }
+
+    /// <summary>Spatial reference wkid. Required.</summary>
+    public required int SpatialReference { get; init; }
+
+    /// <summary>Length unit (e.g. <c>esriSRUnit_Meter</c>).</summary>
+    public string? LengthUnit { get; init; }
+
+    /// <summary>Calculation type (<c>planar</c>, <c>geodesic</c>, or <c>preserveShape</c>).</summary>
+    public string? CalculationType { get; init; }
+}
+
+/// <summary>
+/// A request to compute polygon areas and lengths (GeometryServer <c>areasAndLengths</c>).
+/// </summary>
+public sealed class AreasAndLengthsRequest
+{
+    /// <summary>Optional service id override; falls back to the configured GeometryServer id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>The polygons, as GeoServices JSON objects. Required.</summary>
+    public required IReadOnlyList<JsonElement> Polygons { get; init; }
+
+    /// <summary>Spatial reference wkid. Required.</summary>
+    public required int SpatialReference { get; init; }
+
+    /// <summary>Length unit (e.g. <c>esriSRUnit_Meter</c>).</summary>
+    public string? LengthUnit { get; init; }
+
+    /// <summary>Area unit (e.g. <c>esriSquareMeters</c>).</summary>
+    public string? AreaUnit { get; init; }
+
+    /// <summary>Calculation type (<c>planar</c>, <c>geodesic</c>, or <c>preserveShape</c>).</summary>
+    public string? CalculationType { get; init; }
+}
+
+/// <summary>
+/// Result of a GeometryServer <c>lengths</c> request.
+/// </summary>
+public sealed class LengthsResult
+{
+    /// <summary>Computed lengths, one per input polyline.</summary>
+    public required IReadOnlyList<double> Lengths { get; init; }
+
+    /// <summary>Raw JSON response.</summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Result of a GeometryServer <c>areasAndLengths</c> request.
+/// </summary>
+public sealed class AreasAndLengthsResult
+{
+    /// <summary>Computed areas, one per input polygon.</summary>
+    public required IReadOnlyList<double> Areas { get; init; }
+
+    /// <summary>Computed perimeter lengths, one per input polygon.</summary>
+    public required IReadOnlyList<double> Lengths { get; init; }
+
+    /// <summary>Raw JSON response.</summary>
+    public JsonElement RawResponse { get; init; }
+}

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -123,6 +123,11 @@ public sealed class HonuaGeoServicesClientOptions : IHonuaAuthenticationOptions,
     /// </summary>
     public string RoutingClosestFacilityLayerName { get; set; } = "ClosestFacility";
 
+    /// <summary>
+    /// Default GeoServices GeometryServer service id used by the geometry client.
+    /// </summary>
+    public string GeometryServiceId { get; set; } = "Geometry";
+
     internal static void ValidateBaseAddress(Uri? baseAddress)
     {
         if (baseAddress is null)

--- a/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerClient.cs
@@ -1,0 +1,390 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Honua.Sdk.GeoServices.ImageServer;
+
+/// <summary>
+/// GeoServices ImageServer client: service metadata, raster <c>exportImage</c>, and pixel <c>identify</c>.
+/// </summary>
+public sealed class HonuaImageServerClient
+{
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaImageServerClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    /// <param name="options">GeoServices options.</param>
+    [ActivatorUtilitiesConstructor]
+    public HonuaImageServerClient(HttpClient httpClient, IOptions<HonuaGeoServicesClientOptions> options)
+        : this(httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _ = options.Value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaImageServerClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and authentication handlers.</param>
+    public HonuaImageServerClient(HttpClient httpClient)
+    {
+        _http = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    }
+
+    /// <summary>
+    /// Gets the ImageServer service metadata (<c>GET .../ImageServer?f=json</c>).
+    /// </summary>
+    /// <param name="serviceId">The ImageServer service id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Parsed image-service metadata.</returns>
+    public async Task<ImageServerMetadata> GetServiceMetadataAsync(
+        string serviceId, CancellationToken cancellationToken = default)
+    {
+        var resolved = RequireServiceId(serviceId);
+        var body = await GeoServicesHttp.GetStringAsync(
+            _http, $"{ServicePath(resolved)}?f=json", cancellationToken).ConfigureAwait(false);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        return new ImageServerMetadata
+        {
+            ServiceId = resolved,
+            ServiceDescription = ReadString(root, "serviceDescription"),
+            Name = ReadString(root, "name"),
+            PixelType = ReadString(root, "pixelType"),
+            Extent = ReadExtent(root, "extent") ?? ReadExtent(root, "fullExtent"),
+            BandCount = ReadInt(root, "bandCount"),
+            MinValues = ReadDoubleArray(root, "minValues"),
+            MaxValues = ReadDoubleArray(root, "maxValues"),
+            SupportedQueryFormats = ReadStringList(root, "supportedQueryFormats"),
+            SupportedImageFormatTypes = ReadStringList(root, "supportedImageFormatTypes"),
+            AllowedMosaicMethods = ReadStringList(root, "allowedMosaicMethods"),
+            DefaultMosaicMethod = ReadString(root, "defaultMosaicMethod"),
+            HasRasterAttributeTable = ReadBool(root, "hasRasterAttributeTable"),
+            HasHistograms = ReadBool(root, "hasHistograms"),
+            RawResponse = root.Clone(),
+        };
+    }
+
+    /// <summary>
+    /// Exports a raster image (<c>POST .../ImageServer/exportImage</c> with <c>f=image</c>).
+    /// The returned <see cref="ExportImageResult"/> owns the response stream; dispose it when done.
+    /// </summary>
+    /// <param name="request">Export parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The raster image result.</returns>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Response ownership is transferred to ExportImageResult via ResponseOwningStream.")]
+    public async Task<ExportImageResult> ExportImageAsync(
+        ExportImageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var form = BuildExportForm(request, "image");
+        var path = $"{ServicePath(RequireServiceId(request.ServiceId))}/exportImage";
+
+        using var content = CreateFormContent(form);
+        var response = await _http.PostAsync(
+            GeoServicesHttp.CreateRequestUri(path), content, cancellationToken).ConfigureAwait(false);
+
+        var contentType = response.Content.Headers.ContentType?.MediaType;
+        if (!response.IsSuccessStatusCode || IsJsonContent(contentType))
+        {
+            // Either an HTTP error, or a GeoServices error envelope returned with 200 + JSON.
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            response.Dispose();
+            GeoServicesHttp.EnsureSuccess(CreateStatusOnly(response.StatusCode), body);
+
+            // No error envelope but JSON content: treat as a contract violation for f=image.
+            throw new FeatureServer.Exceptions.HonuaFeatureServerException(
+                response.StatusCode,
+                "ImageServer exportImage returned JSON instead of a raster image stream.",
+                body);
+        }
+
+        var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var length = response.Content.Headers.ContentLength;
+        return new ExportImageResult(new ResponseOwningStream(stream, response), contentType, length);
+    }
+
+    /// <summary>
+    /// Exports image metadata (<c>POST .../ImageServer/exportImage</c> with <c>f=json</c>):
+    /// returns the href and extent rather than the raster bytes.
+    /// </summary>
+    /// <param name="request">Export parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Export metadata (href, size, extent, scale).</returns>
+    public async Task<ExportImageMetadata> ExportImageMetadataAsync(
+        ExportImageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var form = BuildExportForm(request, "json");
+        var path = $"{ServicePath(RequireServiceId(request.ServiceId))}/exportImage";
+        var body = await GeoServicesHttp.PostFormAsync(_http, path, form, cancellationToken).ConfigureAwait(false);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        return new ExportImageMetadata
+        {
+            Href = ReadString(root, "href"),
+            Width = ReadInt(root, "width"),
+            Height = ReadInt(root, "height"),
+            Extent = ReadExtent(root, "extent"),
+            Scale = ReadDouble(root, "scale"),
+            RawResponse = root.Clone(),
+        };
+    }
+
+    /// <summary>
+    /// Identifies the pixel value at a point (<c>GET .../ImageServer/identify</c>).
+    /// </summary>
+    /// <param name="request">Identify parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The identify result.</returns>
+    public async Task<IdentifyImageResult> IdentifyAsync(
+        IdentifyImageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("geometry", BuildPointGeometry(request.X, request.Y, request.SpatialReferenceWkid)),
+            ("geometryType", "esriGeometryPoint"),
+            ("mosaicRule", request.MosaicRule),
+            ("renderingRule", request.RenderingRule),
+            ("pixelSize", request.PixelSize),
+        };
+        AddAdditional(form, request.AdditionalParameters);
+
+        var path = $"{ServicePath(RequireServiceId(request.ServiceId))}/identify";
+        var body = await GeoServicesHttp.PostFormAsync(_http, path, form, cancellationToken).ConfigureAwait(false);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+        return new IdentifyImageResult
+        {
+            ObjectId = ReadLong(root, "objectId"),
+            Name = ReadString(root, "name"),
+            Value = ReadString(root, "value"),
+            Location = ReadLocation(root),
+            RawResponse = root.Clone(),
+        };
+    }
+
+    private static List<(string Key, string? Value)> BuildExportForm(ExportImageRequest request, string format)
+    {
+        ArgumentNullException.ThrowIfNull(request.BoundingBox);
+        if (request.Width <= 0 || request.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Export image size must be positive.");
+        }
+
+        var bbox = request.BoundingBox;
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", format),
+            ("bbox", string.Join(',', new[]
+            {
+                Num(bbox.XMin), Num(bbox.YMin), Num(bbox.XMax), Num(bbox.YMax),
+            })),
+            ("bboxSR", (request.BoundingBoxSpatialReference ?? bbox.SpatialReferenceWkid)?.ToString(CultureInfo.InvariantCulture)),
+            ("imageSR", request.ImageSpatialReference?.ToString(CultureInfo.InvariantCulture)),
+            ("size", $"{request.Width.ToString(CultureInfo.InvariantCulture)},{request.Height.ToString(CultureInfo.InvariantCulture)}"),
+            ("format", request.Format),
+            ("pixelType", request.PixelType),
+            ("noData", request.NoData),
+            ("noDataInterpretation", request.NoDataInterpretation),
+            ("interpolation", request.Interpolation),
+            ("mosaicRule", request.MosaicRule),
+            ("renderingRule", request.RenderingRule),
+        };
+        AddAdditional(form, request.AdditionalParameters);
+        return form;
+    }
+
+    private static FormUrlEncodedContent CreateFormContent(IEnumerable<(string Key, string? Value)> parameters)
+        => new(parameters
+            .Where(parameter => !string.IsNullOrWhiteSpace(parameter.Value))
+            .Select(parameter => new KeyValuePair<string, string>(parameter.Key, parameter.Value!)));
+
+    private static string BuildPointGeometry(double x, double y, int? wkid)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{\"x\":").Append(Num(x)).Append(",\"y\":").Append(Num(y));
+        if (wkid is { } w)
+        {
+            sb.Append(",\"spatialReference\":{\"wkid\":").Append(w.ToString(CultureInfo.InvariantCulture)).Append('}');
+        }
+
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private static void AddAdditional(
+        List<(string Key, string? Value)> form, IReadOnlyDictionary<string, string?>? additional)
+    {
+        if (additional is null)
+        {
+            return;
+        }
+
+        foreach (var pair in additional)
+        {
+            form.Add((pair.Key, pair.Value));
+        }
+    }
+
+    private static string ServicePath(string serviceId)
+        => $"/rest/services/{Uri.EscapeDataString(serviceId)}/ImageServer";
+
+    private static string RequireServiceId(string? serviceId)
+        => string.IsNullOrWhiteSpace(serviceId)
+            ? throw new InvalidOperationException("Honua GeoServices ImageServer service id must be provided.")
+            : serviceId;
+
+    private static HttpResponseMessage CreateStatusOnly(System.Net.HttpStatusCode status) => new(status);
+
+    private static bool IsJsonContent(string? contentType)
+        => contentType is not null && contentType.Contains("json", StringComparison.OrdinalIgnoreCase);
+
+    private static string Num(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static string? ReadString(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static string? ReadLocation(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty("location", out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : value.GetRawText();
+    }
+
+    private static int? ReadInt(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.Number &&
+           value.TryGetInt32(out var number)
+            ? number
+            : null;
+
+    private static long? ReadLong(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.Number &&
+           value.TryGetInt64(out var number)
+            ? number
+            : null;
+
+    private static double? ReadDouble(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.Number &&
+           value.TryGetDouble(out var number)
+            ? number
+            : null;
+
+    private static bool? ReadBool(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty(name, out var value))
+        {
+            return null;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
+    }
+
+    private static List<double>? ReadDoubleArray(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object ||
+            !element.TryGetProperty(name, out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var list = new List<double>();
+        foreach (var item in value.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.Number && item.TryGetDouble(out var number))
+            {
+                list.Add(number);
+            }
+        }
+
+        return list;
+    }
+
+    private static List<string>? ReadStringList(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty(name, out var value))
+        {
+            return null;
+        }
+
+        if (value.ValueKind == JsonValueKind.Array)
+        {
+            return value.EnumerateArray()
+                .Where(item => item.ValueKind == JsonValueKind.String)
+                .Select(item => item.GetString()!)
+                .ToList();
+        }
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            return value.GetString()?
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToList();
+        }
+
+        return null;
+    }
+
+    private static ImageServerExtent? ReadExtent(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object ||
+            !element.TryGetProperty(name, out var extent) ||
+            extent.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        int? wkid = null;
+        if (extent.TryGetProperty("spatialReference", out var sr) &&
+            sr.ValueKind == JsonValueKind.Object &&
+            (sr.TryGetProperty("latestWkid", out var latest) && latest.TryGetInt32(out var latestWkid) ||
+             sr.TryGetProperty("wkid", out latest) && latest.TryGetInt32(out latestWkid)))
+        {
+            wkid = latestWkid;
+        }
+
+        return new ImageServerExtent
+        {
+            XMin = ReadDouble(extent, "xmin") ?? 0,
+            YMin = ReadDouble(extent, "ymin") ?? 0,
+            XMax = ReadDouble(extent, "xmax") ?? 0,
+            YMax = ReadDouble(extent, "ymax") ?? 0,
+            SpatialReferenceWkid = wkid,
+        };
+    }
+}

--- a/src/Honua.Sdk.GeoServices/ImageServer/Models/ImageServerModels.cs
+++ b/src/Honua.Sdk.GeoServices/ImageServer/Models/ImageServerModels.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.GeoServices.ImageServer;
+
+/// <summary>
+/// Spatial extent of an ImageServer service, with an optional spatial reference well-known id.
+/// </summary>
+public sealed class ImageServerExtent
+{
+    /// <summary>Minimum x coordinate.</summary>
+    public double XMin { get; init; }
+
+    /// <summary>Minimum y coordinate.</summary>
+    public double YMin { get; init; }
+
+    /// <summary>Maximum x coordinate.</summary>
+    public double XMax { get; init; }
+
+    /// <summary>Maximum y coordinate.</summary>
+    public double YMax { get; init; }
+
+    /// <summary>Spatial reference well-known id, when present.</summary>
+    public int? SpatialReferenceWkid { get; init; }
+}
+
+/// <summary>
+/// Parsed ImageServer service description (from <c>GET .../ImageServer?f=json</c>).
+/// </summary>
+public sealed class ImageServerMetadata
+{
+    /// <summary>The resolved service id used to address the ImageServer.</summary>
+    public required string ServiceId { get; init; }
+
+    /// <summary>Human-readable service description.</summary>
+    public string? ServiceDescription { get; init; }
+
+    /// <summary>Service name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Pixel type (e.g. <c>U8</c>, <c>F32</c>).</summary>
+    public string? PixelType { get; init; }
+
+    /// <summary>Full extent of the image service.</summary>
+    public ImageServerExtent? Extent { get; init; }
+
+    /// <summary>Number of raster bands.</summary>
+    public int? BandCount { get; init; }
+
+    /// <summary>Per-band minimum pixel values.</summary>
+    public IReadOnlyList<double>? MinValues { get; init; }
+
+    /// <summary>Per-band maximum pixel values.</summary>
+    public IReadOnlyList<double>? MaxValues { get; init; }
+
+    /// <summary>Supported query formats (e.g. <c>JSON, geoJSON</c>).</summary>
+    public IReadOnlyList<string>? SupportedQueryFormats { get; init; }
+
+    /// <summary>Supported image output formats (e.g. <c>PNG, JPG, ...</c>).</summary>
+    public IReadOnlyList<string>? SupportedImageFormatTypes { get; init; }
+
+    /// <summary>Allowed mosaic methods.</summary>
+    public IReadOnlyList<string>? AllowedMosaicMethods { get; init; }
+
+    /// <summary>Default mosaic method.</summary>
+    public string? DefaultMosaicMethod { get; init; }
+
+    /// <summary>Whether a raster attribute table is available.</summary>
+    public bool? HasRasterAttributeTable { get; init; }
+
+    /// <summary>Whether histograms are available.</summary>
+    public bool? HasHistograms { get; init; }
+
+    /// <summary>Raw service description JSON.</summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Parameters for an ImageServer <c>exportImage</c> request.
+/// </summary>
+public sealed class ExportImageRequest
+{
+    /// <summary>Optional service id override; falls back to the metadata service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>Export bounding box <c>xmin,ymin,xmax,ymax</c>. Required.</summary>
+    public required ImageServerExtent BoundingBox { get; init; }
+
+    /// <summary>Spatial reference wkid of the bounding box.</summary>
+    public int? BoundingBoxSpatialReference { get; init; }
+
+    /// <summary>Output image spatial reference wkid.</summary>
+    public int? ImageSpatialReference { get; init; }
+
+    /// <summary>Output image width in pixels. Required.</summary>
+    public required int Width { get; init; }
+
+    /// <summary>Output image height in pixels. Required.</summary>
+    public required int Height { get; init; }
+
+    /// <summary>Output format (e.g. <c>png</c>, <c>png24</c>, <c>jpg</c>, <c>tiff</c>).</summary>
+    public string Format { get; init; } = "png";
+
+    /// <summary>Optional pixel type override.</summary>
+    public string? PixelType { get; init; }
+
+    /// <summary>Optional no-data value(s).</summary>
+    public string? NoData { get; init; }
+
+    /// <summary>Optional no-data interpretation (e.g. <c>esriNoDataMatchAny</c>).</summary>
+    public string? NoDataInterpretation { get; init; }
+
+    /// <summary>Optional resampling interpolation (e.g. <c>RSP_BilinearInterpolation</c>).</summary>
+    public string? Interpolation { get; init; }
+
+    /// <summary>Optional mosaic rule JSON.</summary>
+    public string? MosaicRule { get; init; }
+
+    /// <summary>Optional rendering rule JSON.</summary>
+    public string? RenderingRule { get; init; }
+
+    /// <summary>Additional GeoServices parameters appended verbatim.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Result of an <c>exportImage</c> request issued with <c>f=image</c>. The caller owns the stream.
+/// </summary>
+public sealed class ExportImageResult : IDisposable, IAsyncDisposable
+{
+    private readonly Stream _content;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportImageResult"/> class.
+    /// </summary>
+    /// <param name="content">The raster content stream (owned by this result).</param>
+    /// <param name="contentType">The response content type.</param>
+    /// <param name="contentLength">The response content length, if known.</param>
+    public ExportImageResult(Stream content, string? contentType, long? contentLength)
+    {
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        ContentType = contentType;
+        ContentLength = contentLength;
+    }
+
+    /// <summary>The raster image stream. Disposing this result disposes the stream.</summary>
+    public Stream Content => _content;
+
+    /// <summary>The response content type (e.g. <c>image/png</c>).</summary>
+    public string? ContentType { get; }
+
+    /// <summary>The response content length, if reported by the server.</summary>
+    public long? ContentLength { get; }
+
+    /// <inheritdoc />
+    public void Dispose() => _content.Dispose();
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _content.DisposeAsync();
+}
+
+/// <summary>
+/// Result of an <c>exportImage</c> request issued with <c>f=json</c> (href + extent metadata).
+/// </summary>
+public sealed class ExportImageMetadata
+{
+    /// <summary>URL of the exported image.</summary>
+    public string? Href { get; init; }
+
+    /// <summary>Image width in pixels.</summary>
+    public int? Width { get; init; }
+
+    /// <summary>Image height in pixels.</summary>
+    public int? Height { get; init; }
+
+    /// <summary>Extent covered by the exported image.</summary>
+    public ImageServerExtent? Extent { get; init; }
+
+    /// <summary>Map scale of the exported image.</summary>
+    public double? Scale { get; init; }
+
+    /// <summary>Raw JSON response.</summary>
+    public JsonElement RawResponse { get; init; }
+}
+
+/// <summary>
+/// Parameters for an ImageServer <c>identify</c> request at a point location.
+/// </summary>
+public sealed class IdentifyImageRequest
+{
+    /// <summary>Optional service id override; falls back to the metadata service id.</summary>
+    public string? ServiceId { get; init; }
+
+    /// <summary>X coordinate of the identify point. Required.</summary>
+    public required double X { get; init; }
+
+    /// <summary>Y coordinate of the identify point. Required.</summary>
+    public required double Y { get; init; }
+
+    /// <summary>Spatial reference wkid of the identify point.</summary>
+    public int? SpatialReferenceWkid { get; init; }
+
+    /// <summary>Optional mosaic rule JSON.</summary>
+    public string? MosaicRule { get; init; }
+
+    /// <summary>Optional rendering rule JSON.</summary>
+    public string? RenderingRule { get; init; }
+
+    /// <summary>Optional pixel size <c>x,y</c>.</summary>
+    public string? PixelSize { get; init; }
+
+    /// <summary>Additional GeoServices parameters appended verbatim.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Parsed ImageServer <c>identify</c> response.
+/// </summary>
+public sealed class IdentifyImageResult
+{
+    /// <summary>Object id of the identified catalog item, when present.</summary>
+    public long? ObjectId { get; init; }
+
+    /// <summary>Name of the identified item.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Pixel value(s) at the identified location, as returned by the service.</summary>
+    public string? Value { get; init; }
+
+    /// <summary>Location text, when present.</summary>
+    public string? Location { get; init; }
+
+    /// <summary>Raw JSON response, including any <c>catalogItems</c>.</summary>
+    public JsonElement RawResponse { get; init; }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/GeometryServer/HonuaGeometryServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/GeometryServer/HonuaGeometryServerClientTests.cs
@@ -1,0 +1,284 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
+using Honua.Sdk.GeoServices.GeometryServer;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.Tests.GeometryServer;
+
+public sealed class HonuaGeometryServerClientTests
+{
+    [Fact]
+    public async Task ProjectAsync_SendsGeometriesAndSpatialReferences()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        HttpMethod? method = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            method = request.Method;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""
+            {
+              "geometries": [
+                { "x": -17563470.0, "y": 2426417.0 }
+              ]
+            }
+            """);
+        });
+
+        var result = await client.ProjectAsync(new ProjectGeometriesRequest
+        {
+            ServiceId = "Geometry",
+            GeometryType = "esriGeometryPoint",
+            InSpatialReference = 4326,
+            OutSpatialReference = 3857,
+            Geometries = [Point(-157.8, 21.3)],
+        });
+
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal("http://localhost:5000/rest/services/Geometry/GeometryServer/project", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("4326", form["inSR"]);
+        Assert.Equal("3857", form["outSR"]);
+        using var geometries = JsonDocument.Parse(form["geometries"]);
+        Assert.Equal("esriGeometryPoint", geometries.RootElement.GetProperty("geometryType").GetString());
+        Assert.Equal(-157.8, geometries.RootElement.GetProperty("geometries")[0].GetProperty("x").GetDouble(), precision: 4);
+
+        var geometry = Assert.Single(result.Geometries);
+        Assert.Equal(-17563470.0, geometry.GetProperty("x").GetDouble(), precision: 1);
+    }
+
+    [Fact]
+    public async Task BufferAsync_SendsDistancesUnitAndGeodesicFlag()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""{ "geometries": [ { "rings": [] } ] }""");
+        });
+
+        var result = await client.BufferAsync(new BufferGeometriesRequest
+        {
+            ServiceId = "Geometry",
+            GeometryType = "esriGeometryPoint",
+            InSpatialReference = 4326,
+            OutSpatialReference = 4326,
+            BufferSpatialReference = 3857,
+            Distances = [100, 250],
+            Unit = "esriSRUnit_Meter",
+            UnionResults = true,
+            Geodesic = true,
+            Geometries = [Point(-157.8, 21.3)],
+        });
+
+        Assert.Equal("http://localhost:5000/rest/services/Geometry/GeometryServer/buffer", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("100,250", form["distances"]);
+        Assert.Equal("esriSRUnit_Meter", form["unit"]);
+        Assert.Equal("3857", form["bufferSR"]);
+        Assert.Equal("true", form["unionResults"]);
+        Assert.Equal("true", form["geodesic"]);
+        Assert.Single(result.Geometries);
+    }
+
+    [Fact]
+    public async Task LengthsAsync_SendsPolylinesAndParsesLengths()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""{ "lengths": [ 1234.5, 678.9 ] }""");
+        });
+
+        var result = await client.LengthsAsync(new LengthsRequest
+        {
+            ServiceId = "Geometry",
+            SpatialReference = 4326,
+            LengthUnit = "esriSRUnit_Meter",
+            CalculationType = "geodesic",
+            Polylines = [Polyline()],
+        });
+
+        Assert.Equal("http://localhost:5000/rest/services/Geometry/GeometryServer/lengths", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("4326", form["sr"]);
+        Assert.Equal("geodesic", form["calculationType"]);
+        Assert.Equal("esriSRUnit_Meter", form["lengthUnit"]);
+        using var polylines = JsonDocument.Parse(form["polylines"]);
+        Assert.Equal(JsonValueKind.Array, polylines.RootElement.ValueKind);
+        Assert.Equal([1234.5, 678.9], result.Lengths);
+    }
+
+    [Fact]
+    public async Task AreasAndLengthsAsync_ParsesAreasAndLengths()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""{ "areas": [ 5000.0 ], "lengths": [ 300.0 ] }""");
+        });
+
+        var result = await client.AreasAndLengthsAsync(new AreasAndLengthsRequest
+        {
+            ServiceId = "Geometry",
+            SpatialReference = 4326,
+            AreaUnit = "esriSquareMeters",
+            LengthUnit = "esriSRUnit_Meter",
+            CalculationType = "geodesic",
+            Polygons = [Polygon()],
+        });
+
+        Assert.Equal("http://localhost:5000/rest/services/Geometry/GeometryServer/areasAndLengths", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("esriSquareMeters", form["areaUnit"]);
+        Assert.Equal([5000.0], result.Areas);
+        Assert.Equal([300.0], result.Lengths);
+    }
+
+    [Fact]
+    public async Task ProjectAsync_GeoServicesErrorSurfacesAsHonuaFeatureServerException()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("""
+        {
+          "error": {
+            "code": 500,
+            "message": "Projection failed.",
+            "details": ["Unsupported transformation."]
+          }
+        }
+        """)));
+
+        var exception = await Assert.ThrowsAsync<HonuaFeatureServerException>(() =>
+            client.ProjectAsync(new ProjectGeometriesRequest
+            {
+                ServiceId = "Geometry",
+                GeometryType = "esriGeometryPoint",
+                InSpatialReference = 4326,
+                OutSpatialReference = 3857,
+                Geometries = [Point(-157.8, 21.3)],
+            }));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, exception.StatusCode);
+        Assert.Equal(500, exception.GeoServicesErrorCode);
+        Assert.Equal("Projection failed.", exception.Message);
+        Assert.Equal(["Unsupported transformation."], exception.Details!);
+    }
+
+    [Fact]
+    public void AddHonuaGeometryServer_RegistersGeometryServerClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaGeometryServer(options =>
+        {
+            options.BaseAddress = new Uri("http://localhost:5000");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<HonuaGeometryServerClient>());
+    }
+
+    [Fact]
+    public async Task ProjectAsync_UsesConfiguredDefaultServiceIdWhenNotProvided()
+    {
+        Uri? uri = null;
+        var options = new HonuaGeoServicesClientOptions
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+            GeometryServiceId = "Utilities/Geometry",
+        };
+        var client = CreateClient(
+            (request, _) =>
+            {
+                uri = request.RequestUri;
+                return Task.FromResult(JsonResponse("""{ "geometries": [] }"""));
+            },
+            options);
+
+        await client.ProjectAsync(new ProjectGeometriesRequest
+        {
+            GeometryType = "esriGeometryPoint",
+            InSpatialReference = 4326,
+            OutSpatialReference = 3857,
+            Geometries = [Point(-157.8, 21.3)],
+        });
+
+        Assert.Equal(
+            "http://localhost:5000/rest/services/Utilities%2FGeometry/GeometryServer/project",
+            uri?.ToString());
+    }
+
+    private static JsonElement Point(double x, double y)
+    {
+        using var doc = JsonDocument.Parse(
+            $"{{\"x\":{x.ToString(System.Globalization.CultureInfo.InvariantCulture)},\"y\":{y.ToString(System.Globalization.CultureInfo.InvariantCulture)}}}");
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonElement Polyline()
+    {
+        using var doc = JsonDocument.Parse("""{ "paths": [ [ [-157.8, 21.3], [-157.7, 21.4] ] ] }""");
+        return doc.RootElement.Clone();
+    }
+
+    private static JsonElement Polygon()
+    {
+        using var doc = JsonDocument.Parse("""{ "rings": [ [ [-157.8, 21.3], [-157.7, 21.3], [-157.7, 21.4], [-157.8, 21.3] ] ] }""");
+        return doc.RootElement.Clone();
+    }
+
+    private static HonuaGeometryServerClient CreateClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler,
+        HonuaGeoServicesClientOptions? options = null)
+    {
+        var mockHandler = new MockHttpHandler(request => handler(request, CancellationToken.None));
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+        };
+
+        options ??= new HonuaGeoServicesClientOptions
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+            GeometryServiceId = "Geometry",
+        };
+
+        return new HonuaGeometryServerClient(httpClient, options);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static async Task<Dictionary<string, string>> ReadFormAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string Decode(string value) => Uri.UnescapeDataString(value.Replace("+", " ", StringComparison.Ordinal));
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/ImageServer/HonuaImageServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/ImageServer/HonuaImageServerClientTests.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
+using Honua.Sdk.GeoServices.ImageServer;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.Tests.ImageServer;
+
+public sealed class HonuaImageServerClientTests
+{
+    [Fact]
+    public async Task GetServiceMetadataAsync_ParsesImageServiceDescription()
+    {
+        Uri? uri = null;
+        var client = CreateClient((request, _) =>
+        {
+            uri = request.RequestUri;
+            return Task.FromResult(JsonResponse("""
+            {
+              "serviceDescription": "Elevation",
+              "name": "Elevation",
+              "pixelType": "F32",
+              "bandCount": 1,
+              "minValues": [0.0],
+              "maxValues": [4207.5],
+              "extent": {
+                "xmin": -160.3, "ymin": 18.9, "xmax": -154.8, "ymax": 22.3,
+                "spatialReference": { "wkid": 4326, "latestWkid": 4326 }
+              },
+              "supportedQueryFormats": "JSON, geoJSON",
+              "supportedImageFormatTypes": "PNG,PNG8,PNG24,JPG,TIFF",
+              "allowedMosaicMethods": "Center,NorthWest",
+              "defaultMosaicMethod": "Center",
+              "hasRasterAttributeTable": false,
+              "hasHistograms": true
+            }
+            """));
+        });
+
+        var metadata = await client.GetServiceMetadataAsync("Elevation");
+
+        Assert.Equal("http://localhost:5000/rest/services/Elevation/ImageServer?f=json", uri?.ToString());
+        Assert.Equal("Elevation", metadata.ServiceId);
+        Assert.Equal("F32", metadata.PixelType);
+        Assert.Equal(1, metadata.BandCount);
+        Assert.Equal([0.0], metadata.MinValues!);
+        Assert.Equal([4207.5], metadata.MaxValues!);
+        Assert.NotNull(metadata.Extent);
+        Assert.Equal(-160.3, metadata.Extent!.XMin, precision: 4);
+        Assert.Equal(4326, metadata.Extent.SpatialReferenceWkid);
+        Assert.Equal(["JSON", "geoJSON"], metadata.SupportedQueryFormats!);
+        Assert.Equal(["PNG", "PNG8", "PNG24", "JPG", "TIFF"], metadata.SupportedImageFormatTypes!);
+        Assert.Equal("Center", metadata.DefaultMosaicMethod);
+        Assert.False(metadata.HasRasterAttributeTable);
+        Assert.True(metadata.HasHistograms);
+    }
+
+    [Fact]
+    public async Task ExportImageAsync_SendsExportFormAndReturnsRasterStream()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        HttpMethod? method = null;
+        var raster = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A };
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            method = request.Method;
+            form = await ReadFormAsync(request, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(raster)
+                {
+                    Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/png") },
+                },
+            };
+        });
+
+        await using var result = await client.ExportImageAsync(new ExportImageRequest
+        {
+            ServiceId = "Elevation",
+            BoundingBox = new ImageServerExtent { XMin = -158, YMin = 21, XMax = -157, YMax = 22 },
+            BoundingBoxSpatialReference = 4326,
+            ImageSpatialReference = 3857,
+            Width = 512,
+            Height = 256,
+            Format = "png24",
+            Interpolation = "RSP_BilinearInterpolation",
+        });
+
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal("http://localhost:5000/rest/services/Elevation/ImageServer/exportImage", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("image", form["f"]);
+        Assert.Equal("-158,21,-157,22", form["bbox"]);
+        Assert.Equal("4326", form["bboxSR"]);
+        Assert.Equal("3857", form["imageSR"]);
+        Assert.Equal("512,256", form["size"]);
+        Assert.Equal("png24", form["format"]);
+        Assert.Equal("RSP_BilinearInterpolation", form["interpolation"]);
+
+        Assert.Equal("image/png", result.ContentType);
+        using var memory = new MemoryStream();
+        await result.Content.CopyToAsync(memory);
+        Assert.Equal(raster, memory.ToArray());
+    }
+
+    [Fact]
+    public async Task ExportImageMetadataAsync_ParsesHrefAndExtent()
+    {
+        Dictionary<string, string>? form = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""
+            {
+              "href": "https://honua.example/exports/elevation.png",
+              "width": 512,
+              "height": 256,
+              "scale": 12345.6,
+              "extent": {
+                "xmin": -158, "ymin": 21, "xmax": -157, "ymax": 22,
+                "spatialReference": { "wkid": 3857 }
+              }
+            }
+            """);
+        });
+
+        var metadata = await client.ExportImageMetadataAsync(new ExportImageRequest
+        {
+            ServiceId = "Elevation",
+            BoundingBox = new ImageServerExtent { XMin = -158, YMin = 21, XMax = -157, YMax = 22 },
+            Width = 512,
+            Height = 256,
+        });
+
+        Assert.NotNull(form);
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("https://honua.example/exports/elevation.png", metadata.Href);
+        Assert.Equal(512, metadata.Width);
+        Assert.Equal(256, metadata.Height);
+        Assert.Equal(12345.6, metadata.Scale);
+        Assert.Equal(3857, metadata.Extent!.SpatialReferenceWkid);
+    }
+
+    [Fact]
+    public async Task IdentifyAsync_SendsPointGeometryAndParsesValue()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""
+            {
+              "objectId": 42,
+              "name": "DEM",
+              "value": "1234.5",
+              "location": { "x": -157.8, "y": 21.3 },
+              "catalogItems": { "features": [] }
+            }
+            """);
+        });
+
+        var result = await client.IdentifyAsync(new IdentifyImageRequest
+        {
+            ServiceId = "Elevation",
+            X = -157.8,
+            Y = 21.3,
+            SpatialReferenceWkid = 4326,
+        });
+
+        Assert.Equal("http://localhost:5000/rest/services/Elevation/ImageServer/identify", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("json", form["f"]);
+        Assert.Equal("esriGeometryPoint", form["geometryType"]);
+        using var geometry = JsonDocument.Parse(form["geometry"]);
+        Assert.Equal(-157.8, geometry.RootElement.GetProperty("x").GetDouble(), precision: 4);
+        Assert.Equal(4326, geometry.RootElement.GetProperty("spatialReference").GetProperty("wkid").GetInt32());
+
+        Assert.Equal(42, result.ObjectId);
+        Assert.Equal("DEM", result.Name);
+        Assert.Equal("1234.5", result.Value);
+    }
+
+    [Fact]
+    public async Task ExportImageAsync_GeoServicesErrorSurfacesAsHonuaFeatureServerException()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("""
+        {
+          "error": {
+            "code": 400,
+            "message": "Unable to complete operation.",
+            "details": ["Invalid bounding box."]
+          }
+        }
+        """)));
+
+        var exception = await Assert.ThrowsAsync<HonuaFeatureServerException>(() =>
+            client.ExportImageAsync(new ExportImageRequest
+            {
+                ServiceId = "Elevation",
+                BoundingBox = new ImageServerExtent { XMin = 0, YMin = 0, XMax = 1, YMax = 1 },
+                Width = 256,
+                Height = 256,
+            }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.Equal(400, exception.GeoServicesErrorCode);
+        Assert.Equal("Unable to complete operation.", exception.Message);
+        Assert.Equal(["Invalid bounding box."], exception.Details!);
+    }
+
+    [Fact]
+    public void AddHonuaImageServer_RegistersImageServerClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaImageServer(options =>
+        {
+            options.BaseAddress = new Uri("http://localhost:5000");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<HonuaImageServerClient>());
+    }
+
+    private static HonuaImageServerClient CreateClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+    {
+        var mockHandler = new MockHttpHandler(request => handler(request, CancellationToken.None));
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+        };
+
+        return new HonuaImageServerClient(httpClient);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static async Task<Dictionary<string, string>> ReadFormAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string Decode(string value) => Uri.UnescapeDataString(value.Replace("+", " ", StringComparison.Ordinal));
+}


### PR DESCRIPTION
Implements GeoServices ImageServer (GetServiceMetadata/exportImage/identify) and GeometryServer (project/buffer/lengths/areasAndLengths) clients mirroring HonuaRoutingClient, with shared error-envelope handling. 12 MockHttpHandler unit tests; API-compat clean (additive only). On the critical path to unblock honua-console #166. Wire contract verified against mocks — needs server-side validation once available.
🤖 Generated with [Claude Code](https://claude.com/claude-code)