### PR TITLE
ci: add Trivy + OpenSSF Scorecard security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+name: Security
+
+on:
+  push:
+    branches: [ "trunk" ]
+  pull_request:
+    branches: [ "trunk" ]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+  actions: read
+
+jobs:
+  trivy:
+    uses: honua-io/.github/.github/workflows/reusable-trivy.yml@main
+    with:
+      scan-type: fs
+
+  scorecard:
+    uses: honua-io/.github/.github/workflows/reusable-scorecard.yml@main


### PR DESCRIPTION
Adds `.github/workflows/security.yml` calling the org reusable security workflows (`honua-io/.github`):
- **Trivy** filesystem scan (vulns + secrets + misconfig)
- **OpenSSF Scorecard** (posture score + README badge)

Deliberately **no CodeQL** here — handled by the org-wide default setup (no default-vs-advanced conflict). Phase 1 security program (honua-compliance #5/#6).