### PR TITLE
feat: add styleId-keyed OGC styles client (#184)

### DIFF
--- a/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminStylesClient.cs
+++ b/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminStylesClient.cs
@@ -6,13 +6,26 @@ using Honua.Sdk.Admin.Models;
 namespace Honua.Sdk.Admin;
 
 /// <summary>
-/// Per-layer style read and update.
+/// Per-layer style read and update over the admin metadata API
+/// (<c>/api/v1/admin/metadata/layers/{layerId}/style</c>), keyed by <c>layerId</c>.
 /// </summary>
+/// <remarks>
+/// This layer-keyed surface is retained as a back-compat alias for editing a
+/// layer's default style. For the canonical, <c>styleId</c>-keyed styles surface
+/// (ADR-0048), prefer <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient</c>
+/// over <c>/ogc/styles</c>, which supports listing styles, content-negotiated
+/// stylesheet encodings (MapLibre/SLD), and style metadata.
+/// </remarks>
 public interface IHonuaAdminStylesClient
 {
     /// <summary>
     /// Gets the style for a layer.
     /// </summary>
+    /// <remarks>
+    /// Prefer the <c>styleId</c>-keyed
+    /// <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.GetStylesheetAsync</c>
+    /// for the canonical OGC API - Styles surface (ADR-0048).
+    /// </remarks>
     /// <param name="layerId">The layer identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The layer style response.</returns>
@@ -21,6 +34,11 @@ public interface IHonuaAdminStylesClient
     /// <summary>
     /// Updates the style for a layer.
     /// </summary>
+    /// <remarks>
+    /// Prefer the <c>styleId</c>-keyed
+    /// <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.UpdateStyleAsync</c>
+    /// for the canonical OGC API - Styles surface (ADR-0048).
+    /// </remarks>
     /// <param name="layerId">The layer identifier.</param>
     /// <param name="request">The style update request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.OgcFeatures.Styles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
@@ -58,6 +59,33 @@ public static class ServiceCollectionExtensions
         if (snapshot.EnableRetry)
         {
             httpBuilder.AddStandardResilienceHandler(options =>
+            {
+                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
+                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
+                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
+                options.Retry.DisableForUnsafeHttpMethods();
+                options.Retry.UseJitter = true;
+            });
+        }
+
+        var stylesBuilder = services.AddHttpClient<HonuaOgcStylesClient>((sp, client) =>
+        {
+            var options = sp.GetRequiredService<IOptions<HonuaOgcFeaturesClientOptions>>().Value;
+            client.BaseAddress = options.BaseAddress;
+            client.Timeout = options.Timeout;
+        })
+        .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
+        services.AddTransient<IHonuaOgcStylesClient>(sp => sp.GetRequiredService<HonuaOgcStylesClient>());
+
+        if (snapshot.PrimaryHttpMessageHandlerFactory is { } stylesPrimaryHandlerFactory)
+        {
+            stylesBuilder.ConfigurePrimaryHttpMessageHandler(stylesPrimaryHandlerFactory);
+        }
+
+        if (snapshot.EnableRetry)
+        {
+            stylesBuilder.AddStandardResilienceHandler(options =>
             {
                 options.TotalRequestTimeout.Timeout = snapshot.Timeout;
                 options.AttemptTimeout.Timeout = snapshot.Timeout;

--- a/src/Honua.Sdk.OgcFeatures/README.md
+++ b/src/Honua.Sdk.OgcFeatures/README.md
@@ -10,6 +10,15 @@ Also ships the **WFS 2.0 read/query** surface under
 parsing pipeline for GetCapabilities, DescribeFeatureType, and GetFeature
 (GeoJSON).
 
+And the **OGC API – Styles** surface under `Honua.Sdk.OgcFeatures.Styles.*`:
+`IHonuaOgcStylesClient` / `HonuaOgcStylesClient` keyed by `styleId` over
+`/ogc/styles` (ADR-0048) — list styles, get a content-negotiated stylesheet
+(MapLibre default, or derived SLD 1.0/1.1), read style metadata, and update a
+style's MapLibre stylesheet. This is the canonical styles surface; the per-layer
+`IHonuaAdminStylesClient` (keyed by `layerId`) remains a back-compat alias for
+editing a layer's default style. Registered alongside the features client via
+`AddHonuaOgcFeatures(...)`.
+
 Part of the [Honua .NET SDK](https://github.com/honua-io/honua-sdk-dotnet) — see the
 repo README for the full package catalog, browser/WASM support, authentication, and
 release policy.
@@ -70,6 +79,30 @@ var page = await wfs.GetFeaturesAsync(new GetFeaturesRequest
     TypeNames = caps.FeatureTypes[0].Name,
     Count = 50,
 }, cancellationToken);
+```
+
+### OGC API – Styles
+
+```csharp
+using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.OgcFeatures.Styles;
+using Honua.Sdk.OgcFeatures.Styles.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddHonuaOgcFeatures(o => o.BaseAddress = new Uri("https://your-honua-server"));
+var provider = services.BuildServiceProvider();
+
+var styles = provider.GetRequiredService<IHonuaOgcStylesClient>();
+
+var list = await styles.ListStylesAsync(cancellationToken);
+var styleId = list.Default ?? list.Styles[0].Id;
+
+// MapLibre by default; request SLD via the encoding argument.
+var sheet = await styles.GetStylesheetAsync(styleId, OgcStyleEncoding.MapboxStyle, cancellationToken);
+var metadata = await styles.GetStyleMetadataAsync(styleId, cancellationToken);
+
+await styles.UpdateStyleAsync(styleId, sheet.Content, strict: true, cancellationToken);
 ```
 
 ## Documentation

--- a/src/Honua.Sdk.OgcFeatures/Styles/HonuaOgcStylesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/Styles/HonuaOgcStylesClient.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.OgcFeatures.Exceptions;
+using Honua.Sdk.OgcFeatures.Styles.Models;
+
+namespace Honua.Sdk.OgcFeatures.Styles;
+
+/// <summary>
+/// HTTP client implementation for the Honua OGC API - Styles surface keyed by
+/// <c>styleId</c> (ADR-0048).
+/// </summary>
+public sealed class HonuaOgcStylesClient : IHonuaOgcStylesClient
+{
+    private const string BasePath = "/ogc/styles";
+    private const string MapboxStyleMediaType = "application/vnd.mapbox.style+json";
+    private const string SldMediaType = "application/vnd.ogc.sld+xml";
+
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaOgcStylesClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client configured with base address and auth handlers.</param>
+    public HonuaOgcStylesClient(HttpClient httpClient)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        _http = httpClient;
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStylesList> ListStylesAsync(CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{BasePath}?f=json");
+        request.Headers.Accept.ParseAdd("application/json");
+
+        var (body, _) = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize(body, OgcStylesJsonContext.Default.OgcStylesList)
+            ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize styles list.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStylesheet> GetStylesheetAsync(
+        string styleId,
+        OgcStyleEncoding encoding = OgcStyleEncoding.MapboxStyle,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"{BasePath}/{Uri.EscapeDataString(styleId)}");
+        request.Headers.Accept.ParseAdd(ToAcceptHeader(encoding));
+
+        var (body, mediaType) = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return new OgcStylesheet
+        {
+            StyleId = styleId,
+            Encoding = encoding,
+            MediaType = mediaType,
+            Content = body
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<OgcStyleMetadata> GetStyleMetadataAsync(
+        string styleId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"{BasePath}/{Uri.EscapeDataString(styleId)}/metadata?f=json");
+        request.Headers.Accept.ParseAdd("application/json");
+
+        var (body, _) = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Deserialize(body, OgcStylesJsonContext.Default.OgcStyleMetadata)
+            ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize style metadata.", body);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        bool strict = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(mapLibreStyleJson);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Put,
+            $"{BasePath}/{Uri.EscapeDataString(styleId)}")
+        {
+            Content = new StringContent(mapLibreStyleJson, Encoding.UTF8)
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue(MapboxStyleMediaType);
+
+        if (strict)
+        {
+            request.Headers.TryAddWithoutValidation("Prefer", "handling=strict");
+        }
+
+        await SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string ToAcceptHeader(OgcStyleEncoding encoding) => encoding switch
+    {
+        OgcStyleEncoding.MapboxStyle => MapboxStyleMediaType,
+        OgcStyleEncoding.Sld10 => $"{SldMediaType};version=1.0",
+        OgcStyleEncoding.Sld11 => $"{SldMediaType};version=1.1",
+        _ => MapboxStyleMediaType,
+    };
+
+    private async Task<(string Body, string? MediaType)> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body);
+        return (body, response.Content.Headers.ContentType?.MediaType);
+    }
+
+    private static void EnsureSuccess(HttpResponseMessage response, string body)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        string? problemType = null;
+        string? problemTitle = null;
+        string? problemDetail = null;
+
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            try
+            {
+                var problem = JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcProblemDetails);
+                if (problem is not null)
+                {
+                    problemType = problem.Type;
+                    problemTitle = problem.Title;
+                    problemDetail = problem.Detail;
+                }
+            }
+            catch (JsonException)
+            {
+                // Not valid Problem Details JSON.
+            }
+        }
+
+        var message = problemDetail ?? problemTitle ?? response.ReasonPhrase ?? "OGC API Styles request failed";
+        throw new HonuaOgcFeaturesException(
+            response.StatusCode, message, body, problemType, problemTitle, problemDetail);
+    }
+}

--- a/src/Honua.Sdk.OgcFeatures/Styles/IHonuaOgcStylesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/Styles/IHonuaOgcStylesClient.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.OgcFeatures.Styles.Models;
+
+namespace Honua.Sdk.OgcFeatures.Styles;
+
+/// <summary>
+/// Client for the Honua OGC API - Styles surface (<c>/ogc/styles</c>), keyed by
+/// <c>styleId</c> per ADR-0048. This is the canonical styles client; the
+/// per-layer admin styles client (<c>IHonuaAdminStylesClient</c>) keyed by
+/// <c>layerId</c> remains a back-compat alias for editing a layer's default style.
+/// </summary>
+public interface IHonuaOgcStylesClient
+{
+    /// <summary>
+    /// Lists the styles available on the server (<c>GET /ogc/styles</c>).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The styles list, including any declared default style.</returns>
+    Task<OgcStylesList> ListStylesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a stylesheet (<c>GET /ogc/styles/{styleId}</c>), content-negotiated by
+    /// the requested <paramref name="encoding"/> via the <c>Accept</c> header.
+    /// </summary>
+    /// <param name="styleId">The stable style identifier.</param>
+    /// <param name="encoding">
+    /// The desired stylesheet encoding. Defaults to
+    /// <see cref="OgcStyleEncoding.MapboxStyle"/> (the canonical MapLibre JSON).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The stylesheet document and its negotiated media type.</returns>
+    Task<OgcStylesheet> GetStylesheetAsync(
+        string styleId,
+        OgcStyleEncoding encoding = OgcStyleEncoding.MapboxStyle,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets descriptive metadata for a style
+    /// (<c>GET /ogc/styles/{styleId}/metadata</c>).
+    /// </summary>
+    /// <param name="styleId">The stable style identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The style metadata.</returns>
+    Task<OgcStyleMetadata> GetStyleMetadataAsync(
+        string styleId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates a style's MapLibre stylesheet (<c>PUT /ogc/styles/{styleId}</c>),
+    /// requiring the <c>manage-styles</c> capability. The body is sent as
+    /// <c>application/vnd.mapbox.style+json</c>.
+    /// </summary>
+    /// <param name="styleId">The stable style identifier.</param>
+    /// <param name="mapLibreStyleJson">The MapLibre/Mapbox style document to store.</param>
+    /// <param name="strict">
+    /// When <c>true</c>, requests strict validation via <c>Prefer: handling=strict</c>;
+    /// invalid styles are rejected with a 400.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the style has been updated.</returns>
+    Task UpdateStyleAsync(
+        string styleId,
+        string mapLibreStyleJson,
+        bool strict = false,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Sdk.OgcFeatures/Styles/Models/OgcStyles.cs
+++ b/src/Honua.Sdk.OgcFeatures/Styles/Models/OgcStyles.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Sdk.OgcFeatures.Models;
+
+namespace Honua.Sdk.OgcFeatures.Styles.Models;
+
+// TODO(#184): dedup these envelopes against Geospatial.Grpc StyleRef once the
+// 0.1.0-alpha.2 package is consumable in this repo's restore. The repo currently
+// pins Geospatial.Grpc 0.1.0-alpha.1 (Directory.Build.props) and the OgcFeatures
+// package does not reference the proto package, so the dedup is deferred.
+
+/// <summary>
+/// OGC API - Styles styles list response (<c>GET /ogc/styles</c>).
+/// </summary>
+public sealed class OgcStylesList
+{
+    /// <summary>The styles available on the server.</summary>
+    [JsonPropertyName("styles")]
+    public IReadOnlyList<OgcStyleEntry> Styles { get; init; } = [];
+
+    /// <summary>Optional default style identifier.</summary>
+    [JsonPropertyName("default")]
+    public string? Default { get; init; }
+
+    /// <summary>Links to related resources (self, alternate, etc.).</summary>
+    [JsonPropertyName("links")]
+    public IReadOnlyList<OgcLink>? Links { get; init; }
+}
+
+/// <summary>
+/// A single entry in the OGC API - Styles styles list.
+/// </summary>
+public sealed class OgcStyleEntry
+{
+    /// <summary>Stable style identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human-readable title for the style.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Links to the stylesheet encodings and style metadata.</summary>
+    [JsonPropertyName("links")]
+    public IReadOnlyList<OgcLink> Links { get; init; } = [];
+}
+
+/// <summary>
+/// OGC API - Styles style metadata response (<c>GET /ogc/styles/{styleId}/metadata</c>).
+/// </summary>
+public sealed class OgcStyleMetadata
+{
+    /// <summary>Stable style identifier.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human-readable title for the style.</summary>
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    /// <summary>Description of the style.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    /// <summary>Keywords describing the style.</summary>
+    [JsonPropertyName("keywords")]
+    public IReadOnlyList<string>? Keywords { get; init; }
+
+    /// <summary>License identifier for the style, when known.</summary>
+    [JsonPropertyName("license")]
+    public string? License { get; init; }
+
+    /// <summary>Style revision number, expressed as a string, when known.</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary>
+    /// Links incl. the stylesheet encodings, the schema (describedby), and a preview.
+    /// </summary>
+    [JsonPropertyName("links")]
+    public IReadOnlyList<OgcLink> Links { get; init; } = [];
+}
+
+/// <summary>
+/// The encoding (media type) used to read or write a stylesheet from the
+/// OGC API - Styles surface.
+/// </summary>
+public enum OgcStyleEncoding
+{
+    /// <summary>MapLibre/Mapbox style JSON (<c>application/vnd.mapbox.style+json</c>); the canonical default.</summary>
+    MapboxStyle,
+
+    /// <summary>OGC SLD 1.0 (<c>application/vnd.ogc.sld+xml;version=1.0</c>), derived from the canonical style.</summary>
+    Sld10,
+
+    /// <summary>OGC SLD 1.1 (<c>application/vnd.ogc.sld+xml;version=1.1</c>), derived from the canonical style.</summary>
+    Sld11
+}
+
+/// <summary>
+/// A stylesheet returned by <c>GET /ogc/styles/{styleId}</c>, including the raw
+/// document content and the negotiated media type.
+/// </summary>
+public sealed class OgcStylesheet
+{
+    /// <summary>The stable style identifier the stylesheet was requested for.</summary>
+    public string StyleId { get; init; } = string.Empty;
+
+    /// <summary>The encoding the server returned the stylesheet in.</summary>
+    public OgcStyleEncoding Encoding { get; init; }
+
+    /// <summary>The media type reported by the server (the response <c>Content-Type</c>).</summary>
+    public string? MediaType { get; init; }
+
+    /// <summary>The raw stylesheet document (MapLibre JSON or SLD XML).</summary>
+    public string Content { get; init; } = string.Empty;
+}

--- a/src/Honua.Sdk.OgcFeatures/Styles/OgcStylesJsonContext.cs
+++ b/src/Honua.Sdk.OgcFeatures/Styles/OgcStylesJsonContext.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+using Honua.Sdk.OgcFeatures.Styles.Models;
+
+namespace Honua.Sdk.OgcFeatures.Styles;
+
+/// <summary>
+/// Source-generated JSON serializer context for OGC API - Styles types (AOT-compatible).
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(OgcStylesList))]
+[JsonSerializable(typeof(OgcStyleEntry))]
+[JsonSerializable(typeof(OgcStyleMetadata))]
+internal sealed partial class OgcStylesJsonContext : JsonSerializerContext
+{
+}

--- a/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/ClientOptionsTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.OgcFeatures.Extensions;
+using Honua.Sdk.OgcFeatures.Styles;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Honua.Sdk.OgcFeatures.Tests;
@@ -63,6 +64,22 @@ public sealed class ClientOptionsTests
         Assert.Equal("ogc-features", attachmentClient.ProviderName);
         Assert.False(attachmentClient.AttachmentCapabilities.SupportsList);
         Assert.Contains("attachment operations", attachmentClient.AttachmentCapabilities.UnsupportedReason);
+    }
+
+    [Fact]
+    public void AddHonuaOgcFeatures_RegistersStylesClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var stylesClient = Assert.Single(provider.GetServices<IHonuaOgcStylesClient>());
+
+        Assert.IsType<HonuaOgcStylesClient>(stylesClient);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.Tests/Fixtures/TestHelpers.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/Fixtures/TestHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text.Json;
+using Honua.Sdk.OgcFeatures.Styles;
 
 namespace Honua.Sdk.OgcFeatures.Tests.Fixtures;
 
@@ -20,6 +21,29 @@ internal static class TestHelpers
             BaseAddress = new Uri("http://localhost:5000")
         };
         return new HonuaOgcFeaturesClient(httpClient);
+    }
+
+    public static HonuaOgcStylesClient CreateOgcStylesClient(
+        Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+    {
+        var mockHandler = new MockHttpHandler(handler);
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000")
+        };
+        return new HonuaOgcStylesClient(httpClient);
+    }
+
+    public static HttpResponseMessage CreateRawResponse(
+        string content, string mediaType, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var httpContent = new StringContent(content, System.Text.Encoding.UTF8);
+        httpContent.Headers.ContentType =
+            System.Net.Http.Headers.MediaTypeHeaderValue.Parse(mediaType);
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = httpContent
+        };
     }
 
     public static HttpResponseMessage CreateRawJsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcStylesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcStylesClientTests.cs
@@ -1,0 +1,255 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.OgcFeatures.Exceptions;
+using Honua.Sdk.OgcFeatures.Styles.Models;
+using Honua.Sdk.OgcFeatures.Tests.Fixtures;
+
+namespace Honua.Sdk.OgcFeatures.Tests.OgcFeatures;
+
+public class HonuaOgcStylesClientTests
+{
+    // ── ListStylesAsync ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task ListStylesAsync_ReturnsStylesAndDefault()
+    {
+        var json = """
+        {
+            "styles": [
+                {
+                    "id": "topographic",
+                    "title": "Topographic",
+                    "links": [
+                        { "href": "/ogc/styles/topographic", "rel": "stylesheet", "type": "application/vnd.mapbox.style+json" }
+                    ]
+                },
+                {
+                    "id": "satellite",
+                    "title": "Satellite",
+                    "links": []
+                }
+            ],
+            "default": "topographic",
+            "links": [
+                { "href": "/ogc/styles", "rel": "self", "type": "application/json" }
+            ]
+        }
+        """;
+        HttpRequestMessage? captured = null;
+        var client = TestHelpers.CreateOgcStylesClient(req =>
+        {
+            captured = req;
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var result = await client.ListStylesAsync();
+
+        Assert.Equal(2, result.Styles.Count);
+        Assert.Equal("topographic", result.Styles[0].Id);
+        Assert.Equal("Topographic", result.Styles[0].Title);
+        Assert.Single(result.Styles[0].Links);
+        Assert.Equal("stylesheet", result.Styles[0].Links[0].Rel);
+        Assert.Equal("topographic", result.Default);
+        Assert.NotNull(result.Links);
+        Assert.NotNull(captured);
+        Assert.Equal("/ogc/styles?f=json", captured!.RequestUri!.PathAndQuery);
+    }
+
+    // ── GetStylesheetAsync (content negotiation) ────────────────────
+
+    [Fact]
+    public async Task GetStylesheetAsync_DefaultEncoding_SendsMapboxAcceptHeader()
+    {
+        const string style = """{ "version": 8, "layers": [] }""";
+        HttpRequestMessage? captured = null;
+        var client = TestHelpers.CreateOgcStylesClient(req =>
+        {
+            captured = req;
+            return Task.FromResult(
+                TestHelpers.CreateRawResponse(style, "application/vnd.mapbox.style+json"));
+        });
+
+        var result = await client.GetStylesheetAsync("topographic");
+
+        Assert.Equal("topographic", result.StyleId);
+        Assert.Equal(OgcStyleEncoding.MapboxStyle, result.Encoding);
+        Assert.Equal("application/vnd.mapbox.style+json", result.MediaType);
+        Assert.Equal(style, result.Content);
+        Assert.NotNull(captured);
+        Assert.Equal("/ogc/styles/topographic", captured!.RequestUri!.PathAndQuery);
+        Assert.Contains(
+            captured.Headers.Accept,
+            h => h.MediaType == "application/vnd.mapbox.style+json");
+    }
+
+    [Theory]
+    [InlineData(OgcStyleEncoding.Sld10, "application/vnd.ogc.sld+xml", "1.0")]
+    [InlineData(OgcStyleEncoding.Sld11, "application/vnd.ogc.sld+xml", "1.1")]
+    public async Task GetStylesheetAsync_SldEncoding_SendsVersionedAcceptHeader(
+        OgcStyleEncoding encoding, string expectedMediaType, string expectedVersion)
+    {
+        const string sld = "<StyledLayerDescriptor/>";
+        HttpRequestMessage? captured = null;
+        var client = TestHelpers.CreateOgcStylesClient(req =>
+        {
+            captured = req;
+            return Task.FromResult(
+                TestHelpers.CreateRawResponse(sld, $"{expectedMediaType};version={expectedVersion}"));
+        });
+
+        var result = await client.GetStylesheetAsync("topographic", encoding);
+
+        Assert.Equal(encoding, result.Encoding);
+        Assert.Equal(sld, result.Content);
+        Assert.NotNull(captured);
+        var accept = Assert.Single(captured!.Headers.Accept);
+        Assert.Equal(expectedMediaType, accept.MediaType);
+        Assert.Contains(
+            accept.Parameters,
+            p => p.Name == "version" && p.Value == expectedVersion);
+    }
+
+    [Fact]
+    public async Task GetStylesheetAsync_NotAcceptable_ThrowsWithStatusCode()
+    {
+        var client = TestHelpers.CreateOgcStylesClient(_ =>
+            Task.FromResult(TestHelpers.CreateProblemDetailsResponse(
+                HttpStatusCode.NotAcceptable, "Not Acceptable", "Unsupported stylesheet media type.")));
+
+        var ex = await Assert.ThrowsAsync<HonuaOgcFeaturesException>(
+            () => client.GetStylesheetAsync("topographic", OgcStyleEncoding.Sld11));
+
+        Assert.Equal(HttpStatusCode.NotAcceptable, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetStylesheetAsync_EmptyStyleId_Throws()
+    {
+        var client = TestHelpers.CreateOgcStylesClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse("{}")));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => client.GetStylesheetAsync("  "));
+    }
+
+    // ── GetStyleMetadataAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetStyleMetadataAsync_ReturnsMetadata()
+    {
+        var json = """
+        {
+            "id": "topographic",
+            "title": "Topographic",
+            "description": "Default topographic basemap",
+            "keywords": ["basemap", "topo"],
+            "license": "CC-BY-4.0",
+            "version": "3",
+            "links": [
+                { "href": "/ogc/styles/topographic", "rel": "stylesheet", "type": "application/vnd.mapbox.style+json" }
+            ]
+        }
+        """;
+        HttpRequestMessage? captured = null;
+        var client = TestHelpers.CreateOgcStylesClient(req =>
+        {
+            captured = req;
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var result = await client.GetStyleMetadataAsync("topographic");
+
+        Assert.Equal("topographic", result.Id);
+        Assert.Equal("Topographic", result.Title);
+        Assert.Equal("Default topographic basemap", result.Description);
+        Assert.NotNull(result.Keywords);
+        Assert.Equal(2, result.Keywords!.Count);
+        Assert.Equal("CC-BY-4.0", result.License);
+        Assert.Equal("3", result.Version);
+        Assert.Single(result.Links);
+        Assert.NotNull(captured);
+        Assert.Equal("/ogc/styles/topographic/metadata?f=json", captured!.RequestUri!.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task GetStyleMetadataAsync_NotFound_ThrowsWithStatusCode()
+    {
+        var client = TestHelpers.CreateOgcStylesClient(_ =>
+            Task.FromResult(TestHelpers.CreateProblemDetailsResponse(
+                HttpStatusCode.NotFound, "Not Found", "Style 'missing' not found.")));
+
+        var ex = await Assert.ThrowsAsync<HonuaOgcFeaturesException>(
+            () => client.GetStyleMetadataAsync("missing"));
+
+        Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── UpdateStyleAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateStyleAsync_PutsMapboxStyleJson()
+    {
+        const string style = """{ "version": 8, "name": "topo", "layers": [] }""";
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+        var client = TestHelpers.CreateOgcStylesClient(async req =>
+        {
+            captured = req;
+            capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        });
+
+        await client.UpdateStyleAsync("topographic", style);
+
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Put, captured!.Method);
+        Assert.Equal("/ogc/styles/topographic", captured.RequestUri!.PathAndQuery);
+        Assert.Equal(
+            "application/vnd.mapbox.style+json",
+            captured.Content!.Headers.ContentType!.MediaType);
+        Assert.Equal(style, capturedBody);
+        Assert.DoesNotContain(captured.Headers, h => h.Key == "Prefer");
+    }
+
+    [Fact]
+    public async Task UpdateStyleAsync_Strict_SendsPreferHandlingStrict()
+    {
+        HttpRequestMessage? captured = null;
+        var client = TestHelpers.CreateOgcStylesClient(req =>
+        {
+            captured = req;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));
+        });
+
+        await client.UpdateStyleAsync("topographic", """{ "version": 8 }""", strict: true);
+
+        Assert.NotNull(captured);
+        Assert.True(captured!.Headers.TryGetValues("Prefer", out var prefer));
+        Assert.Contains("handling=strict", prefer!);
+    }
+
+    [Fact]
+    public async Task UpdateStyleAsync_InvalidStyle_ThrowsWithStatusCode()
+    {
+        var client = TestHelpers.CreateOgcStylesClient(_ =>
+            Task.FromResult(TestHelpers.CreateProblemDetailsResponse(
+                HttpStatusCode.BadRequest, "Bad Request", "MapLibre style is invalid.")));
+
+        var ex = await Assert.ThrowsAsync<HonuaOgcFeaturesException>(
+            () => client.UpdateStyleAsync("topographic", """{ "bad": true }""", strict: true));
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateStyleAsync_EmptyBody_Throws()
+    {
+        var client = TestHelpers.CreateOgcStylesClient(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent)));
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => client.UpdateStyleAsync("topographic", "   "));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a styles client keyed by `styleId` targeting the server's OGC API – Styles REST surface (`/ogc/styles`), per ADR-0048. Lives in `Honua.Sdk.OgcFeatures.Styles.*`.

Resolves #184. Part of umbrella honua-io/honua-server#1387.

## What's added

`IHonuaOgcStylesClient` / `HonuaOgcStylesClient`:

- `ListStylesAsync()` → `GET /ogc/styles` (`{ styles: [...], default? }`)
- `GetStylesheetAsync(styleId, encoding)` → `GET /ogc/styles/{styleId}`, content-negotiated via `Accept`: MapLibre/Mapbox JSON (`application/vnd.mapbox.style+json`, default), or derived SLD `;version=1.0` / `;version=1.1`. Returns the raw stylesheet plus the negotiated media type.
- `GetStyleMetadataAsync(styleId)` → `GET /ogc/styles/{styleId}/metadata`
- `UpdateStyleAsync(styleId, mapLibreStyleJson, strict)` → `PUT /ogc/styles/{styleId}` (body `application/vnd.mapbox.style+json`; `strict` adds `Prefer: handling=strict`)

Models: `OgcStylesList`, `OgcStyleEntry`, `OgcStyleMetadata`, `OgcStylesheet`, `OgcStyleEncoding`, plus a source-generated `OgcStylesJsonContext` (AOT-friendly). Errors map to the existing `HonuaOgcFeaturesException` with RFC 7807 Problem Details parsing.

The client is registered by the existing `AddHonuaOgcFeatures(...)`, sharing `HonuaOgcFeaturesClientOptions`, the auth handler, and the resilience pipeline.

## Back-compat

The per-layer `IHonuaAdminStylesClient` (keyed by `layerId`, over `/api/v1/admin/metadata/layers/{layerId}/style`) is **kept** and documented via XML `<remarks>` as a back-compat alias for editing a layer's default style, pointing to the canonical `styleId` surface. No `[Obsolete]` attribute (avoids a breaking change for existing consumers).

## Proto dedup — deferred

The optional `StyleRef` dedup against `Geospatial.Grpc` is deferred. This repo pins `Geospatial.Grpc 0.1.0-alpha.1` (not the alpha.2 mentioned in the issue) and the `OgcFeatures` package does not reference the proto package, so the REST client is fully independent. Left as `// TODO(#184)` in the models file.

## Tests

- New `HonuaOgcStylesClientTests` (mock `HttpMessageHandler`): list, stylesheet get with default + SLD 1.0/1.1 content-negotiation headers, metadata, update (PUT body + content type), `Prefer: handling=strict`, and error/argument-validation paths.
- New DI registration test for `IHonuaOgcStylesClient`.
- Full `Honua.Sdk.OgcFeatures.Tests` suite: 104 passing.
- Full solution builds Release with `TreatWarningsAsErrors=true` (0 warnings); meta-smoke API tests pass.