### PR TITLE
feat(forms): real expression engine, constraint & relevance expressions, geo field types

### DIFF
--- a/src/Honua.Sdk.Field/Forms/CalculatedFieldEvaluator.cs
+++ b/src/Honua.Sdk.Field/Forms/CalculatedFieldEvaluator.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Globalization;
+using Honua.Sdk.Field.Forms.Expressions;
 using Honua.Sdk.Field.Records;
 
 namespace Honua.Sdk.Field.Forms;
@@ -51,64 +51,14 @@ public static class CalculatedFieldEvaluator
                 continue;
             }
 
-            values[field.FieldId] = EvaluateExpression(field.CalculatedExpression!, values);
+            var result = ExpressionEvaluator.EvaluateDetailed(field.CalculatedExpression, values);
+
+            // A malformed or unresolvable expression must not clobber an existing
+            // value with null; only write through results that actually evaluated.
+            if (result.Succeeded)
+            {
+                values[field.FieldId] = result.Value;
+            }
         }
-    }
-
-    private static object? EvaluateExpression(string expression, Dictionary<string, object?> values)
-    {
-        var openParen = expression.IndexOf('(', StringComparison.Ordinal);
-        var closeParen = expression.LastIndexOf(')');
-
-        if (openParen <= 0 || closeParen <= openParen)
-        {
-            return expression;
-        }
-
-        var function = expression[..openParen].Trim();
-        var args = expression[(openParen + 1)..closeParen]
-            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-            .Select(arg => ResolveArg(arg, values))
-            .ToArray();
-
-        if (string.Equals(function, "concat", StringComparison.OrdinalIgnoreCase))
-        {
-            return string.Concat(args.Select(arg => arg?.ToString() ?? string.Empty));
-        }
-
-        if (string.Equals(function, "sum", StringComparison.OrdinalIgnoreCase))
-        {
-            return args.Sum(ParseDouble);
-        }
-
-        return expression;
-    }
-
-    private static object? ResolveArg(string arg, Dictionary<string, object?> values)
-    {
-        if (arg.StartsWith('$'))
-        {
-            var key = arg[1..];
-            return values.TryGetValue(key, out var value) ? value : null;
-        }
-
-        if (arg.Length >= 2 && arg[0] == '\'' && arg[^1] == '\'')
-        {
-            return arg[1..^1];
-        }
-
-        return arg;
-    }
-
-    private static double ParseDouble(object? value)
-    {
-        if (value is null)
-        {
-            return 0;
-        }
-
-        return double.TryParse(Convert.ToString(value, CultureInfo.InvariantCulture), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed)
-            ? parsed
-            : 0;
     }
 }

--- a/src/Honua.Sdk.Field/Forms/Expressions/ExpressionEvaluator.cs
+++ b/src/Honua.Sdk.Field/Forms/Expressions/ExpressionEvaluator.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Sdk.Field.Forms.Expressions;
+
+/// <summary>
+/// Evaluates portable form expressions against a context of field values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The engine supports literals (numbers, single-quoted strings, <c>true</c>,
+/// <c>false</c>, <c>null</c>), field references (<c>$fieldId</c> and
+/// <c>${fieldId}</c>), arithmetic, comparison and logical operators, and a small
+/// library of functions. It is deliberately tolerant: a malformed expression,
+/// an unknown function, or a type mismatch never throws — the evaluator returns
+/// <see langword="null"/> and records a diagnostic on the
+/// <see cref="ExpressionResult"/>.
+/// </para>
+/// <para>
+/// Date helpers operate on <see cref="DateTimeOffset"/>. <c>today()</c> and
+/// <c>now()</c> read the current clock; tests that need determinism should pass
+/// fixed dates as field values rather than relying on those functions.
+/// </para>
+/// </remarks>
+public static class ExpressionEvaluator
+{
+    /// <summary>Maximum supported expression length, guarding against runaway input.</summary>
+    public const int MaxExpressionLength = 8_000;
+
+    /// <summary>Maximum parser/evaluator recursion depth, guarding against runaway nesting.</summary>
+    public const int MaxDepth = 64;
+
+    /// <summary>
+    /// Evaluates an expression against the supplied field-value context and
+    /// returns the raw object result, or <see langword="null"/> when the
+    /// expression is empty, malformed, or fails to evaluate.
+    /// </summary>
+    /// <param name="expression">Expression source text.</param>
+    /// <param name="context">Field values keyed by field id. May be <see langword="null"/>.</param>
+    /// <returns>The evaluated value, or <see langword="null"/>.</returns>
+    public static object? Evaluate(string? expression, IReadOnlyDictionary<string, object?>? context)
+        => EvaluateDetailed(expression, context).Value;
+
+    /// <summary>
+    /// Evaluates an expression and returns the value together with any diagnostic
+    /// produced while tokenizing, parsing, or evaluating it.
+    /// </summary>
+    /// <param name="expression">Expression source text.</param>
+    /// <param name="context">Field values keyed by field id. May be <see langword="null"/>.</param>
+    /// <returns>An <see cref="ExpressionResult"/> describing the outcome.</returns>
+    public static ExpressionResult EvaluateDetailed(string? expression, IReadOnlyDictionary<string, object?>? context)
+    {
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return ExpressionResult.Failure("Expression is empty.");
+        }
+
+        if (expression!.Length > MaxExpressionLength)
+        {
+            return ExpressionResult.Failure("Expression exceeds the maximum supported length.");
+        }
+
+        try
+        {
+            var tokens = Tokenizer.Tokenize(expression);
+            var parser = new Parser(tokens);
+            var node = parser.ParseExpression();
+            parser.ExpectEnd();
+            var value = node.Evaluate(context ?? EmptyContext, 0);
+            return ExpressionResult.Success(value);
+        }
+        catch (ExpressionException ex)
+        {
+            return ExpressionResult.Failure(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an expression and coerces the result to a boolean using truthiness
+    /// rules. A failed or null evaluation yields <see langword="false"/>.
+    /// </summary>
+    /// <param name="expression">Expression source text.</param>
+    /// <param name="context">Field values keyed by field id.</param>
+    /// <returns>The boolean interpretation of the result.</returns>
+    public static bool EvaluateBoolean(string? expression, IReadOnlyDictionary<string, object?>? context)
+        => Coercion.ToBoolean(Evaluate(expression, context));
+
+    private static readonly IReadOnlyDictionary<string, object?> EmptyContext =
+        new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Outcome of an expression evaluation.
+/// </summary>
+public sealed class ExpressionResult
+{
+    private ExpressionResult(bool succeeded, object? value, string? diagnostic)
+    {
+        Succeeded = succeeded;
+        Value = value;
+        Diagnostic = diagnostic;
+    }
+
+    /// <summary>Whether the expression evaluated without a diagnostic.</summary>
+    public bool Succeeded { get; }
+
+    /// <summary>Evaluated value, or <see langword="null"/>.</summary>
+    public object? Value { get; }
+
+    /// <summary>Diagnostic message when evaluation failed, otherwise <see langword="null"/>.</summary>
+    public string? Diagnostic { get; }
+
+    internal static ExpressionResult Success(object? value) => new(true, value, null);
+
+    internal static ExpressionResult Failure(string diagnostic) => new(false, null, diagnostic);
+}
+
+/// <summary>
+/// Exception used to unwind tokenizer/parser/evaluator errors into a diagnostic.
+/// </summary>
+public sealed class ExpressionException : Exception
+{
+    /// <summary>Initializes a new instance of the <see cref="ExpressionException"/> class.</summary>
+    public ExpressionException()
+    {
+    }
+
+    /// <summary>Initializes a new instance with a diagnostic message.</summary>
+    /// <param name="message">Diagnostic message.</param>
+    public ExpressionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new instance with a diagnostic message and inner exception.</summary>
+    /// <param name="message">Diagnostic message.</param>
+    /// <param name="innerException">Underlying cause.</param>
+    public ExpressionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>
+/// Shared null/numeric/boolean/string coercion helpers.
+/// </summary>
+internal static class Coercion
+{
+    public static bool TryToDouble(object? value, out double result)
+    {
+        switch (value)
+        {
+            case null:
+                result = default;
+                return false;
+            case bool b:
+                result = b ? 1 : 0;
+                return true;
+            case double d:
+                result = d;
+                return true;
+            case float f:
+                result = f;
+                return true;
+            case decimal m:
+                result = (double)m;
+                return true;
+            case int i:
+                result = i;
+                return true;
+            case long l:
+                result = l;
+                return true;
+            case short s:
+                result = s;
+                return true;
+            case byte by:
+                result = by;
+                return true;
+            case DateTimeOffset dto:
+                result = dto.ToUnixTimeMilliseconds();
+                return true;
+            case DateTime dt:
+                result = new DateTimeOffset(dt.ToUniversalTime(), TimeSpan.Zero).ToUnixTimeMilliseconds();
+                return true;
+            case string str:
+                return double.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out result);
+            default:
+                return double.TryParse(
+                    Convert.ToString(value, CultureInfo.InvariantCulture),
+                    NumberStyles.Any,
+                    CultureInfo.InvariantCulture,
+                    out result);
+        }
+    }
+
+    public static bool ToBoolean(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return false;
+            case bool b:
+                return b;
+            case string str:
+                if (bool.TryParse(str, out var parsed))
+                {
+                    return parsed;
+                }
+
+                return !string.IsNullOrEmpty(str);
+            default:
+                return TryToDouble(value, out var number) ? number != 0 : true;
+        }
+    }
+
+    public static string ToStringValue(object? value)
+    {
+        return value switch
+        {
+            null => string.Empty,
+            string str => str,
+            bool b => b ? "true" : "false",
+            double d => d.ToString("R", CultureInfo.InvariantCulture),
+            float f => f.ToString("R", CultureInfo.InvariantCulture),
+            decimal m => m.ToString(CultureInfo.InvariantCulture),
+            DateTimeOffset dto => dto.ToString("o", CultureInfo.InvariantCulture),
+            DateTime dt => dt.ToString("o", CultureInfo.InvariantCulture),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty,
+        };
+    }
+
+    public static bool TryToDateTimeOffset(object? value, out DateTimeOffset result)
+    {
+        switch (value)
+        {
+            case DateTimeOffset dto:
+                result = dto;
+                return true;
+            case DateTime dt:
+                result = new DateTimeOffset(dt.ToUniversalTime(), TimeSpan.Zero);
+                return true;
+            case string str when DateTimeOffset.TryParse(
+                str,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed):
+                result = parsed;
+                return true;
+            case DateOnly dateOnly:
+                result = new DateTimeOffset(dateOnly.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc));
+                return true;
+            default:
+                result = default;
+                return false;
+        }
+    }
+}

--- a/src/Honua.Sdk.Field/Forms/Expressions/ExpressionFunctions.cs
+++ b/src/Honua.Sdk.Field/Forms/Expressions/ExpressionFunctions.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+
+namespace Honua.Sdk.Field.Forms.Expressions;
+
+/// <summary>
+/// Built-in expression function library.
+/// </summary>
+internal static class ExpressionFunctions
+{
+    public static object? Invoke(
+        string name,
+        IReadOnlyList<ExpressionNode> args,
+        IReadOnlyDictionary<string, object?> context,
+        int depth)
+    {
+        // if() must control argument evaluation, so it is handled before eager evaluation.
+        if (NameEquals(name, "if"))
+        {
+            if (args.Count != 3)
+            {
+                throw new ExpressionException("if() requires exactly 3 arguments.");
+            }
+
+            var condition = Coercion.ToBoolean(args[0].Evaluate(context, depth));
+            return condition ? args[1].Evaluate(context, depth) : args[2].Evaluate(context, depth);
+        }
+
+        // coalesce() also benefits from lazy evaluation.
+        if (NameEquals(name, "coalesce"))
+        {
+            foreach (var arg in args)
+            {
+                var value = arg.Evaluate(context, depth);
+                if (value is not null && !(value is string s && s.Length == 0))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+
+        var values = new object?[args.Count];
+        for (var i = 0; i < args.Count; i++)
+        {
+            values[i] = args[i].Evaluate(context, depth);
+        }
+
+        return name.ToUpperInvariant() switch
+        {
+            "CONCAT" => Concat(values),
+            "SUM" => (object?)values.Sum(ToDouble),
+            "MIN" => Aggregate(values, Math.Min),
+            "MAX" => Aggregate(values, Math.Max),
+            "ROUND" => Round(values),
+            "FLOOR" => UnaryMath(values, Math.Floor),
+            "CEIL" or "CEILING" => UnaryMath(values, Math.Ceiling),
+            "ABS" => UnaryMath(values, Math.Abs),
+            "LEN" or "STRING-LENGTH" or "LENGTH" => StringLength(values),
+            "UPPER" => Transform(values, static s => s.ToUpperInvariant()),
+#pragma warning disable CA1308 // lower() intentionally lower-cases its argument.
+            "LOWER" => Transform(values, static s => s.ToLowerInvariant()),
+#pragma warning restore CA1308
+            "TRIM" => Transform(values, static s => s.Trim()),
+            "CONTAINS" => Contains(values),
+            "NUMBER" => ToNumberOrNull(values),
+            "STRING" => values.Length >= 1 ? Coercion.ToStringValue(values[0]) : string.Empty,
+            "TODAY" => Today(),
+            "NOW" => DateTimeOffset.UtcNow,
+            "DATE-DIFF-DAYS" or "DATEDIFFDAYS" => DateDiffDays(values),
+            "ADD-DAYS" or "ADDDAYS" => AddDays(values),
+            _ => throw new ExpressionException($"Unknown function '{name}'."),
+        };
+    }
+
+    private static bool NameEquals(string name, string candidate)
+        => string.Equals(name, candidate, StringComparison.OrdinalIgnoreCase);
+
+    private static double ToDouble(object? value)
+        => Coercion.TryToDouble(value, out var d) ? d : 0;
+
+    private static string Concat(object?[] values)
+        => string.Concat(values.Select(Coercion.ToStringValue));
+
+    private static double? Aggregate(object?[] values, Func<double, double, double> op)
+    {
+        double? acc = null;
+        foreach (var value in values)
+        {
+            if (Coercion.TryToDouble(value, out var number))
+            {
+                acc = acc is null ? number : op(acc.Value, number);
+            }
+        }
+
+        return acc;
+    }
+
+    private static double? Round(object?[] values)
+    {
+        if (values.Length == 0 || !Coercion.TryToDouble(values[0], out var x))
+        {
+            return null;
+        }
+
+        var digits = 0;
+        if (values.Length >= 2 && Coercion.TryToDouble(values[1], out var d))
+        {
+            digits = Math.Clamp((int)d, 0, 15);
+        }
+
+        return Math.Round(x, digits, MidpointRounding.AwayFromZero);
+    }
+
+    private static double? UnaryMath(object?[] values, Func<double, double> op)
+    {
+        if (values.Length == 0 || !Coercion.TryToDouble(values[0], out var x))
+        {
+            return null;
+        }
+
+        return op(x);
+    }
+
+    private static double StringLength(object?[] values)
+        => values.Length == 0 ? 0d : Coercion.ToStringValue(values[0]).Length;
+
+    private static string? Transform(object?[] values, Func<string, string> op)
+        => values.Length == 0 ? null : op(Coercion.ToStringValue(values[0]));
+
+    private static bool Contains(object?[] values)
+    {
+        if (values.Length < 2)
+        {
+            return false;
+        }
+
+        return Coercion.ToStringValue(values[0])
+            .Contains(Coercion.ToStringValue(values[1]), StringComparison.Ordinal);
+    }
+
+    private static double? ToNumberOrNull(object?[] values)
+        => values.Length >= 1 && Coercion.TryToDouble(values[0], out var d) ? d : null;
+
+    private static DateTimeOffset Today()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new DateTimeOffset(now.Year, now.Month, now.Day, 0, 0, 0, TimeSpan.Zero);
+    }
+
+    private static double? DateDiffDays(object?[] values)
+    {
+        if (values.Length < 2
+            || !Coercion.TryToDateTimeOffset(values[0], out var a)
+            || !Coercion.TryToDateTimeOffset(values[1], out var b))
+        {
+            return null;
+        }
+
+        // Whole-day difference of a minus b.
+        return Math.Truncate((a - b).TotalDays);
+    }
+
+    private static DateTimeOffset? AddDays(object?[] values)
+    {
+        if (values.Length < 2
+            || !Coercion.TryToDateTimeOffset(values[0], out var date)
+            || !Coercion.TryToDouble(values[1], out var days))
+        {
+            return null;
+        }
+
+        return date.AddDays(days);
+    }
+}

--- a/src/Honua.Sdk.Field/Forms/Expressions/ExpressionNodes.cs
+++ b/src/Honua.Sdk.Field/Forms/Expressions/ExpressionNodes.cs
@@ -1,0 +1,246 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Field.Forms.Expressions;
+
+/// <summary>
+/// Base class for evaluable expression-tree nodes.
+/// </summary>
+internal abstract class ExpressionNode
+{
+    public abstract object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth);
+
+    protected static void GuardDepth(int depth)
+    {
+        if (depth > ExpressionEvaluator.MaxDepth)
+        {
+            throw new ExpressionException("Expression nesting is too deep.");
+        }
+    }
+}
+
+internal sealed class LiteralNode : ExpressionNode
+{
+    private readonly object? _value;
+
+    public LiteralNode(object? value) => _value = value;
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth) => _value;
+}
+
+internal sealed class FieldRefNode : ExpressionNode
+{
+    private readonly string _name;
+
+    public FieldRefNode(string name) => _name = name;
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth)
+        => context.TryGetValue(_name, out var value) ? value : null;
+}
+
+internal sealed class UnaryNode : ExpressionNode
+{
+    private readonly string _op;
+    private readonly ExpressionNode _operand;
+
+    public UnaryNode(string op, ExpressionNode operand)
+    {
+        _op = op;
+        _operand = operand;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth)
+    {
+        GuardDepth(depth);
+        var value = _operand.Evaluate(context, depth + 1);
+        switch (_op)
+        {
+            case "-":
+                return Coercion.TryToDouble(value, out var number) ? -number : null;
+            case "!":
+            case "not":
+                return !Coercion.ToBoolean(value);
+            default:
+                throw new ExpressionException($"Unknown unary operator '{_op}'.");
+        }
+    }
+}
+
+internal sealed class BinaryNode : ExpressionNode
+{
+    private readonly string _op;
+    private readonly ExpressionNode _left;
+    private readonly ExpressionNode _right;
+
+    public BinaryNode(string op, ExpressionNode left, ExpressionNode right)
+    {
+        _op = op;
+        _left = left;
+        _right = right;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth)
+    {
+        GuardDepth(depth);
+
+        // Short-circuit logical operators.
+        if (_op is "and" or "&&")
+        {
+            return Coercion.ToBoolean(_left.Evaluate(context, depth + 1))
+                && Coercion.ToBoolean(_right.Evaluate(context, depth + 1));
+        }
+
+        if (_op is "or" or "||")
+        {
+            return Coercion.ToBoolean(_left.Evaluate(context, depth + 1))
+                || Coercion.ToBoolean(_right.Evaluate(context, depth + 1));
+        }
+
+        var left = _left.Evaluate(context, depth + 1);
+        var right = _right.Evaluate(context, depth + 1);
+
+        switch (_op)
+        {
+            case "+":
+                return Add(left, right);
+            case "-":
+                return Arithmetic(left, right, static (a, b) => a - b);
+            case "*":
+                return Arithmetic(left, right, static (a, b) => a * b);
+            case "/":
+                return Divide(left, right);
+            case "%":
+                return Modulo(left, right);
+            case "=":
+            case "==":
+                return AreEqual(left, right);
+            case "!=":
+                return !AreEqual(left, right);
+            case "<":
+                return Compare(left, right) is { } lt && lt < 0;
+            case "<=":
+                return Compare(left, right) is { } le && le <= 0;
+            case ">":
+                return Compare(left, right) is { } gt && gt > 0;
+            case ">=":
+                return Compare(left, right) is { } ge && ge >= 0;
+            default:
+                throw new ExpressionException($"Unknown operator '{_op}'.");
+        }
+    }
+
+    private static object? Add(object? left, object? right)
+    {
+        // Null propagates rather than silently coercing to an empty string;
+        // callers wanting null-safe joining should use concat().
+        if (left is null || right is null)
+        {
+            return null;
+        }
+
+        // Numeric addition when both sides are numbers; otherwise string concatenation.
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r)
+            && left is not string && right is not string)
+        {
+            return l + r;
+        }
+
+        return Coercion.ToStringValue(left) + Coercion.ToStringValue(right);
+    }
+
+    private static double? Arithmetic(object? left, object? right, Func<double, double, double> op)
+    {
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r))
+        {
+            return op(l, r);
+        }
+
+        return null;
+    }
+
+    private static object? Divide(object? left, object? right)
+    {
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r))
+        {
+            return r == 0 ? null : l / r;
+        }
+
+        return null;
+    }
+
+    private static object? Modulo(object? left, object? right)
+    {
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r))
+        {
+            return r == 0 ? null : l % r;
+        }
+
+        return null;
+    }
+
+    private static bool AreEqual(object? left, object? right)
+    {
+        if (left is null || right is null)
+        {
+            return left is null && right is null;
+        }
+
+        if (left is bool || right is bool)
+        {
+            return Coercion.ToBoolean(left) == Coercion.ToBoolean(right);
+        }
+
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r)
+            && left is not string && right is not string)
+        {
+            return Math.Abs(l - r) < 1e-9;
+        }
+
+        // If both numeric-looking strings, compare numerically; otherwise string compare.
+        if (Coercion.TryToDouble(left, out var ls) && Coercion.TryToDouble(right, out var rs))
+        {
+            return Math.Abs(ls - rs) < 1e-9;
+        }
+
+        return string.Equals(
+            Coercion.ToStringValue(left),
+            Coercion.ToStringValue(right),
+            StringComparison.Ordinal);
+    }
+
+    private static int? Compare(object? left, object? right)
+    {
+        if (left is null || right is null)
+        {
+            return null;
+        }
+
+        if (Coercion.TryToDouble(left, out var l) && Coercion.TryToDouble(right, out var r))
+        {
+            return l.CompareTo(r);
+        }
+
+        return string.Compare(
+            Coercion.ToStringValue(left),
+            Coercion.ToStringValue(right),
+            StringComparison.Ordinal);
+    }
+}
+
+internal sealed class FunctionNode : ExpressionNode
+{
+    private readonly string _name;
+    private readonly IReadOnlyList<ExpressionNode> _args;
+
+    public FunctionNode(string name, IReadOnlyList<ExpressionNode> args)
+    {
+        _name = name;
+        _args = args;
+    }
+
+    public override object? Evaluate(IReadOnlyDictionary<string, object?> context, int depth)
+    {
+        GuardDepth(depth);
+        return ExpressionFunctions.Invoke(_name, _args, context, depth + 1);
+    }
+}

--- a/src/Honua.Sdk.Field/Forms/Expressions/Parser.cs
+++ b/src/Honua.Sdk.Field/Forms/Expressions/Parser.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Field.Forms.Expressions;
+
+/// <summary>
+/// Recursive-descent / precedence-climbing parser that turns a token list into
+/// an evaluable <see cref="ExpressionNode"/> tree.
+/// </summary>
+internal sealed class Parser
+{
+    private readonly IReadOnlyList<Token> _tokens;
+    private int _position;
+    private int _depth;
+
+    public Parser(IReadOnlyList<Token> tokens) => _tokens = tokens;
+
+    public ExpressionNode ParseExpression() => ParseBinary(0);
+
+    public void ExpectEnd()
+    {
+        if (Current.Type != TokenType.End)
+        {
+            throw new ExpressionException($"Unexpected token '{Current.Text}' after expression.");
+        }
+    }
+
+    private Token Current => _tokens[_position];
+
+    private Token Advance() => _tokens[_position++];
+
+    private ExpressionNode ParseBinary(int minPrecedence)
+    {
+        EnterDepth();
+        try
+        {
+            var left = ParseUnary();
+
+            while (true)
+            {
+                var op = CurrentBinaryOperator();
+                if (op is null)
+                {
+                    break;
+                }
+
+                var precedence = PrecedenceOf(op);
+                if (precedence < minPrecedence)
+                {
+                    break;
+                }
+
+                Advance();
+
+                // All supported binary operators are left-associative.
+                var right = ParseBinary(precedence + 1);
+                left = new BinaryNode(op, left, right);
+            }
+
+            return left;
+        }
+        finally
+        {
+            ExitDepth();
+        }
+    }
+
+    private ExpressionNode ParseUnary()
+    {
+        if (Current.Type == TokenType.Operator && (Current.Text == "-" || Current.Text == "!"))
+        {
+            var op = Advance().Text;
+            return new UnaryNode(op, ParseUnary());
+        }
+
+        if (Current.Type == TokenType.Identifier
+            && string.Equals(Current.Text, "not", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            return new UnaryNode("not", ParseUnary());
+        }
+
+        return ParsePrimary();
+    }
+
+    private ExpressionNode ParsePrimary()
+    {
+        var token = Current;
+        switch (token.Type)
+        {
+            case TokenType.Number:
+            case TokenType.String:
+                Advance();
+                return new LiteralNode(token.Literal);
+
+            case TokenType.FieldRef:
+                Advance();
+                return new FieldRefNode((string)token.Literal!);
+
+            case TokenType.LeftParen:
+                Advance();
+                var inner = ParseExpression();
+                Expect(TokenType.RightParen, ")");
+                return inner;
+
+            case TokenType.Identifier:
+                return ParseIdentifier(token);
+
+            default:
+                throw new ExpressionException($"Unexpected token '{token.Text}'.");
+        }
+    }
+
+    private ExpressionNode ParseIdentifier(Token token)
+    {
+        // Keyword literals.
+        if (string.Equals(token.Text, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            return new LiteralNode(true);
+        }
+
+        if (string.Equals(token.Text, "false", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            return new LiteralNode(false);
+        }
+
+        if (string.Equals(token.Text, "null", StringComparison.OrdinalIgnoreCase))
+        {
+            Advance();
+            return new LiteralNode(null);
+        }
+
+        // Function call: identifier immediately followed by '('.
+        if (_position + 1 < _tokens.Count && _tokens[_position + 1].Type == TokenType.LeftParen)
+        {
+            var name = Advance().Text;
+            Advance(); // '('
+            var args = ParseArguments();
+            Expect(TokenType.RightParen, ")");
+            return new FunctionNode(name, args);
+        }
+
+        // Bare identifier resolves as a field reference (lenient fallback).
+        Advance();
+        return new FieldRefNode(token.Text);
+    }
+
+    private List<ExpressionNode> ParseArguments()
+    {
+        var args = new List<ExpressionNode>();
+        if (Current.Type == TokenType.RightParen)
+        {
+            return args;
+        }
+
+        args.Add(ParseExpression());
+        while (Current.Type == TokenType.Comma)
+        {
+            Advance();
+            args.Add(ParseExpression());
+        }
+
+        return args;
+    }
+
+    private string? CurrentBinaryOperator()
+    {
+        if (Current.Type == TokenType.Operator)
+        {
+            return Current.Text switch
+            {
+                "+" or "-" or "*" or "/" or "%"
+                    or "=" or "==" or "!=" or "<" or "<=" or ">" or ">="
+                    or "&&" or "||" => Current.Text,
+                _ => null,
+            };
+        }
+
+        if (Current.Type == TokenType.Identifier)
+        {
+            if (string.Equals(Current.Text, "and", StringComparison.OrdinalIgnoreCase))
+            {
+                return "and";
+            }
+
+            if (string.Equals(Current.Text, "or", StringComparison.OrdinalIgnoreCase))
+            {
+                return "or";
+            }
+        }
+
+        return null;
+    }
+
+    private static int PrecedenceOf(string op) => op switch
+    {
+        "or" or "||" => 1,
+        "and" or "&&" => 2,
+        "=" or "==" or "!=" => 3,
+        "<" or "<=" or ">" or ">=" => 4,
+        "+" or "-" => 5,
+        "*" or "/" or "%" => 6,
+        _ => 0,
+    };
+
+    private void Expect(TokenType type, string text)
+    {
+        if (Current.Type != type)
+        {
+            throw new ExpressionException($"Expected '{text}' but found '{Current.Text}'.");
+        }
+
+        Advance();
+    }
+
+    private void EnterDepth()
+    {
+        if (++_depth > ExpressionEvaluator.MaxDepth)
+        {
+            throw new ExpressionException("Expression nesting is too deep.");
+        }
+    }
+
+    private void ExitDepth() => _depth--;
+}

--- a/src/Honua.Sdk.Field/Forms/Expressions/Tokenizer.cs
+++ b/src/Honua.Sdk.Field/Forms/Expressions/Tokenizer.cs
@@ -1,0 +1,323 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text;
+
+namespace Honua.Sdk.Field.Forms.Expressions;
+
+internal enum TokenType
+{
+    Number,
+    String,
+    Identifier,
+    FieldRef,
+    Operator,
+    LeftParen,
+    RightParen,
+    Comma,
+    End,
+}
+
+internal readonly struct Token
+{
+    public Token(TokenType type, string text, object? literal = null)
+    {
+        Type = type;
+        Text = text;
+        Literal = literal;
+    }
+
+    public TokenType Type { get; }
+
+    public string Text { get; }
+
+    public object? Literal { get; }
+}
+
+/// <summary>
+/// Converts expression source text into a flat token list.
+/// </summary>
+internal static class Tokenizer
+{
+    /// <summary>
+    /// Context key that a bare <c>.</c> token resolves to. Constraint evaluation
+    /// populates this with the value of the field under validation.
+    /// </summary>
+    public const string SelfReferenceKey = ".";
+
+    public static IReadOnlyList<Token> Tokenize(string source)
+    {
+        var tokens = new List<Token>();
+        var i = 0;
+        var length = source.Length;
+
+        while (i < length)
+        {
+            var c = source[i];
+
+            if (char.IsWhiteSpace(c))
+            {
+                i++;
+                continue;
+            }
+
+            switch (c)
+            {
+                case '(':
+                    tokens.Add(new Token(TokenType.LeftParen, "("));
+                    i++;
+                    continue;
+                case ')':
+                    tokens.Add(new Token(TokenType.RightParen, ")"));
+                    i++;
+                    continue;
+                case ',':
+                    tokens.Add(new Token(TokenType.Comma, ","));
+                    i++;
+                    continue;
+                case '\'':
+                    tokens.Add(ReadString(source, ref i));
+                    continue;
+                case '$':
+                    tokens.Add(ReadFieldRef(source, ref i));
+                    continue;
+            }
+
+            if (char.IsDigit(c) || (c == '.' && i + 1 < length && char.IsDigit(source[i + 1])))
+            {
+                tokens.Add(ReadNumber(source, ref i));
+                continue;
+            }
+
+            // A standalone '.' references the "current" value (the field under constraint).
+            if (c == '.')
+            {
+                i++;
+                tokens.Add(new Token(TokenType.FieldRef, SelfReferenceKey, SelfReferenceKey));
+                continue;
+            }
+
+            if (IsIdentifierStart(c))
+            {
+                tokens.Add(ReadIdentifier(source, ref i));
+                continue;
+            }
+
+            var op = ReadOperator(source, ref i);
+            if (op is not null)
+            {
+                tokens.Add(op.Value);
+                continue;
+            }
+
+            throw new ExpressionException($"Unexpected character '{c}' at position {i}.");
+        }
+
+        tokens.Add(new Token(TokenType.End, string.Empty));
+        return tokens;
+    }
+
+    private static Token ReadString(string source, ref int i)
+    {
+        // i points at the opening quote.
+        var sb = new StringBuilder();
+        i++;
+        while (i < source.Length)
+        {
+            var c = source[i];
+            if (c == '\'')
+            {
+                // Doubled single-quote is an escaped quote.
+                if (i + 1 < source.Length && source[i + 1] == '\'')
+                {
+                    sb.Append('\'');
+                    i += 2;
+                    continue;
+                }
+
+                i++;
+                return new Token(TokenType.String, sb.ToString(), sb.ToString());
+            }
+
+            sb.Append(c);
+            i++;
+        }
+
+        throw new ExpressionException("Unterminated string literal.");
+    }
+
+    private static Token ReadFieldRef(string source, ref int i)
+    {
+        // i points at '$'.
+        i++;
+        if (i < source.Length && source[i] == '{')
+        {
+            i++;
+            var sb = new StringBuilder();
+            while (i < source.Length && source[i] != '}')
+            {
+                sb.Append(source[i]);
+                i++;
+            }
+
+            if (i >= source.Length)
+            {
+                throw new ExpressionException("Unterminated field reference; missing '}'.");
+            }
+
+            i++; // consume '}'
+            var name = sb.ToString().Trim();
+            if (name.Length == 0)
+            {
+                throw new ExpressionException("Empty field reference.");
+            }
+
+            return new Token(TokenType.FieldRef, name, name);
+        }
+        else
+        {
+            var start = i;
+            while (i < source.Length && IsIdentifierPart(source[i]))
+            {
+                i++;
+            }
+
+            if (i == start)
+            {
+                throw new ExpressionException("Empty field reference.");
+            }
+
+            var name = source[start..i];
+            return new Token(TokenType.FieldRef, name, name);
+        }
+    }
+
+    private static Token ReadNumber(string source, ref int i)
+    {
+        var start = i;
+        var seenDot = false;
+        var seenExp = false;
+        while (i < source.Length)
+        {
+            var c = source[i];
+            if (char.IsDigit(c))
+            {
+                i++;
+            }
+            else if (c == '.' && !seenDot && !seenExp)
+            {
+                seenDot = true;
+                i++;
+            }
+            else if ((c == 'e' || c == 'E') && !seenExp)
+            {
+                seenExp = true;
+                i++;
+                if (i < source.Length && (source[i] == '+' || source[i] == '-'))
+                {
+                    i++;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        var text = source[start..i];
+        if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+        {
+            throw new ExpressionException($"Invalid number literal '{text}'.");
+        }
+
+        return new Token(TokenType.Number, text, number);
+    }
+
+    private static Token ReadIdentifier(string source, ref int i)
+    {
+        var start = i;
+        while (i < source.Length && IsIdentifierPart(source[i]))
+        {
+            i++;
+        }
+
+        var text = source[start..i];
+        return new Token(TokenType.Identifier, text);
+    }
+
+    private static Token? ReadOperator(string source, ref int i)
+    {
+        var c = source[i];
+        var next = i + 1 < source.Length ? source[i + 1] : '\0';
+
+        switch (c)
+        {
+            case '=':
+                if (next == '=')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, "==");
+                }
+
+                i++;
+                return new Token(TokenType.Operator, "=");
+            case '!':
+                if (next == '=')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, "!=");
+                }
+
+                i++;
+                return new Token(TokenType.Operator, "!");
+            case '<':
+                if (next == '=')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, "<=");
+                }
+
+                i++;
+                return new Token(TokenType.Operator, "<");
+            case '>':
+                if (next == '=')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, ">=");
+                }
+
+                i++;
+                return new Token(TokenType.Operator, ">");
+            case '&':
+                if (next == '&')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, "&&");
+                }
+
+                break;
+            case '|':
+                if (next == '|')
+                {
+                    i += 2;
+                    return new Token(TokenType.Operator, "||");
+                }
+
+                break;
+            case '+':
+            case '-':
+            case '*':
+            case '/':
+            case '%':
+                i++;
+                return new Token(TokenType.Operator, c.ToString());
+        }
+
+        return null;
+    }
+
+    private static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
+
+    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.';
+}

--- a/src/Honua.Sdk.Field/Forms/FormModels.cs
+++ b/src/Honua.Sdk.Field/Forms/FormModels.cs
@@ -116,6 +116,14 @@ public sealed record FormField
     /// <summary>Optional visibility rule evaluated against the current record.</summary>
     public FieldVisibilityRule? VisibilityRule { get; init; }
 
+    /// <summary>
+    /// Optional boolean relevance expression. When set it supersedes
+    /// <see cref="VisibilityRule"/> and is evaluated by the expression engine,
+    /// enabling compound conditions such as <c>${a}='x' and ${b}&gt;5</c>. The
+    /// field is shown only when the expression evaluates truthy.
+    /// </summary>
+    public string? RelevanceExpression { get; init; }
+
     /// <summary>Optional calculated expression, such as <c>concat($first, ' ', $last)</c>.</summary>
     public string? CalculatedExpression { get; init; }
 
@@ -189,7 +197,13 @@ public enum FormFieldType
     File,
 
     /// <summary>GPS or map-picked location input.</summary>
-    Location
+    Location,
+
+    /// <summary>Multi-vertex polygon geometry input.</summary>
+    GeoShape,
+
+    /// <summary>Multi-vertex polyline geometry input.</summary>
+    GeoTrace
 }
 
 /// <summary>
@@ -235,6 +249,17 @@ public sealed record FieldValidationRule
 
     /// <summary>Maximum media attachment count allowed for media fields.</summary>
     public int? MaxMediaCount { get; init; }
+
+    /// <summary>
+    /// Optional boolean constraint expression evaluated against the record values.
+    /// Validation fails when the expression evaluates falsey. Within the expression
+    /// the field's own value is addressable as <c>.</c> (and as <c>$thisFieldId</c>).
+    /// Example: <c>. &gt;= 0 and . &lt;= 100</c>.
+    /// </summary>
+    public string? ConstraintExpression { get; init; }
+
+    /// <summary>Optional message reported when <see cref="ConstraintExpression"/> fails.</summary>
+    public string? ConstraintMessage { get; init; }
 }
 
 /// <summary>

--- a/src/Honua.Sdk.Field/Forms/FormValidator.cs
+++ b/src/Honua.Sdk.Field/Forms/FormValidator.cs
@@ -92,6 +92,7 @@ public static class FormValidator
             {
                 ValidateType(local, field, rawValue);
                 ValidateRules(local, field, rawValue);
+                ValidateConstraintExpression(local, field, rawValue, values);
             }
 
             ValidateMediaRules(local, field, mediaCount);
@@ -105,6 +106,12 @@ public static class FormValidator
 
     private static bool IsVisible(FormField field, Dictionary<string, object?> values)
     {
+        // A boolean relevance expression, when present, supersedes the single-comparison rule.
+        if (!string.IsNullOrWhiteSpace(field.RelevanceExpression))
+        {
+            return Expressions.ExpressionEvaluator.EvaluateBoolean(field.RelevanceExpression, values);
+        }
+
         if (field.VisibilityRule is null)
         {
             return true;
@@ -193,6 +200,32 @@ public static class FormValidator
             {
                 errors.Add(new FormValidationError(field.FieldId, $"{field.Label} must be <= {max}."));
             }
+        }
+    }
+
+    private static void ValidateConstraintExpression(
+        List<FormValidationError> errors,
+        FormField field,
+        object? rawValue,
+        Dictionary<string, object?> values)
+    {
+        if (string.IsNullOrWhiteSpace(field.Validation.ConstraintExpression))
+        {
+            return;
+        }
+
+        // Overlay a "." self-reference (and keep $thisFieldId resolving via the field id)
+        // without mutating the caller's record values.
+        var context = new Dictionary<string, object?>(values, StringComparer.OrdinalIgnoreCase)
+        {
+            ["."] = rawValue,
+        };
+
+        if (!Expressions.ExpressionEvaluator.EvaluateBoolean(field.Validation.ConstraintExpression, context))
+        {
+            errors.Add(new FormValidationError(
+                field.FieldId,
+                field.Validation.ConstraintMessage ?? $"{field.Label} does not satisfy its constraint."));
         }
     }
 

--- a/tests/Honua.Sdk.Field.Tests/ExpressionEvaluatorTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/ExpressionEvaluatorTests.cs
@@ -1,0 +1,303 @@
+using System.Globalization;
+using Honua.Sdk.Field.Forms.Expressions;
+
+namespace Honua.Sdk.Field.Tests;
+
+public sealed class ExpressionEvaluatorTests
+{
+    private static Dictionary<string, object?> Ctx(params (string Key, object? Value)[] entries)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in entries)
+        {
+            dict[key] = value;
+        }
+
+        return dict;
+    }
+
+    private static double AsDouble(object? value)
+    {
+        Assert.NotNull(value);
+        return Convert.ToDouble(value, CultureInfo.InvariantCulture);
+    }
+
+    // ---- literals ----
+
+    [Theory]
+    [InlineData("1", 1d)]
+    [InlineData("3.5", 3.5d)]
+    [InlineData("1e3", 1000d)]
+    [InlineData("-4", -4d)]
+    public void Evaluate_NumberLiterals(string expr, double expected)
+        => Assert.Equal(expected, AsDouble(ExpressionEvaluator.Evaluate(expr, null)));
+
+    [Fact]
+    public void Evaluate_StringLiteral()
+        => Assert.Equal("hello world", ExpressionEvaluator.Evaluate("'hello world'", null));
+
+    [Fact]
+    public void Evaluate_EscapedQuoteInString()
+        => Assert.Equal("it's", ExpressionEvaluator.Evaluate("'it''s'", null));
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void Evaluate_BooleanLiterals(string expr, bool expected)
+        => Assert.Equal(expected, ExpressionEvaluator.Evaluate(expr, null));
+
+    [Fact]
+    public void Evaluate_NullLiteral()
+        => Assert.Null(ExpressionEvaluator.Evaluate("null", null));
+
+    // ---- field references ----
+
+    [Fact]
+    public void Evaluate_DollarFieldReference()
+        => Assert.Equal(42d, AsDouble(ExpressionEvaluator.Evaluate("$score", Ctx(("score", 42)))));
+
+    [Fact]
+    public void Evaluate_BracedFieldReference()
+        => Assert.Equal(42d, AsDouble(ExpressionEvaluator.Evaluate("${score}", Ctx(("score", 42)))));
+
+    [Fact]
+    public void Evaluate_BracedFieldReference_WithHyphenAndDot()
+        => Assert.Equal("x", ExpressionEvaluator.Evaluate("${a-b.c}", Ctx(("a-b.c", "x"))));
+
+    [Fact]
+    public void Evaluate_MissingFieldReference_IsNull()
+        => Assert.Null(ExpressionEvaluator.Evaluate("$missing", Ctx()));
+
+    [Fact]
+    public void Evaluate_DollarAndBraced_Equivalent()
+    {
+        var ctx = Ctx(("a", 5));
+        Assert.Equal(
+            ExpressionEvaluator.Evaluate("$a + 1", ctx),
+            ExpressionEvaluator.Evaluate("${a} + 1", ctx));
+    }
+
+    // ---- arithmetic ----
+
+    [Theory]
+    [InlineData("2 + 3", 5d)]
+    [InlineData("10 - 4", 6d)]
+    [InlineData("6 * 7", 42d)]
+    [InlineData("20 / 5", 4d)]
+    [InlineData("17 % 5", 2d)]
+    [InlineData("2 + 3 * 4", 14d)]
+    [InlineData("(2 + 3) * 4", 20d)]
+    [InlineData("-3 + 5", 2d)]
+    [InlineData("2 * -3", -6d)]
+    public void Evaluate_Arithmetic(string expr, double expected)
+        => Assert.Equal(expected, AsDouble(ExpressionEvaluator.Evaluate(expr, null)));
+
+    [Fact]
+    public void Evaluate_DivisionByZero_IsNull()
+        => Assert.Null(ExpressionEvaluator.Evaluate("5 / 0", null));
+
+    [Fact]
+    public void Evaluate_PlusOnStrings_Concatenates()
+        => Assert.Equal("ab", ExpressionEvaluator.Evaluate("'a' + 'b'", null));
+
+    // ---- comparison ----
+
+    [Theory]
+    [InlineData("1 = 1", true)]
+    [InlineData("1 == 1", true)]
+    [InlineData("1 != 2", true)]
+    [InlineData("2 > 1", true)]
+    [InlineData("1 < 2", true)]
+    [InlineData("2 >= 2", true)]
+    [InlineData("2 <= 1", false)]
+    [InlineData("'a' = 'a'", true)]
+    [InlineData("'a' = 'b'", false)]
+    public void Evaluate_Comparison(string expr, bool expected)
+        => Assert.Equal(expected, ExpressionEvaluator.Evaluate(expr, null));
+
+    [Fact]
+    public void Evaluate_Comparison_NumericStringCoercion()
+        => Assert.Equal(true, ExpressionEvaluator.Evaluate("$n > 3", Ctx(("n", "5"))));
+
+    // ---- logical ----
+
+    [Theory]
+    [InlineData("true and true", true)]
+    [InlineData("true and false", false)]
+    [InlineData("false or true", true)]
+    [InlineData("false or false", false)]
+    [InlineData("not true", false)]
+    [InlineData("not false", true)]
+    [InlineData("true && false", false)]
+    [InlineData("false || true", true)]
+    [InlineData("!false", true)]
+    [InlineData("1 > 0 and 2 > 1", true)]
+    [InlineData("1 > 0 or 2 < 1", true)]
+    public void Evaluate_Logical(string expr, bool expected)
+        => Assert.Equal(expected, ExpressionEvaluator.Evaluate(expr, null));
+
+    [Fact]
+    public void Evaluate_LogicalPrecedence_OrBelowAnd()
+        => Assert.Equal(true, ExpressionEvaluator.Evaluate("false and false or true", null));
+
+    [Fact]
+    public void Evaluate_CompoundFieldCondition()
+    {
+        var ctx = Ctx(("a", "x"), ("b", 10));
+        Assert.Equal(true, ExpressionEvaluator.Evaluate("${a}='x' and ${b}>5", ctx));
+        Assert.Equal(false, ExpressionEvaluator.Evaluate("${a}='x' and ${b}>50", ctx));
+    }
+
+    // ---- functions ----
+
+    [Fact]
+    public void Function_If()
+    {
+        Assert.Equal("yes", ExpressionEvaluator.Evaluate("if(1 > 0, 'yes', 'no')", null));
+        Assert.Equal("no", ExpressionEvaluator.Evaluate("if(1 < 0, 'yes', 'no')", null));
+    }
+
+    [Fact]
+    public void Function_Coalesce()
+    {
+        Assert.Equal("fallback", ExpressionEvaluator.Evaluate("coalesce($missing, '', 'fallback')", Ctx()));
+        Assert.Equal(7d, AsDouble(ExpressionEvaluator.Evaluate("coalesce($a, 7)", Ctx(("a", null)))));
+    }
+
+    [Fact]
+    public void Function_Concat()
+        => Assert.Equal("a-b", ExpressionEvaluator.Evaluate("concat('a','-','b')", null));
+
+    [Fact]
+    public void Function_Sum()
+        => Assert.Equal(8d, AsDouble(ExpressionEvaluator.Evaluate("sum($a,$b)", Ctx(("a", 3), ("b", 5)))));
+
+    [Fact]
+    public void Function_MinMax()
+    {
+        Assert.Equal(1d, AsDouble(ExpressionEvaluator.Evaluate("min(3, 1, 2)", null)));
+        Assert.Equal(3d, AsDouble(ExpressionEvaluator.Evaluate("max(3, 1, 2)", null)));
+    }
+
+    [Theory]
+    [InlineData("round(3.14159, 2)", 3.14d)]
+    [InlineData("round(2.5)", 3d)]
+    [InlineData("floor(3.9)", 3d)]
+    [InlineData("ceil(3.1)", 4d)]
+    [InlineData("abs(-5)", 5d)]
+    public void Function_Math(string expr, double expected)
+        => Assert.Equal(expected, AsDouble(ExpressionEvaluator.Evaluate(expr, null)));
+
+    [Fact]
+    public void Function_LenAndStringLength()
+    {
+        Assert.Equal(5d, AsDouble(ExpressionEvaluator.Evaluate("len('hello')", null)));
+        Assert.Equal(5d, AsDouble(ExpressionEvaluator.Evaluate("string-length('hello')", null)));
+    }
+
+    [Fact]
+    public void Function_UpperLowerTrim()
+    {
+        Assert.Equal("ABC", ExpressionEvaluator.Evaluate("upper('abc')", null));
+        Assert.Equal("abc", ExpressionEvaluator.Evaluate("lower('ABC')", null));
+        Assert.Equal("abc", ExpressionEvaluator.Evaluate("trim('  abc  ')", null));
+    }
+
+    [Fact]
+    public void Function_Contains()
+    {
+        Assert.Equal(true, ExpressionEvaluator.Evaluate("contains('hello', 'ell')", null));
+        Assert.Equal(false, ExpressionEvaluator.Evaluate("contains('hello', 'z')", null));
+    }
+
+    [Fact]
+    public void Function_NumberAndString()
+    {
+        Assert.Equal(12d, AsDouble(ExpressionEvaluator.Evaluate("number('12')", null)));
+        Assert.Equal("3.5", ExpressionEvaluator.Evaluate("string(3.5)", null));
+    }
+
+    [Fact]
+    public void Function_DateDiffDays_UsesFixedFieldDates()
+    {
+        var ctx = Ctx(
+            ("start", DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture)),
+            ("end", DateTimeOffset.Parse("2026-01-11T00:00:00Z", CultureInfo.InvariantCulture)));
+        Assert.Equal(10d, AsDouble(ExpressionEvaluator.Evaluate("date-diff-days($end, $start)", ctx)));
+    }
+
+    [Fact]
+    public void Function_AddDays_UsesFixedFieldDate()
+    {
+        var ctx = Ctx(("d", DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture)));
+        var result = ExpressionEvaluator.Evaluate("add-days($d, 5)", ctx);
+        var expected = DateTimeOffset.Parse("2026-01-06T00:00:00Z", CultureInfo.InvariantCulture);
+        Assert.Equal(expected, Assert.IsType<DateTimeOffset>(result));
+    }
+
+    [Fact]
+    public void Function_DateDiffDays_AcceptsIsoStrings()
+    {
+        var ctx = Ctx(("a", "2026-03-10"), ("b", "2026-03-01"));
+        Assert.Equal(9d, AsDouble(ExpressionEvaluator.Evaluate("date-diff-days($a, $b)", ctx)));
+    }
+
+    [Fact]
+    public void Function_Today_ReturnsMidnightUtc()
+    {
+        var result = Assert.IsType<DateTimeOffset>(ExpressionEvaluator.Evaluate("today()", null));
+        Assert.Equal(TimeSpan.Zero, result.TimeOfDay);
+    }
+
+    // ---- null / robustness ----
+
+    [Fact]
+    public void Evaluate_NullArithmetic_IsNull()
+        => Assert.Null(ExpressionEvaluator.Evaluate("$missing + 1", Ctx()));
+
+    [Fact]
+    public void Evaluate_EmptyExpression_ReturnsNull()
+        => Assert.Null(ExpressionEvaluator.Evaluate("   ", null));
+
+    [Fact]
+    public void Evaluate_MalformedExpression_DoesNotThrow_ReturnsNullWithDiagnostic()
+    {
+        var result = ExpressionEvaluator.EvaluateDetailed("1 + + )", null);
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Value);
+        Assert.NotNull(result.Diagnostic);
+    }
+
+    [Fact]
+    public void Evaluate_UnknownFunction_ReturnsDiagnostic()
+    {
+        var result = ExpressionEvaluator.EvaluateDetailed("bogus(1)", null);
+        Assert.False(result.Succeeded);
+        Assert.Contains("bogus", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Evaluate_OverlongInput_IsRejected()
+    {
+        var huge = new string('1', ExpressionEvaluator.MaxExpressionLength + 1);
+        var result = ExpressionEvaluator.EvaluateDetailed(huge, null);
+        Assert.False(result.Succeeded);
+    }
+
+    [Fact]
+    public void Evaluate_DeeplyNestedInput_DoesNotThrow()
+    {
+        var expr = new string('(', 500) + "1" + new string(')', 500);
+        var result = ExpressionEvaluator.EvaluateDetailed(expr, null);
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Diagnostic);
+    }
+
+    [Fact]
+    public void EvaluateBoolean_TruthyAndFalsy()
+    {
+        Assert.True(ExpressionEvaluator.EvaluateBoolean("$a > 5", Ctx(("a", 10))));
+        Assert.False(ExpressionEvaluator.EvaluateBoolean("$a > 5", Ctx(("a", 1))));
+        Assert.False(ExpressionEvaluator.EvaluateBoolean("$missing", Ctx()));
+    }
+}

--- a/tests/Honua.Sdk.Field.Tests/FormExpressionFeatureTests.cs
+++ b/tests/Honua.Sdk.Field.Tests/FormExpressionFeatureTests.cs
@@ -1,0 +1,229 @@
+using Honua.Sdk.Field.Forms;
+using Honua.Sdk.Field.Records;
+
+namespace Honua.Sdk.Field.Tests;
+
+public sealed class FormExpressionFeatureTests
+{
+    private static FormDefinition SingleFieldForm(FormField field) => new()
+    {
+        FormId = "f",
+        Name = "f",
+        Sections = [new FormSection { SectionId = "main", Label = "Main", Fields = [field] }],
+    };
+
+    // ---- constraint expressions ----
+
+    [Fact]
+    public void Constraint_PassesWhenSatisfied()
+    {
+        var form = SingleFieldForm(new FormField
+        {
+            FieldId = "score",
+            Label = "Score",
+            Type = FormFieldType.Numeric,
+            Validation = new FieldValidationRule { ConstraintExpression = ". >= 0 and . <= 100" },
+        });
+
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["score"] = 50 } };
+
+        var result = FormValidator.Validate(form, record);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Constraint_FailsWhenViolated_WithDefaultMessage()
+    {
+        var form = SingleFieldForm(new FormField
+        {
+            FieldId = "score",
+            Label = "Score",
+            Type = FormFieldType.Numeric,
+            Validation = new FieldValidationRule { ConstraintExpression = ". >= 0 and . <= 100" },
+        });
+
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["score"] = 150 } };
+
+        var result = FormValidator.Validate(form, record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.FieldId == "score" && e.Message.Contains("constraint", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Constraint_FailsWithCustomMessage()
+    {
+        var form = SingleFieldForm(new FormField
+        {
+            FieldId = "score",
+            Label = "Score",
+            Type = FormFieldType.Numeric,
+            Validation = new FieldValidationRule
+            {
+                ConstraintExpression = ". <= 100",
+                ConstraintMessage = "Score cannot exceed 100.",
+            },
+        });
+
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["score"] = 150 } };
+
+        var result = FormValidator.Validate(form, record);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.FieldId == "score" && e.Message == "Score cannot exceed 100.");
+    }
+
+    [Fact]
+    public void Constraint_CanReferenceOtherFields()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "f",
+            Name = "f",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField { FieldId = "min", Label = "Min", Type = FormFieldType.Numeric },
+                        new FormField
+                        {
+                            FieldId = "max",
+                            Label = "Max",
+                            Type = FormFieldType.Numeric,
+                            Validation = new FieldValidationRule { ConstraintExpression = ". >= $min", ConstraintMessage = "Max must be >= Min." },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var bad = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["min"] = 10, ["max"] = 5 } };
+        var good = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["min"] = 10, ["max"] = 15 } };
+
+        Assert.False(FormValidator.Validate(form, bad).IsValid);
+        Assert.True(FormValidator.Validate(form, good).IsValid);
+    }
+
+    [Fact]
+    public void Constraint_DoesNotMutateRecordValues()
+    {
+        var form = SingleFieldForm(new FormField
+        {
+            FieldId = "score",
+            Label = "Score",
+            Type = FormFieldType.Numeric,
+            Validation = new FieldValidationRule { ConstraintExpression = ". <= 100" },
+        });
+
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["score"] = 50 } };
+
+        FormValidator.Validate(form, record);
+
+        Assert.False(record.Values.ContainsKey("."));
+    }
+
+    // ---- boolean relevance ----
+
+    [Fact]
+    public void Relevance_CompoundExpression_ShowsAndRequires()
+    {
+        var form = new FormDefinition
+        {
+            FormId = "f",
+            Name = "f",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField { FieldId = "type", Label = "Type", Type = FormFieldType.Text },
+                        new FormField { FieldId = "score", Label = "Score", Type = FormFieldType.Numeric },
+                        new FormField
+                        {
+                            FieldId = "followup",
+                            Label = "Follow-up",
+                            Type = FormFieldType.Text,
+                            Required = true,
+                            RelevanceExpression = "${type}='incident' and ${score}>5",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // Both conditions true -> field is relevant and required -> missing -> error.
+        var visible = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["type"] = "incident", ["score"] = 8 } };
+        Assert.Contains(FormValidator.Validate(form, visible).Errors, e => e.FieldId == "followup");
+
+        // One condition false -> field hidden -> no required error.
+        var hidden = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["type"] = "incident", ["score"] = 2 } };
+        Assert.DoesNotContain(FormValidator.Validate(form, hidden).Errors, e => e.FieldId == "followup");
+    }
+
+    [Fact]
+    public void Relevance_SupersedesVisibilityRule()
+    {
+        // RelevanceExpression is always false; VisibilityRule would otherwise show the field.
+        var form = new FormDefinition
+        {
+            FormId = "f",
+            Name = "f",
+            Sections =
+            [
+                new FormSection
+                {
+                    SectionId = "main",
+                    Label = "Main",
+                    Fields =
+                    [
+                        new FormField { FieldId = "score", Label = "Score", Type = FormFieldType.Numeric },
+                        new FormField
+                        {
+                            FieldId = "followup",
+                            Label = "Follow-up",
+                            Type = FormFieldType.Text,
+                            Required = true,
+                            RelevanceExpression = "false",
+                            VisibilityRule = new FieldVisibilityRule
+                            {
+                                DependsOnFieldId = "score",
+                                Operator = ComparisonOperator.GreaterThan,
+                                MatchValue = 0,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["score"] = 100 } };
+
+        Assert.DoesNotContain(FormValidator.Validate(form, record).Errors, e => e.FieldId == "followup");
+    }
+
+    // ---- geometry field types ----
+
+    [Fact]
+    public void GeometryFieldTypes_Exist_AndAreAppendedAfterLocation()
+    {
+        Assert.True((int)FormFieldType.GeoShape > (int)FormFieldType.Location);
+        Assert.True((int)FormFieldType.GeoTrace > (int)FormFieldType.GeoShape);
+    }
+
+    [Fact]
+    public void GeometryField_DoesNotBreakValidation()
+    {
+        var form = SingleFieldForm(new FormField { FieldId = "area", Label = "Area", Type = FormFieldType.GeoShape });
+        var record = new FieldRecord { RecordId = "r", FormId = "f", Values = { ["area"] = "POLYGON((0 0,1 0,1 1,0 0))" } };
+
+        Assert.True(FormValidator.Validate(form, record).IsValid);
+    }
+}


### PR DESCRIPTION
Replaces the toy `concat`/`sum` calculated-field handling with a real expression engine and adds constraint expressions, boolean relevance, and two geometry field types — closing the biggest Survey123 forms-depth gap. Backward compatible; **108/108** Field tests pass.

## Adds
- `Forms/Expressions/` — tokenizer + precedence-climbing parser + evaluator. Arithmetic `+ - * / %`, comparison, logical `and/or/not`, parentheses, `$x`/`${x}` field refs, `.` self-ref. Functions: `if`, `coalesce`, `concat`, `sum`, `min`, `max`, `round`, `floor`, `ceil`, `abs`, `len`, `upper`, `lower`, `trim`, `contains`, `number`, `string`, `today`, `now`, `date-diff-days`, `add-days`. Length/depth caps; never throws (returns null + diagnostic).
- `CalculatedFieldEvaluator` rewired onto the engine (identical results for existing `concat`/`sum`, repeat-row scoping preserved).
- `FieldValidationRule.ConstraintExpression` + `ConstraintMessage`, enforced in `FormValidator`.
- `FormField.RelevanceExpression` (supersedes the single-comparison visibility rule when set).
- `FormFieldType.GeoShape` + `GeoTrace` (appended; ordinals unchanged).

## Back-compat
Existing calc expressions, single-comparison visibility, and enum ordinals unchanged — verified by regression tests. Consumed by honua-collect after a 1.2.0 cut.