### PR TITLE
feat: add native repeatable-section support to Honua.Sdk.Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Honua .NET SDK will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+* `Honua.Sdk.Field`: native repeatable-section support. `FieldRecord.Repeats`
+  carries captured rows (`FieldRepeatInstance`) per repeatable section, so repeat
+  data is part of the portable record contract and round-trips through
+  serialization, sync, and export rather than being flattened by consumers.
+  `FormValidator` and `CalculatedFieldEvaluator` now evaluate each row against
+  its own values; repeat-row validation errors are reported with field ids of
+  the form `sectionId[index].fieldId`. Additive and backward compatible.
+
 ## [1.0.0] - 2026-05-21
 
 First stable release of the Honua .NET SDK. Subsequent releases follow standard

--- a/src/Honua.Sdk.Field/Forms/CalculatedFieldEvaluator.cs
+++ b/src/Honua.Sdk.Field/Forms/CalculatedFieldEvaluator.cs
@@ -12,7 +12,9 @@ namespace Honua.Sdk.Field.Forms;
 public static class CalculatedFieldEvaluator
 {
     /// <summary>
-    /// Evaluates calculated fields and writes results into the record values dictionary.
+    /// Evaluates calculated fields and writes results into the record values
+    /// dictionary, including each captured row of a repeatable section (where
+    /// expressions resolve against the row's own values).
     /// </summary>
     /// <param name="form">Form with calculated field definitions.</param>
     /// <param name="record">Record containing input values and receiving calculated output values.</param>
@@ -21,19 +23,39 @@ public static class CalculatedFieldEvaluator
         ArgumentNullException.ThrowIfNull(form);
         ArgumentNullException.ThrowIfNull(record);
 
-        foreach (var field in form.Sections.SelectMany(section => section.Fields))
+        foreach (var section in form.Sections)
+        {
+            if (section.Repeatable)
+            {
+                if (record.Repeats.TryGetValue(section.SectionId, out var instances) && instances is not null)
+                {
+                    foreach (var instance in instances)
+                    {
+                        ApplyToScope(section.Fields, instance.Values);
+                    }
+                }
+
+                continue;
+            }
+
+            ApplyToScope(section.Fields, record.Values);
+        }
+    }
+
+    private static void ApplyToScope(IEnumerable<FormField> fields, Dictionary<string, object?> values)
+    {
+        foreach (var field in fields)
         {
             if (string.IsNullOrWhiteSpace(field.CalculatedExpression))
             {
                 continue;
             }
 
-            var value = EvaluateExpression(field.CalculatedExpression!, record);
-            record.Values[field.FieldId] = value;
+            values[field.FieldId] = EvaluateExpression(field.CalculatedExpression!, values);
         }
     }
 
-    private static object? EvaluateExpression(string expression, FieldRecord record)
+    private static object? EvaluateExpression(string expression, Dictionary<string, object?> values)
     {
         var openParen = expression.IndexOf('(', StringComparison.Ordinal);
         var closeParen = expression.LastIndexOf(')');
@@ -46,7 +68,7 @@ public static class CalculatedFieldEvaluator
         var function = expression[..openParen].Trim();
         var args = expression[(openParen + 1)..closeParen]
             .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-            .Select(arg => ResolveArg(arg, record))
+            .Select(arg => ResolveArg(arg, values))
             .ToArray();
 
         if (string.Equals(function, "concat", StringComparison.OrdinalIgnoreCase))
@@ -62,12 +84,12 @@ public static class CalculatedFieldEvaluator
         return expression;
     }
 
-    private static object? ResolveArg(string arg, FieldRecord record)
+    private static object? ResolveArg(string arg, Dictionary<string, object?> values)
     {
         if (arg.StartsWith('$'))
         {
             var key = arg[1..];
-            return record.Values.TryGetValue(key, out var value) ? value : null;
+            return values.TryGetValue(key, out var value) ? value : null;
         }
 
         if (arg.Length >= 2 && arg[0] == '\'' && arg[^1] == '\'')

--- a/src/Honua.Sdk.Field/Forms/FormValidator.cs
+++ b/src/Honua.Sdk.Field/Forms/FormValidator.cs
@@ -17,11 +17,16 @@ public static class FormValidator
     private static readonly TimeSpan RegexEvaluationTimeout = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Validates every visible field in a form.
+    /// Validates every visible field in a form, including each captured row of a
+    /// repeatable section.
     /// </summary>
     /// <param name="form">Form definition.</param>
     /// <param name="record">Record values to validate.</param>
-    /// <returns>Validation result with field-level errors.</returns>
+    /// <returns>
+    /// Validation result with field-level errors. Errors raised inside a
+    /// repeatable section are reported with a field id of the form
+    /// <c>sectionId[index].fieldId</c>.
+    /// </returns>
     public static FormValidationResult Validate(FormDefinition form, FieldRecord record)
     {
         ArgumentNullException.ThrowIfNull(form);
@@ -29,43 +34,83 @@ public static class FormValidator
 
         var errors = new List<FormValidationError>();
 
-        foreach (var field in form.Sections.SelectMany(section => section.Fields))
+        foreach (var section in form.Sections)
         {
-            var isVisible = IsVisible(field, record);
-            record.Values.TryGetValue(field.FieldId, out var rawValue);
-            var mediaCount = CountMedia(record, field);
-
-            if (field.Required && isVisible && IsMissing(rawValue) && mediaCount == 0)
+            if (section.Repeatable)
             {
-                errors.Add(new FormValidationError(field.FieldId, $"{field.Label} is required."));
+                ValidateRepeatSection(errors, section, record);
                 continue;
             }
 
-            if (!isVisible || (IsMissing(rawValue) && mediaCount == 0))
+            foreach (var field in section.Fields)
             {
-                continue;
+                ValidateField(errors, field, record.Values, record.Media, prefix: null);
             }
-
-            if (!IsMissing(rawValue))
-            {
-                ValidateType(errors, field, rawValue);
-                ValidateRules(errors, field, rawValue);
-            }
-
-            ValidateMediaRules(errors, field, mediaCount);
         }
 
         return new FormValidationResult(errors);
     }
 
-    private static bool IsVisible(FormField field, FieldRecord record)
+    private static void ValidateRepeatSection(List<FormValidationError> errors, FormSection section, FieldRecord record)
+    {
+        if (!record.Repeats.TryGetValue(section.SectionId, out var instances) || instances is null)
+        {
+            return;
+        }
+
+        for (var index = 0; index < instances.Count; index++)
+        {
+            var instance = instances[index];
+            var prefix = $"{section.SectionId}[{index}].";
+            foreach (var field in section.Fields)
+            {
+                ValidateField(errors, field, instance.Values, instance.Media, prefix);
+            }
+        }
+    }
+
+    private static void ValidateField(
+        List<FormValidationError> errors,
+        FormField field,
+        Dictionary<string, object?> values,
+        IEnumerable<FieldMediaAttachment> media,
+        string? prefix)
+    {
+        var local = new List<FormValidationError>();
+
+        var isVisible = IsVisible(field, values);
+        values.TryGetValue(field.FieldId, out var rawValue);
+        var mediaCount = CountMedia(media, field);
+
+        if (field.Required && isVisible && IsMissing(rawValue) && mediaCount == 0)
+        {
+            local.Add(new FormValidationError(field.FieldId, $"{field.Label} is required."));
+        }
+        else if (isVisible && (!IsMissing(rawValue) || mediaCount > 0))
+        {
+            if (!IsMissing(rawValue))
+            {
+                ValidateType(local, field, rawValue);
+                ValidateRules(local, field, rawValue);
+            }
+
+            ValidateMediaRules(local, field, mediaCount);
+        }
+
+        foreach (var error in local)
+        {
+            errors.Add(prefix is null ? error : new FormValidationError(prefix + error.FieldId, error.Message));
+        }
+    }
+
+    private static bool IsVisible(FormField field, Dictionary<string, object?> values)
     {
         if (field.VisibilityRule is null)
         {
             return true;
         }
 
-        if (!record.Values.TryGetValue(field.VisibilityRule.DependsOnFieldId, out var actual))
+        if (!values.TryGetValue(field.VisibilityRule.DependsOnFieldId, out var actual))
         {
             return false;
         }
@@ -164,16 +209,16 @@ public static class FormValidator
         }
     }
 
-    private static int CountMedia(FieldRecord record, FormField field)
+    private static int CountMedia(IEnumerable<FieldMediaAttachment> media, FormField field)
     {
         if (!IsMediaField(field.Type))
         {
             return 0;
         }
 
-        return record.Media.Count(media =>
-            string.IsNullOrWhiteSpace(media.FieldId) ||
-            string.Equals(media.FieldId, field.FieldId, StringComparison.OrdinalIgnoreCase));
+        return media.Count(item =>
+            string.IsNullOrWhiteSpace(item.FieldId) ||
+            string.Equals(item.FieldId, field.FieldId, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool IsMediaField(FormFieldType fieldType)

--- a/src/Honua.Sdk.Field/Records/FieldRecord.cs
+++ b/src/Honua.Sdk.Field/Records/FieldRecord.cs
@@ -22,6 +22,13 @@ public sealed class FieldRecord
     /// <summary>Portable media attachment metadata. Host-specific local paths stay outside the SDK contract.</summary>
     public Collection<FieldMediaAttachment> Media { get; init; } = [];
 
+    /// <summary>
+    /// Captured rows for repeatable sections, keyed by <see cref="Forms.FormSection.SectionId"/>.
+    /// Each section maps to its ordered list of <see cref="FieldRepeatInstance"/> rows, so repeat
+    /// data is part of the portable contract rather than flattened into <see cref="Values"/>.
+    /// </summary>
+    public Dictionary<string, IList<FieldRepeatInstance>> Repeats { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Capture location, when available.</summary>
     public FieldGeoPoint? Location { get; set; }
 

--- a/src/Honua.Sdk.Field/Records/FieldRepeatInstance.cs
+++ b/src/Honua.Sdk.Field/Records/FieldRepeatInstance.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Collections.ObjectModel;
+
+namespace Honua.Sdk.Field.Records;
+
+/// <summary>
+/// One captured row of a repeatable <see cref="Forms.FormSection"/> (a Survey123
+/// "repeat" / Fulcrum "repeatable section" instance). Each instance carries its
+/// own field values and media so repeat data is part of the portable record
+/// contract and round-trips through serialization, sync, and export.
+/// </summary>
+public sealed class FieldRepeatInstance
+{
+    /// <summary>Captured field values for this row, keyed by form field identifier.</summary>
+    public Dictionary<string, object?> Values { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Portable media metadata captured against this row.</summary>
+    public Collection<FieldMediaAttachment> Media { get; init; } = [];
+}

--- a/tests/Honua.Sdk.Field.Tests/RepeatSectionValidationTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/RepeatSectionValidationTests.cs
@@ -1,0 +1,172 @@
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Sdk.Field.Tests;
+
+public sealed class RepeatSectionValidationTests
+{
+    private static FormDefinition Form() => new()
+    {
+        FormId = "pole",
+        Name = "Pole inspection",
+        Sections =
+        [
+            new FormSection
+            {
+                SectionId = "header",
+                Label = "Header",
+                Fields = [new FormField { FieldId = "poleId", Label = "Pole ID", Type = FormFieldType.Text, Required = true }],
+            },
+            new FormSection
+            {
+                SectionId = "attachments",
+                Label = "Attachments",
+                Repeatable = true,
+                Fields =
+                [
+                    new FormField { FieldId = "kind", Label = "Kind", Type = FormFieldType.Text, Required = true },
+                    new FormField { FieldId = "height", Label = "Height", Type = FormFieldType.Numeric },
+                ],
+            },
+        ],
+    };
+
+    private static FieldRepeatInstance Row(params (string Key, object? Value)[] values)
+    {
+        var instance = new FieldRepeatInstance();
+        foreach (var (key, value) in values)
+        {
+            instance.Values[key] = value;
+        }
+
+        return instance;
+    }
+
+    [Fact]
+    public void Validate_ReportsRowErrors_WithIndexedFieldIds()
+    {
+        var record = new FieldRecord { RecordId = "r1", FormId = "pole" };
+        record.Values["poleId"] = "P-7";
+        record.Repeats["attachments"] =
+        [
+            Row(("kind", "transformer"), ("height", 9)),
+            Row(("height", "not-a-number")), // kind missing (required) + height non-numeric
+        ];
+
+        var result = FormValidator.Validate(Form(), record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.FieldId == "attachments[1].kind" && e.Message.Contains("required"));
+        Assert.Contains(result.Errors, e => e.FieldId == "attachments[1].height" && e.Message.Contains("numeric"));
+        Assert.DoesNotContain(result.Errors, e => e.FieldId.StartsWith("attachments[0]", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_NoRows_RaisesNoRepeatErrors()
+    {
+        var record = new FieldRecord { RecordId = "r1", FormId = "pole" };
+        record.Values["poleId"] = "P-7";
+
+        var result = FormValidator.Validate(Form(), record);
+
+        Assert.True(result.IsValid); // zero repeat rows is allowed; scalar fields satisfied
+    }
+
+    [Fact]
+    public void Validate_RepeatFieldsAreNotValidatedAtTopLevel()
+    {
+        // 'kind' is required but lives in the repeatable section. With no rows it
+        // must not surface as a top-level required error.
+        var record = new FieldRecord { RecordId = "r1", FormId = "pole" };
+        record.Values["poleId"] = "P-7";
+
+        var result = FormValidator.Validate(Form(), record);
+
+        Assert.DoesNotContain(result.Errors, e => e.FieldId == "kind");
+    }
+
+    [Fact]
+    public void CalculatedFields_EvaluatePerRow_AgainstRowValues()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "f",
+            Name = "f",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "people",
+                    Label = "People",
+                    Repeatable = true,
+                    Fields =
+                    [
+                        new FormField { FieldId = "first", Label = "First", Type = FormFieldType.Text },
+                        new FormField { FieldId = "last", Label = "Last", Type = FormFieldType.Text },
+                        new FormField { FieldId = "full", Label = "Full", Type = FormFieldType.Calculated, CalculatedExpression = "concat($first, ' ', $last)" },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord { RecordId = "r1", FormId = "f" };
+        record.Repeats["people"] =
+        [
+            Row(("first", "Ada"), ("last", "Lovelace")),
+            Row(("first", "Alan"), ("last", "Turing")),
+        ];
+
+        CalculatedFieldEvaluator.ApplyCalculatedFields(form, record);
+
+        Assert.Equal("Ada Lovelace", record.Repeats["people"][0].Values["full"]);
+        Assert.Equal("Alan Turing", record.Repeats["people"][1].Values["full"]);
+    }
+
+    [Fact]
+    public void Visibility_WithinARow_UsesRowValues()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "f",
+            Name = "f",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "items",
+                    Label = "Items",
+                    Repeatable = true,
+                    Fields =
+                    [
+                        new FormField { FieldId = "hasDetail", Label = "Has detail?", Type = FormFieldType.YesNo },
+                        new FormField
+                        {
+                            FieldId = "detail",
+                            Label = "Detail",
+                            Type = FormFieldType.Text,
+                            Required = true,
+                            VisibilityRule = new FieldVisibilityRule
+                            {
+                                DependsOnFieldId = "hasDetail",
+                                Operator = ComparisonOperator.Equals,
+                                MatchValue = true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord { RecordId = "r1", FormId = "f" };
+        record.Repeats["items"] =
+        [
+            Row(("hasDetail", false)),               // detail hidden -> not required
+            Row(("hasDetail", true)),                // detail shown but missing -> required error
+        ];
+
+        var result = FormValidator.Validate(form, record);
+
+        Assert.Contains(result.Errors, e => e.FieldId == "items[1].detail");
+        Assert.DoesNotContain(result.Errors, e => e.FieldId == "items[0].detail");
+    }
+}


### PR DESCRIPTION
## Native repeatable-section support in `Honua.Sdk.Field`

Adds repeats to the **portable** field record contract so they round-trip through serialization, sync, and export instead of being a consumer-side convention — the contract piece Survey123/Fulcrum-style "repeats" need.

### Changes
- **`FieldRecord.Repeats`** (`Dictionary<string, IList<FieldRepeatInstance>>`, keyed by section id) carries captured rows; new `FieldRepeatInstance` holds a row's own `Values` + `Media`.
- **`FormValidator`** now validates each repeat row against its own values (visibility + required resolve within the row); repeat-row errors are reported as `sectionId[index].fieldId`. Repeatable-section fields are no longer validated at the top level.
- **`CalculatedFieldEvaluator`** evaluates calculated fields per row against row-local values.

Both helpers were refactored to operate over a value scope; all existing scalar behavior is preserved.

### Compatibility
Additive and backward compatible (new optional members; `Repeatable` was previously defined but unused). 21 existing Field tests still pass; **5 new** repeat tests added (validation indexing, per-row calc, per-row visibility, no-rows).

Unblocks Honua Collect persisting repeats through native server sync.
