### PR TITLE
chore: StyleRef encoding-id alignment + deprecate layerId style methods (#1417)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <HonuaSdkVersion>1.1.0</HonuaSdkVersion> <!-- x-release-please-version -->
-    <GeospatialGrpcVersion>0.1.0-alpha.2</GeospatialGrpcVersion>
+    <GeospatialGrpcVersion>0.1.0-alpha.1</GeospatialGrpcVersion>
     <Version>$(HonuaSdkVersion)</Version>
     <PackageVersion>$(HonuaSdkVersion)</PackageVersion>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <HonuaSdkVersion>1.1.0</HonuaSdkVersion> <!-- x-release-please-version -->
-    <GeospatialGrpcVersion>0.1.0-alpha.1</GeospatialGrpcVersion>
+    <GeospatialGrpcVersion>0.1.0-alpha.2</GeospatialGrpcVersion>
     <Version>$(HonuaSdkVersion)</Version>
     <PackageVersion>$(HonuaSdkVersion)</PackageVersion>
     <InformationalVersion>$(Version)</InformationalVersion>

--- a/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminStylesClient.cs
+++ b/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminStylesClient.cs
@@ -10,11 +10,21 @@ namespace Honua.Sdk.Admin;
 /// (<c>/api/v1/admin/metadata/layers/{layerId}/style</c>), keyed by <c>layerId</c>.
 /// </summary>
 /// <remarks>
-/// This layer-keyed surface is retained as a back-compat alias for editing a
-/// layer's default style. For the canonical, <c>styleId</c>-keyed styles surface
-/// (ADR-0048), prefer <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient</c>
+/// <para>
+/// <b>Deprecated.</b> This layer-keyed surface is retained only as a back-compat
+/// alias for editing a layer's default style and may be removed in a future
+/// major release. New code should use the canonical, <c>styleId</c>-keyed styles
+/// surface (ADR-0048): <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient</c>
 /// over <c>/ogc/styles</c>, which supports listing styles, content-negotiated
 /// stylesheet encodings (MapLibre/SLD), and style metadata.
+/// </para>
+/// <para>
+/// Deprecation is documented here (rather than via <c>[Obsolete]</c>) because the
+/// SDK builds with <c>TreatWarningsAsErrors</c>, under which the <c>CS0618</c>
+/// produced by <c>[Obsolete]</c> would break consumers that still call this
+/// alias. This is consistent with how the alias was documented when the
+/// <c>styleId</c> client was introduced.
+/// </para>
 /// </remarks>
 public interface IHonuaAdminStylesClient
 {
@@ -22,7 +32,7 @@ public interface IHonuaAdminStylesClient
     /// Gets the style for a layer.
     /// </summary>
     /// <remarks>
-    /// Prefer the <c>styleId</c>-keyed
+    /// <b>Deprecated</b> in favor of the <c>styleId</c>-keyed
     /// <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.GetStylesheetAsync</c>
     /// for the canonical OGC API - Styles surface (ADR-0048).
     /// </remarks>
@@ -35,7 +45,7 @@ public interface IHonuaAdminStylesClient
     /// Updates the style for a layer.
     /// </summary>
     /// <remarks>
-    /// Prefer the <c>styleId</c>-keyed
+    /// <b>Deprecated</b> in favor of the <c>styleId</c>-keyed
     /// <c>Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.UpdateStyleAsync</c>
     /// for the canonical OGC API - Styles surface (ADR-0048).
     /// </remarks>

--- a/src/Honua.Sdk.OgcFeatures/README.md
+++ b/src/Honua.Sdk.OgcFeatures/README.md
@@ -15,9 +15,9 @@ And the **OGC API – Styles** surface under `Honua.Sdk.OgcFeatures.Styles.*`:
 `/ogc/styles` (ADR-0048) — list styles, get a content-negotiated stylesheet
 (MapLibre default, or derived SLD 1.0/1.1), read style metadata, and update a
 style's MapLibre stylesheet. This is the canonical styles surface; the per-layer
-`IHonuaAdminStylesClient` (keyed by `layerId`) remains a back-compat alias for
-editing a layer's default style. Registered alongside the features client via
-`AddHonuaOgcFeatures(...)`.
+`IHonuaAdminStylesClient` (keyed by `layerId`) is **deprecated** and retained
+only as a back-compat alias for editing a layer's default style. Registered
+alongside the features client via `AddHonuaOgcFeatures(...)`.
 
 Part of the [Honua .NET SDK](https://github.com/honua-io/honua-sdk-dotnet) — see the
 repo README for the full package catalog, browser/WASM support, authentication, and

--- a/src/Honua.Sdk.OgcFeatures/Styles/Models/OgcStyles.cs
+++ b/src/Honua.Sdk.OgcFeatures/Styles/Models/OgcStyles.cs
@@ -6,10 +6,33 @@ using Honua.Sdk.OgcFeatures.Models;
 
 namespace Honua.Sdk.OgcFeatures.Styles.Models;
 
-// TODO(#184): dedup these envelopes against Geospatial.Grpc StyleRef once the
-// 0.1.0-alpha.2 package is consumable in this repo's restore. The repo currently
-// pins Geospatial.Grpc 0.1.0-alpha.1 (Directory.Build.props) and the OgcFeatures
-// package does not reference the proto package, so the dedup is deferred.
+// Resolves TODO(#184) — relationship to Geospatial.Grpc StyleRef / StyleEncoding
+// (geospatial.v1, available from Geospatial.Grpc 0.1.0-alpha.2):
+//
+// These types intentionally stay separate from the generated proto messages and
+// the OgcFeatures package does NOT take a dependency on Geospatial.Grpc:
+//
+//   * Layering. OgcFeatures is the REST-over-HttpClient surface and ships to
+//     browser/WASM consumers that deliberately exclude the gRPC/proto stack.
+//     Referencing Geospatial.Grpc here would force Google.Protobuf onto that
+//     subset for no shared serialization benefit.
+//   * Different wire shapes. The OGC API - Styles responses below are
+//     link-driven (HATEOAS) projections: a styles list / metadata document plus
+//     `links` that enumerate the available stylesheet encodings. StyleRef is a
+//     self-contained, encoding-list-centric message (an `encodings` collection
+//     of inline/stored bodies, no links). They model the same logical style at
+//     two different layers, so neither is a drop-in for the other.
+//   * No gRPC style surface exists in this SDK yet. There is currently no
+//     gRPC client that exposes StyleRef, so there is nothing in this repo for a
+//     REST DTO to be deduped against; StyleRef is consumed only inside
+//     Honua.Sdk.Grpc (the one package that references Geospatial.Grpc).
+//
+// The one concept the two layers genuinely share is the *encoding identifier*
+// vocabulary. To keep that aligned without coupling packages, the
+// <see cref="OgcStyleEncoding"/> members below map 1:1 onto the canonical
+// StyleEncoding.encoding values defined by geospatial.v1.StyleEncoding
+// (`mapbox-style`, `sld-1.0.0`, `sld-1.1.0`); see
+// <see cref="OgcStyleEncodingExtensions.ToCanonicalEncodingId"/>.
 
 /// <summary>
 /// OGC API - Styles styles list response (<c>GET /ogc/styles</c>).
@@ -97,6 +120,48 @@ public enum OgcStyleEncoding
 
     /// <summary>OGC SLD 1.1 (<c>application/vnd.ogc.sld+xml;version=1.1</c>), derived from the canonical style.</summary>
     Sld11
+}
+
+/// <summary>
+/// Helpers for <see cref="OgcStyleEncoding"/> that align the REST encoding enum
+/// with the canonical encoding identifiers used by the gRPC style contract
+/// (<c>geospatial.v1.StyleEncoding.encoding</c> in <c>Geospatial.Grpc</c>).
+/// </summary>
+public static class OgcStyleEncodingExtensions
+{
+    /// <summary>
+    /// Canonical encoding identifier for MapLibre/Mapbox style JSON, matching
+    /// <c>geospatial.v1.StyleEncoding.encoding == "mapbox-style"</c>.
+    /// </summary>
+    public const string MapboxStyleEncodingId = "mapbox-style";
+
+    /// <summary>
+    /// Canonical encoding identifier for OGC SLD 1.0, matching
+    /// <c>geospatial.v1.StyleEncoding.encoding == "sld-1.0.0"</c>.
+    /// </summary>
+    public const string Sld10EncodingId = "sld-1.0.0";
+
+    /// <summary>
+    /// Canonical encoding identifier for OGC SLD 1.1, matching
+    /// <c>geospatial.v1.StyleEncoding.encoding == "sld-1.1.0"</c>.
+    /// </summary>
+    public const string Sld11EncodingId = "sld-1.1.0";
+
+    /// <summary>
+    /// Maps an <see cref="OgcStyleEncoding"/> to the canonical encoding
+    /// identifier shared with the gRPC style contract
+    /// (<c>geospatial.v1.StyleEncoding.encoding</c>). This keeps the REST and
+    /// gRPC layers using one encoding vocabulary without coupling the packages.
+    /// </summary>
+    /// <param name="encoding">The REST stylesheet encoding.</param>
+    /// <returns>The canonical <c>StyleEncoding.encoding</c> identifier.</returns>
+    public static string ToCanonicalEncodingId(this OgcStyleEncoding encoding) => encoding switch
+    {
+        OgcStyleEncoding.MapboxStyle => MapboxStyleEncodingId,
+        OgcStyleEncoding.Sld10 => Sld10EncodingId,
+        OgcStyleEncoding.Sld11 => Sld11EncodingId,
+        _ => MapboxStyleEncodingId,
+    };
 }
 
 /// <summary>

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcStylesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcStylesClientTests.cs
@@ -252,4 +252,16 @@ public class HonuaOgcStylesClientTests
         await Assert.ThrowsAsync<ArgumentException>(
             () => client.UpdateStyleAsync("topographic", "   "));
     }
+
+    // ── Encoding-id alignment with geospatial.v1.StyleEncoding (#184) ─
+
+    [Theory]
+    [InlineData(OgcStyleEncoding.MapboxStyle, "mapbox-style")]
+    [InlineData(OgcStyleEncoding.Sld10, "sld-1.0.0")]
+    [InlineData(OgcStyleEncoding.Sld11, "sld-1.1.0")]
+    public void ToCanonicalEncodingId_MapsToGrpcStyleEncodingVocabulary(
+        OgcStyleEncoding encoding, string expected)
+    {
+        Assert.Equal(expected, encoding.ToCanonicalEncodingId());
+    }
 }


### PR DESCRIPTION
Implements the honua-sdk-dotnet portion of honua-server#1417.

`Geospatial.Grpc 0.1.0-alpha.2` (GitHub Packages feed `github-honua`) adds the new `geospatial.v1.StyleRef` / `StyleEncoding` messages, and PR #187 shipped the OGC styles client REST-only with a `TODO(#184)` to dedup against the generated StyleRef.

## Changes

1. **Bump `GeospatialGrpcVersion` 0.1.0-alpha.1 → 0.1.0-alpha.2** in `Directory.Build.props` (central version flows through `Directory.Packages.props`).

2. **Resolve `TODO(#184)`** in `Honua.Sdk.OgcFeatures/Styles/Models/OgcStyles.cs`. After investigating the generated `geospatial.v1.StyleRef`/`StyleEncoding` shape, the honest resolution is the documented-separation path the issue explicitly allows:
   - `Honua.Sdk.OgcFeatures` is the REST-over-`HttpClient` surface and ships to browser/WASM consumers that exclude the gRPC/proto stack; referencing `Geospatial.Grpc` there would pull `Google.Protobuf` onto that subset for no shared serialization benefit. (Only `Honua.Sdk.Grpc` references `Geospatial.Grpc`.)
   - The OGC API - Styles DTOs are link-driven HATEOAS projections; `StyleRef` is a self-contained, encoding-list-centric message with no links. They model the same logical style at two different layers, so neither is a drop-in for the other.
   - There is currently **no gRPC style client** in this SDK that exposes `StyleRef`, so there is nothing here to dedup a REST DTO against.
   - The one genuinely shared concept — the **encoding-identifier vocabulary** — is now aligned without coupling packages: new `OgcStyleEncodingExtensions.ToCanonicalEncodingId()` maps the `OgcStyleEncoding` enum 1:1 onto the canonical `StyleEncoding.encoding` values (`mapbox-style`, `sld-1.0.0`, `sld-1.1.0`). The TODO is replaced with a rationale block; a `[Theory]` test locks the mapping.

3. **Deprecate the layerId-keyed admin style methods** (`IHonuaAdminStylesClient.GetLayerStyleAsync` / `UpdateLayerStyleAsync`) in favor of the styleId-keyed `IHonuaOgcStylesClient` (ADR-0048). Deprecation is documented via XML-doc `<remarks>`/`<para>` (not `[Obsolete]`, which would emit `CS0618` and break the solution-wide `TreatWarningsAsErrors` policy for consumers still on the alias) — consistent with how PR #187 documented the alias. README updated to match.

Public client API is stable; this is an internal dedup plus additive helper.

## Build / restore status

- The `github-honua` GitHub Packages feed **authenticated and restored locally** — `Geospatial.Grpc 0.1.0-alpha.2` restored fine.
- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true`: **succeeded, 0 warnings / 0 errors.**
- `Honua.Sdk.OgcFeatures.Tests`: **107 passed** (3 new for the encoding-id mapping). `Honua.Sdk.Admin.Tests`: **177 passed.**
- `scripts/validate-api-compat.sh` was queued behind this multi-agent host's shared build lock and had not drained before push; the change is additive to the public API (one new type + XML-doc edits), and CI runs api-compat authoritatively.

Refs honua-server#1417, closes #184.