### PR TITLE
C# process-authoring SDK + ArcObjects-GP migration guide

### DIFF
--- a/docs/process-authoring.md
+++ b/docs/process-authoring.md
@@ -1,0 +1,223 @@
+# Process authoring & ArcObjects-GP migration
+
+This guide covers authoring Honua geoprocessing (GP) processes in C# with the
+`Honua.Sdk.Processes` authoring API, testing them locally with the in-process
+harness, mapping common ArcObjects / ArcPy GP idioms onto Honua processes, and
+federating an existing compiled .NET GP service during a phased migration.
+
+Honua runs geoprocessing as [OGC API Processes](https://ogcapi.ogc.org/processes/).
+A process declares typed inputs and outputs and is executed as an asynchronous
+job. Honua GP executors are themselves C#, so for .NET shops the migration path
+is **reimplement-as-Honua-process**: compiled ArcObjects assemblies cannot be
+source-translated, so the logic is re-expressed against the Honua process model.
+Federation bridges the gap while that port is in progress.
+
+## When to use what
+
+| Goal | Use |
+|---|---|
+| Describe a process (id, inputs, outputs) for the catalog | `HonuaProcessAuthoring.DefineProcess(...)` -> `HonuaProcessDefinition` |
+| Build a multi-step analysis plan to submit | `HonuaProcessAuthoring.DefinePlan(...)` -> `HonuaProcessExecuteRequest` |
+| Write and unit-test executor logic locally | `IHonuaProcessExecutor` + `HonuaProcessTestHarness` |
+| Submit a job to a running server | `IHonuaProcessesClient` (see [README](../src/Honua.Sdk.Processes/README.md)) |
+
+## Authoring a process definition
+
+`HonuaProcessBuilder` produces a `HonuaProcessDefinition` and projects it to the
+server's OGC API Processes description shape (the body served at
+`GET /ogc/processes/processes/{id}`) via `ToOgcDescription()`.
+
+```csharp
+using Honua.Sdk.Processes.Authoring;
+
+var definition = HonuaProcessAuthoring.DefineProcess("geometry.buffer")
+    .WithTitle("Buffer")
+    .WithDescription("Creates a polygon at a specified distance around each input geometry.")
+    .WithCategory("geometry")
+    .AddInput("wkb", HonuaProcessParameterValueType.Wkb, p => p
+        .WithDisplayName("Input Geometry").Required())
+    .AddInput("srid", HonuaProcessParameterValueType.Srid, p => p
+        .WithDisplayName("Spatial Reference").Required())
+    .AddInput("distance", HonuaProcessParameterValueType.FloatingPoint, p => p
+        .WithDisplayName("Buffer Distance").Required())
+    .AddInput("geodesic", HonuaProcessParameterValueType.Flag, p => p
+        .WithDisplayName("Geodesic").WithDefault("false"))
+    .AddOutput("outputFeatureLayer", HonuaProcessArtifactKind.FeatureLayer)
+    .Build();
+
+// Serialize to the server's OGC process-description format.
+var ogc = definition.ToOgcDescription();
+```
+
+### Parameter value types
+
+Each `HonuaProcessParameterValueType` projects to a JSON Schema fragment that
+matches what Honua Server emits:
+
+| Value type | Schema `type` | `contentMediaType` |
+|---|---|---|
+| `Text` | `string` | — |
+| `WholeNumber` | `integer` | — |
+| `FloatingPoint` | `number` | — |
+| `Flag` | `boolean` | — |
+| `Wkb` | `string` | `application/wkb` |
+| `WkbArray` | `array` | `application/wkb` |
+| `Srid` | `integer` | — |
+| `LayerId` | `string` | — |
+
+## Authoring an analysis plan
+
+The canonical `honua-geoprocessing` process executes a multi-step plan (a DAG).
+`HonuaAnalysisPlanBuilder` authors that plan and wraps it in an execute request.
+It validates that every `dependsOn` references a declared step and rejects
+duplicate or self-referential steps.
+
+```csharp
+var request = HonuaProcessAuthoring.DefinePlan("parcels-near-roads")
+    .WithWorkflowFamily("analyze")
+    .WithOutputs("featureLayer")
+    .AddStep("query", "queryFeatures", s => s.WithInput("layerId", "parcels"))
+    .AddGeoprocessStep("buffer", "geometry.buffer", s => s
+        .WithInput("distance", 100)     // IFormattable overload -> invariant culture
+        .DependsOn("query"))
+    .BuildExecuteRequest();
+
+// Submit through the REST client against the canonical process.
+var job = await processes.SubmitJobAsync("honua-geoprocessing", request, ct);
+```
+
+## Testing an executor locally
+
+Implement `IHonuaProcessExecutor` — the authoring-side mirror of the server's
+`IJobExecutor` — so logic written against this SDK ports directly into a
+server-hosted executor. Inputs arrive as a flattened `string` dictionary
+(matching the server's job parameter contract); progress, logs, and artifacts
+flow through `IHonuaProcessExecutionContext`.
+
+```csharp
+public sealed class BufferExecutor : IHonuaProcessExecutor
+{
+    public string ProcessId => "geometry.buffer";
+
+    public async Task<HonuaProcessJobResult> ExecuteAsync(
+        HonuaProcessJobInput job,
+        IHonuaProcessExecutionContext context,
+        CancellationToken cancellationToken)
+    {
+        await context.ReportProgressAsync(0, "starting", cancellationToken);
+        var distance = double.Parse(job.GetRequired("distance"), CultureInfo.InvariantCulture);
+        // ... run buffer, publish artifact ...
+        await context.PublishArtifactAsync("layer://buffered", cancellationToken);
+        return HonuaProcessJobResult.Success();
+    }
+}
+```
+
+`HonuaProcessTestHarness` runs the executor in-process. When a
+`HonuaProcessDefinition` is supplied, it validates required inputs before
+execution and captures everything the executor reported:
+
+```csharp
+var harness = new HonuaProcessTestHarness(new BufferExecutor(), definition);
+
+var run = await harness.RunAsync(new Dictionary<string, string>
+{
+    ["wkb"] = "AAAA",
+    ["srid"] = "4326",
+    ["distance"] = "100",
+});
+
+Assert.True(run.Succeeded);
+Assert.Single(run.Artifacts);
+Assert.Equal(100, run.Progress[^1].PercentComplete);
+```
+
+You can also drive the harness directly from an authored plan step:
+
+```csharp
+var plan = HonuaProcessAuthoring.DefinePlan("p")
+    .AddGeoprocessStep("buffer", "geometry.buffer", s => s.WithInput("distance", 100))
+    .Build();
+
+var run = await harness.RunAsync(plan.Steps[0]);
+```
+
+## ArcObjects / ArcPy GP idiom → Honua process mapping
+
+Compiled ArcObjects GP tools cannot be source-translated; the migration is a
+reimplementation against the Honua process model. The table maps the idioms a
+.NET / ArcPy GP author reaches for onto their Honua equivalents.
+
+| ArcObjects / ArcPy idiom | Honua process equivalent |
+|---|---|
+| `IGPFunction` / `IGPFunction2` tool class | `IHonuaProcessExecutor` (server-side: `IJobExecutor`) |
+| `Execute(IArray parameters, ITrackCancel, IGPEnvironmentManager, IGPMessages)` | `ExecuteAsync(HonuaProcessJobInput, IHonuaProcessExecutionContext, CancellationToken)` |
+| `ParameterInfo` / `IGPParameter` collection | `HonuaProcessBuilder.AddInput(...)` declarations |
+| `IGPParameter.DataType` (`GPFeatureLayer`, `GPLong`, `GPDouble`, `GPBoolean`, `GPSpatialReference`) | `HonuaProcessParameterValueType` (`LayerId`, `WholeNumber`, `FloatingPoint`, `Flag`, `Srid`) |
+| Output parameter (`Direction = esriGPParameterDirectionOutput`) | `HonuaProcessBuilder.AddOutput(...)` + `HonuaProcessJobResult.Outputs` |
+| `IGPMessages.AddMessage(...)` | `IHonuaProcessExecutionContext.AppendLogAsync(...)` |
+| `IStepProgressor` / `IGPMessages` percent updates | `IHonuaProcessExecutionContext.ReportProgressAsync(percent, phase)` |
+| `ITrackCancel.Continue()` polling | `CancellationToken` / `ThrowIfCancellationRequested()` |
+| ModelBuilder model (chained tools) | `HonuaAnalysisPlanBuilder` plan with `dependsOn` steps |
+| `arcpy.Buffer_analysis(in, out, dist)` one-shot call | one `AddGeoprocessStep("buffer", "geometry.buffer", ...)` in a plan |
+| Tool returns derived feature class | output artifact of kind `FeatureLayer` |
+| `arcpy.env.outputCoordinateSystem` and friends | step inputs (`srid`) / `HonuaProcessExecutionContext` metadata |
+| `GPToolbox` (.tbx) grouping of tools | the process catalog at `/ogc/processes/processes` |
+| Synchronous in-process tool execution | asynchronous OGC job (`jobControlOptions: ["async-execute"]`) |
+
+### Worked example
+
+ArcPy:
+
+```python
+arcpy.analysis.Buffer("parcels", "parcels_buf", "100 Meters")
+```
+
+Honua (authored plan + executor logic):
+
+```csharp
+var plan = HonuaProcessAuthoring.DefinePlan("buffer-parcels")
+    .AddStep("query", "queryFeatures", s => s.WithInput("layerId", "parcels"))
+    .AddGeoprocessStep("buffer", "geometry.buffer", s => s
+        .WithInput("distance", 100)
+        .DependsOn("query"))
+    .Build();
+```
+
+The buffer logic itself lives in a `geometry.buffer` `IHonuaProcessExecutor`,
+unit-tested with `HonuaProcessTestHarness` and then registered with the server's
+geoprocessing runtime as an `IJobExecutor`.
+
+## Federating an existing compiled .NET GP service
+
+While ArcObjects tools are being reimplemented, the existing compiled .NET GP
+service keeps running and is **federated** behind Honua so callers see one
+process catalog. The bridge is operational, not a code change in this SDK:
+
+1. **Wrap the legacy service in OGC API Processes.** Expose the legacy GP
+   service's tools through an OGC API Processes facade (each legacy tool becomes
+   a process with the same input/output contract you would declare with
+   `HonuaProcessBuilder`). Author the *descriptions* with this SDK so the
+   federated processes advertise the same schema shape as native ones.
+2. **Register the facade as a federated process source** in Honua Server so its
+   processes appear alongside native ones in `/ogc/processes/processes`. Honua
+   routes execution for those ids to the legacy facade.
+3. **Migrate tool-by-tool.** As each ArcObjects tool is reimplemented as a
+   native `IJobExecutor`, flip its process id from the federated facade to the
+   native executor. The process id and I/O contract are unchanged, so callers
+   and authored plans are unaffected.
+4. **Decommission the facade** once every tool has a native executor.
+
+Authoring descriptions for both the federated and native versions with the same
+`HonuaProcessBuilder` code keeps the contract identical across the cutover, which
+is what makes the tool-by-tool swap transparent to clients.
+
+> Scope note: a codemod that automatically translates compiled .NET / ArcObjects
+> tools is **not** feasible and is out of scope. Federation plus manual
+> reimplementation is the supported path.
+
+## See also
+
+- [`Honua.Sdk.Processes` README](../src/Honua.Sdk.Processes/README.md) — REST
+  client surface for submitting and polling jobs.
+- [Geometry analysis](geometry-analysis.md) — client-side geometry helpers.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -24,6 +24,8 @@
       href: feature-edits.md
     - name: Geometry analysis
       href: geometry-analysis.md
+    - name: Process authoring & ArcObjects-GP migration
+      href: process-authoring.md
     - name: Geofencing
       href: geofencing.md
     - name: Scenes

--- a/src/Honua.Sdk.Processes/Authoring/HonuaAnalysisPlanBuilder.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaAnalysisPlanBuilder.cs
@@ -1,0 +1,220 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Processes.Models;
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Fluent builder for authoring a <see cref="HonuaAnalysisPlan"/> — the multi-step DAG the
+/// canonical <c>honua-geoprocessing</c> process executes. Create one with
+/// <see cref="HonuaProcessAuthoring.DefinePlan(string)"/>, add steps, then call
+/// <see cref="Build"/> or <see cref="BuildExecuteRequest"/>.
+/// </summary>
+public sealed class HonuaAnalysisPlanBuilder
+{
+    private readonly string _planId;
+    private readonly List<HonuaPlanStep> _steps = [];
+    private readonly HashSet<string> _stepIds = new(StringComparer.Ordinal);
+    private string? _specVersion;
+    private string? _workflowFamily;
+    private List<string>? _outputs;
+
+    internal HonuaAnalysisPlanBuilder(string planId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planId);
+        _planId = planId;
+    }
+
+    /// <summary>Sets the spec/process version recorded on the plan.</summary>
+    /// <param name="specVersion">Spec version.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaAnalysisPlanBuilder WithSpecVersion(string specVersion)
+    {
+        _specVersion = specVersion;
+        return this;
+    }
+
+    /// <summary>Sets the workflow family, for example <c>analyze</c>.</summary>
+    /// <param name="workflowFamily">Workflow family.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaAnalysisPlanBuilder WithWorkflowFamily(string workflowFamily)
+    {
+        _workflowFamily = workflowFamily;
+        return this;
+    }
+
+    /// <summary>Declares the desired output artifact kinds for the plan.</summary>
+    /// <param name="outputs">Output artifact kind identifiers.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaAnalysisPlanBuilder WithOutputs(params string[] outputs)
+    {
+        ArgumentNullException.ThrowIfNull(outputs);
+        _outputs = [.. outputs];
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a geoprocessing step invoking a concrete process.
+    /// </summary>
+    /// <param name="stepId">Unique step identifier.</param>
+    /// <param name="processId">Concrete process id, for example <c>geometry.buffer</c>.</param>
+    /// <param name="configure">Optional step configuration.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaAnalysisPlanBuilder AddGeoprocessStep(
+        string stepId,
+        string processId,
+        Action<HonuaPlanStepBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(processId);
+        return AddStep(stepId, "geoprocess", step =>
+        {
+            step.WithProcessId(processId);
+            configure?.Invoke(step);
+        });
+    }
+
+    /// <summary>
+    /// Adds a step of an arbitrary kind, for example <c>queryFeatures</c>, <c>aggregate</c>,
+    /// <c>renderMap</c>, or <c>export</c>.
+    /// </summary>
+    /// <param name="stepId">Unique step identifier.</param>
+    /// <param name="kind">Step kind.</param>
+    /// <param name="configure">Optional step configuration.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaAnalysisPlanBuilder AddStep(
+        string stepId,
+        string kind,
+        Action<HonuaPlanStepBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stepId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (!_stepIds.Add(stepId))
+        {
+            throw new InvalidOperationException($"Step '{stepId}' is already declared.");
+        }
+
+        var stepBuilder = new HonuaPlanStepBuilder(stepId, kind);
+        configure?.Invoke(stepBuilder);
+        _steps.Add(stepBuilder.Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the immutable analysis plan after validating step references.
+    /// </summary>
+    /// <returns>The authored analysis plan.</returns>
+    public HonuaAnalysisPlan Build()
+    {
+        ValidateDependencies();
+        return new HonuaAnalysisPlan
+        {
+            PlanId = _planId,
+            SpecVersion = _specVersion,
+            WorkflowFamily = _workflowFamily,
+            Steps = [.. _steps],
+            Outputs = _outputs is null ? [] : [.. _outputs]
+        };
+    }
+
+    /// <summary>
+    /// Builds an OGC execute request wrapping the authored plan, ready to submit through
+    /// <see cref="IHonuaProcessesClient.SubmitJobAsync(string, HonuaProcessExecuteRequest, System.Threading.CancellationToken)"/>
+    /// against the canonical <c>honua-geoprocessing</c> process.
+    /// </summary>
+    /// <returns>The execute request.</returns>
+    public HonuaProcessExecuteRequest BuildExecuteRequest() => new()
+    {
+        Inputs = HonuaProcessExecuteInputs.FromPlan(Build())
+    };
+
+    private void ValidateDependencies()
+    {
+        foreach (var step in _steps)
+        {
+            foreach (var dependency in step.DependsOn)
+            {
+                if (!_stepIds.Contains(dependency))
+                {
+                    throw new InvalidOperationException(
+                        $"Step '{step.StepId}' depends on unknown step '{dependency}'.");
+                }
+
+                if (string.Equals(dependency, step.StepId, StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException($"Step '{step.StepId}' cannot depend on itself.");
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Fluent builder for a single <see cref="HonuaPlanStep"/>.
+/// </summary>
+public sealed class HonuaPlanStepBuilder
+{
+    private readonly string _stepId;
+    private readonly string _kind;
+    private readonly Dictionary<string, string> _inputs = new(StringComparer.Ordinal);
+    private readonly List<string> _dependsOn = [];
+    private string? _processId;
+
+    internal HonuaPlanStepBuilder(string stepId, string kind)
+    {
+        _stepId = stepId;
+        _kind = kind;
+    }
+
+    /// <summary>Sets the concrete process id this step invokes.</summary>
+    /// <param name="processId">Process id.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaPlanStepBuilder WithProcessId(string processId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(processId);
+        _processId = processId;
+        return this;
+    }
+
+    /// <summary>Sets a single step input.</summary>
+    /// <param name="name">Input name.</param>
+    /// <param name="value">Input value.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaPlanStepBuilder WithInput(string name, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        _inputs[name] = value ?? string.Empty;
+        return this;
+    }
+
+    /// <summary>Sets a single step input from any formattable value using invariant culture.</summary>
+    /// <param name="name">Input name.</param>
+    /// <param name="value">Input value.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaPlanStepBuilder WithInput(string name, IFormattable value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(value);
+        _inputs[name] = value.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
+        return this;
+    }
+
+    /// <summary>Declares a dependency on another step.</summary>
+    /// <param name="stepIds">Step ids this step depends on.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaPlanStepBuilder DependsOn(params string[] stepIds)
+    {
+        ArgumentNullException.ThrowIfNull(stepIds);
+        _dependsOn.AddRange(stepIds);
+        return this;
+    }
+
+    internal HonuaPlanStep Build() => new()
+    {
+        StepId = _stepId,
+        Kind = _kind,
+        ProcessId = _processId,
+        Inputs = new Dictionary<string, string>(_inputs, StringComparer.Ordinal),
+        DependsOn = [.. _dependsOn]
+    };
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessAuthoring.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessAuthoring.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Entry point for authoring Honua geoprocessing processes and analysis plans in C#.
+/// </summary>
+public static class HonuaProcessAuthoring
+{
+    /// <summary>
+    /// Begins authoring a process definition.
+    /// </summary>
+    /// <param name="processId">Stable process identifier, for example <c>geometry.buffer</c>.</param>
+    /// <returns>A fluent <see cref="HonuaProcessBuilder"/>.</returns>
+    public static HonuaProcessBuilder DefineProcess(string processId) => new(processId);
+
+    /// <summary>
+    /// Begins authoring an analysis plan for the canonical <c>honua-geoprocessing</c> process.
+    /// </summary>
+    /// <param name="planId">Plan identifier.</param>
+    /// <returns>A fluent <see cref="HonuaAnalysisPlanBuilder"/>.</returns>
+    public static HonuaAnalysisPlanBuilder DefinePlan(string planId) => new(planId);
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessBuilder.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessBuilder.cs
@@ -1,0 +1,302 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Fluent builder for authoring a Honua geoprocessing <see cref="HonuaProcessDefinition"/>
+/// in C#. Create one with <see cref="HonuaProcessAuthoring.DefineProcess(string)"/>, declare
+/// inputs and outputs, then call <see cref="Build"/>.
+/// </summary>
+public sealed class HonuaProcessBuilder
+{
+    private readonly string _processId;
+    private readonly List<HonuaProcessParameter> _parameters = [];
+    private readonly List<HonuaProcessOutput> _outputs = [];
+    private string _title;
+    private string _description = string.Empty;
+    private string _version = "1.0.0";
+    private string? _category;
+    private string _runtimeProfile = "managed";
+    private List<string>? _jobControlOptions;
+    private List<string>? _outputTransmission;
+
+    internal HonuaProcessBuilder(string processId)
+    {
+        if (string.IsNullOrWhiteSpace(processId))
+        {
+            throw new ArgumentException("Process id must be supplied.", nameof(processId));
+        }
+
+        _processId = processId;
+        _title = processId;
+    }
+
+    /// <summary>
+    /// Sets the operator-facing title.
+    /// </summary>
+    /// <param name="title">Process title.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithTitle(string title)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        _title = title;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the process description.
+    /// </summary>
+    /// <param name="description">Process description.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithDescription(string description)
+    {
+        _description = description ?? string.Empty;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the process version.
+    /// </summary>
+    /// <param name="version">Semantic version string.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithVersion(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        _version = version;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the process category.
+    /// </summary>
+    /// <param name="category">Category, for example <c>geometry</c>.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithCategory(string category)
+    {
+        _category = category;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the runtime profile the process executes under.
+    /// </summary>
+    /// <param name="runtimeProfile">Runtime profile, for example <c>managed</c> or <c>native</c>.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithRuntimeProfile(string runtimeProfile)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runtimeProfile);
+        _runtimeProfile = runtimeProfile;
+        return this;
+    }
+
+    /// <summary>
+    /// Overrides the advertised job control options.
+    /// </summary>
+    /// <param name="jobControlOptions">Job control option identifiers.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithJobControlOptions(params string[] jobControlOptions)
+    {
+        ArgumentNullException.ThrowIfNull(jobControlOptions);
+        _jobControlOptions = [.. jobControlOptions];
+        return this;
+    }
+
+    /// <summary>
+    /// Overrides the advertised output transmission options.
+    /// </summary>
+    /// <param name="outputTransmission">Output transmission identifiers.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder WithOutputTransmission(params string[] outputTransmission)
+    {
+        ArgumentNullException.ThrowIfNull(outputTransmission);
+        _outputTransmission = [.. outputTransmission];
+        return this;
+    }
+
+    /// <summary>
+    /// Declares an input parameter.
+    /// </summary>
+    /// <param name="name">Parameter name (the key used in step inputs).</param>
+    /// <param name="valueType">Parameter value type.</param>
+    /// <param name="configure">Optional configuration for the parameter.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder AddInput(
+        string name,
+        HonuaProcessParameterValueType valueType,
+        Action<HonuaProcessParameterBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (_parameters.Exists(p => string.Equals(p.Name, name, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException($"Input '{name}' is already declared.");
+        }
+
+        var parameterBuilder = new HonuaProcessParameterBuilder(name, valueType);
+        configure?.Invoke(parameterBuilder);
+        _parameters.Add(parameterBuilder.Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Declares an output artifact.
+    /// </summary>
+    /// <param name="name">Output name (the result document key).</param>
+    /// <param name="artifactKind">Artifact kind the output produces.</param>
+    /// <param name="configure">Optional configuration for the output.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessBuilder AddOutput(
+        string name,
+        HonuaProcessArtifactKind artifactKind,
+        Action<HonuaProcessOutputBuilder>? configure = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (_outputs.Exists(o => string.Equals(o.Name, name, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException($"Output '{name}' is already declared.");
+        }
+
+        var outputBuilder = new HonuaProcessOutputBuilder(name, artifactKind);
+        configure?.Invoke(outputBuilder);
+        _outputs.Add(outputBuilder.Build());
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the immutable process definition.
+    /// </summary>
+    /// <returns>The authored process definition.</returns>
+    public HonuaProcessDefinition Build() => new()
+    {
+        ProcessId = _processId,
+        Title = _title,
+        Description = _description,
+        Version = _version,
+        Category = _category,
+        RuntimeProfile = _runtimeProfile,
+        JobControlOptions = _jobControlOptions ?? ["async-execute"],
+        OutputTransmission = _outputTransmission ?? ["value"],
+        Parameters = [.. _parameters],
+        Outputs = [.. _outputs]
+    };
+}
+
+/// <summary>
+/// Fluent builder for a single process input parameter.
+/// </summary>
+public sealed class HonuaProcessParameterBuilder
+{
+    private readonly string _name;
+    private readonly HonuaProcessParameterValueType _valueType;
+    private string? _displayName;
+    private string _description = string.Empty;
+    private bool _required;
+    private string? _defaultValue;
+    private List<string>? _allowedValues;
+
+    internal HonuaProcessParameterBuilder(string name, HonuaProcessParameterValueType valueType)
+    {
+        _name = name;
+        _valueType = valueType;
+    }
+
+    /// <summary>Sets the operator-facing display name.</summary>
+    /// <param name="displayName">Display name.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessParameterBuilder WithDisplayName(string displayName)
+    {
+        _displayName = displayName;
+        return this;
+    }
+
+    /// <summary>Sets the parameter description.</summary>
+    /// <param name="description">Description.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessParameterBuilder WithDescription(string description)
+    {
+        _description = description ?? string.Empty;
+        return this;
+    }
+
+    /// <summary>Marks the parameter as required.</summary>
+    /// <param name="required">Whether the parameter is required.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessParameterBuilder Required(bool required = true)
+    {
+        _required = required;
+        return this;
+    }
+
+    /// <summary>Sets a default value.</summary>
+    /// <param name="defaultValue">Default value rendered as a string.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessParameterBuilder WithDefault(string defaultValue)
+    {
+        _defaultValue = defaultValue;
+        return this;
+    }
+
+    /// <summary>Restricts the parameter to an enumeration of allowed values.</summary>
+    /// <param name="allowedValues">Allowed values.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessParameterBuilder WithAllowedValues(params string[] allowedValues)
+    {
+        ArgumentNullException.ThrowIfNull(allowedValues);
+        _allowedValues = [.. allowedValues];
+        return this;
+    }
+
+    internal HonuaProcessParameter Build() => new()
+    {
+        Name = _name,
+        ValueType = _valueType,
+        DisplayName = _displayName,
+        Description = _description,
+        Required = _required,
+        DefaultValue = _defaultValue,
+        AllowedValues = _allowedValues is null ? null : [.. _allowedValues]
+    };
+}
+
+/// <summary>
+/// Fluent builder for a single process output.
+/// </summary>
+public sealed class HonuaProcessOutputBuilder
+{
+    private readonly string _name;
+    private readonly HonuaProcessArtifactKind _artifactKind;
+    private string? _displayName;
+    private string _description = string.Empty;
+
+    internal HonuaProcessOutputBuilder(string name, HonuaProcessArtifactKind artifactKind)
+    {
+        _name = name;
+        _artifactKind = artifactKind;
+    }
+
+    /// <summary>Sets the operator-facing display name.</summary>
+    /// <param name="displayName">Display name.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessOutputBuilder WithDisplayName(string displayName)
+    {
+        _displayName = displayName;
+        return this;
+    }
+
+    /// <summary>Sets the output description.</summary>
+    /// <param name="description">Description.</param>
+    /// <returns>The same builder.</returns>
+    public HonuaProcessOutputBuilder WithDescription(string description)
+    {
+        _description = description ?? string.Empty;
+        return this;
+    }
+
+    internal HonuaProcessOutput Build() => new()
+    {
+        Name = _name,
+        ArtifactKind = _artifactKind,
+        DisplayName = _displayName,
+        Description = _description
+    };
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessDefinition.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessDefinition.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Processes.Models;
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// A process definition authored in C#. Produced by <see cref="HonuaProcessBuilder"/> and
+/// projected to the server's OGC API Processes description format via
+/// <see cref="ToOgcDescription"/>.
+/// </summary>
+public sealed record HonuaProcessDefinition
+{
+    /// <summary>
+    /// Stable process identifier, for example <c>geometry.buffer</c>.
+    /// </summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>
+    /// Operator-facing title.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Process description.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Process version. Defaults to <c>1.0.0</c>.
+    /// </summary>
+    public string Version { get; init; } = "1.0.0";
+
+    /// <summary>
+    /// Process category, for example <c>geometry</c>.
+    /// </summary>
+    public string? Category { get; init; }
+
+    /// <summary>
+    /// Runtime profile the process executes under, for example <c>managed</c> or <c>native</c>.
+    /// </summary>
+    public string RuntimeProfile { get; init; } = "managed";
+
+    /// <summary>
+    /// Supported job control options, defaulting to <c>async-execute</c>.
+    /// </summary>
+    public IReadOnlyList<string> JobControlOptions { get; init; } = ["async-execute"];
+
+    /// <summary>
+    /// Supported output transmission options, defaulting to <c>value</c>.
+    /// </summary>
+    public IReadOnlyList<string> OutputTransmission { get; init; } = ["value"];
+
+    /// <summary>
+    /// Declared input parameters in declaration order.
+    /// </summary>
+    public IReadOnlyList<HonuaProcessParameter> Parameters { get; init; } = [];
+
+    /// <summary>
+    /// Declared output artifacts in declaration order.
+    /// </summary>
+    public IReadOnlyList<HonuaProcessOutput> Outputs { get; init; } = [];
+
+    /// <summary>
+    /// Projects this authored definition to the server's OGC API Processes description
+    /// shape (the body served at <c>GET /ogc/processes/processes/{id}</c>).
+    /// </summary>
+    /// <returns>An OGC-shaped process description.</returns>
+    public HonuaProcessDescription ToOgcDescription()
+    {
+        var inputs = new Dictionary<string, HonuaProcessInputDescription>(StringComparer.Ordinal);
+        foreach (var parameter in Parameters)
+        {
+            inputs[parameter.Name] = new HonuaProcessInputDescription
+            {
+                Title = parameter.DisplayName ?? parameter.Name,
+                Description = string.IsNullOrEmpty(parameter.Description) ? null : parameter.Description,
+                Schema = parameter.ToSchema()
+            };
+        }
+
+        var outputs = new Dictionary<string, HonuaProcessOutputDescription>(StringComparer.Ordinal);
+        foreach (var output in Outputs)
+        {
+            outputs[output.Name] = new HonuaProcessOutputDescription
+            {
+                Title = output.DisplayName ?? output.Name,
+                Description = string.IsNullOrEmpty(output.Description) ? null : output.Description,
+                Schema = output.ToSchema()
+            };
+        }
+
+        return new HonuaProcessDescription
+        {
+            Id = ProcessId,
+            Title = Title,
+            Description = string.IsNullOrEmpty(Description) ? null : Description,
+            Version = Version,
+            JobControlOptions = [.. JobControlOptions],
+            OutputTransmission = [.. OutputTransmission],
+            Inputs = inputs,
+            Outputs = outputs
+        };
+    }
+}
+
+/// <summary>
+/// A single declared process input parameter.
+/// </summary>
+public sealed record HonuaProcessParameter
+{
+    /// <summary>
+    /// Parameter name. This is the key callers supply in step inputs.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Parameter value type, which drives the generated JSON Schema.
+    /// </summary>
+    public required HonuaProcessParameterValueType ValueType { get; init; }
+
+    /// <summary>
+    /// Operator-facing display name.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Parameter description.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether the parameter is required.
+    /// </summary>
+    public bool Required { get; init; }
+
+    /// <summary>
+    /// Optional default value rendered as a string.
+    /// </summary>
+    public string? DefaultValue { get; init; }
+
+    /// <summary>
+    /// Optional enumeration of allowed string values.
+    /// </summary>
+    public IReadOnlyList<string>? AllowedValues { get; init; }
+
+    /// <summary>
+    /// Projects this parameter to an OGC/JSON Schema fragment.
+    /// </summary>
+    /// <returns>The schema fragment for this parameter.</returns>
+    public HonuaProcessIoSchema ToSchema() => HonuaProcessSchemaFactory.ForValueType(ValueType);
+}
+
+/// <summary>
+/// A single declared process output.
+/// </summary>
+public sealed record HonuaProcessOutput
+{
+    /// <summary>
+    /// Output name, used as the output identifier in result documents.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Artifact kind this output produces, which drives the generated JSON Schema.
+    /// </summary>
+    public required HonuaProcessArtifactKind ArtifactKind { get; init; }
+
+    /// <summary>
+    /// Operator-facing display name.
+    /// </summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>
+    /// Output description.
+    /// </summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Projects this output to an OGC/JSON Schema fragment.
+    /// </summary>
+    /// <returns>The schema fragment for this output.</returns>
+    public HonuaProcessIoSchema ToSchema() => HonuaProcessSchemaFactory.ForArtifactKind(ArtifactKind);
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessExecutor.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessExecutor.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Authoring-side contract for a Honua geoprocessing process. Mirrors the server's
+/// <c>IJobExecutor</c> contract so logic written and tested against this SDK ports
+/// directly into a server-hosted executor. Implementations receive flattened string
+/// inputs (matching <c>AnalysisPlanStep.Inputs</c>) and report progress, logs, and
+/// artifacts through the supplied context.
+/// </summary>
+public interface IHonuaProcessExecutor
+{
+    /// <summary>
+    /// The process id this executor handles, for example <c>geometry.buffer</c>.
+    /// </summary>
+    string ProcessId { get; }
+
+    /// <summary>
+    /// Executes the process against the supplied job inputs.
+    /// </summary>
+    /// <param name="job">The job inputs and metadata.</param>
+    /// <param name="context">Execution context for progress, logging, and artifacts.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The terminal execution result.</returns>
+    Task<HonuaProcessJobResult> ExecuteAsync(
+        HonuaProcessJobInput job,
+        IHonuaProcessExecutionContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Job inputs handed to an <see cref="IHonuaProcessExecutor"/>.
+/// </summary>
+public sealed record HonuaProcessJobInput
+{
+    /// <summary>
+    /// Job identifier.
+    /// </summary>
+    public required string JobId { get; init; }
+
+    /// <summary>
+    /// Process id being executed.
+    /// </summary>
+    public required string ProcessId { get; init; }
+
+    /// <summary>
+    /// Flattened string parameters, matching the server's job parameter contract.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Gets a required parameter, throwing when it is missing.
+    /// </summary>
+    /// <param name="name">Parameter name.</param>
+    /// <returns>The parameter value.</returns>
+    public string GetRequired(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (!Parameters.TryGetValue(name, out var value))
+        {
+            throw new KeyNotFoundException($"Required parameter '{name}' was not supplied.");
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Gets an optional parameter, or <paramref name="fallback"/> when missing.
+    /// </summary>
+    /// <param name="name">Parameter name.</param>
+    /// <param name="fallback">Fallback value.</param>
+    /// <returns>The parameter value or the fallback.</returns>
+    public string? GetOptional(string name, string? fallback = null)
+        => Parameters.TryGetValue(name, out var value) ? value : fallback;
+}
+
+/// <summary>
+/// Terminal status of a process execution.
+/// </summary>
+public enum HonuaProcessJobState
+{
+    /// <summary>Execution completed successfully.</summary>
+    Succeeded,
+
+    /// <summary>Execution failed.</summary>
+    Failed,
+
+    /// <summary>Execution was cancelled.</summary>
+    Cancelled
+}
+
+/// <summary>
+/// Terminal result of an <see cref="IHonuaProcessExecutor"/> execution.
+/// </summary>
+public sealed record HonuaProcessJobResult
+{
+    /// <summary>
+    /// Terminal job state.
+    /// </summary>
+    public required HonuaProcessJobState State { get; init; }
+
+    /// <summary>
+    /// Optional error message for failed jobs.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Warnings emitted during execution.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Output values keyed by output identifier, mirroring document-mode results.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Outputs { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Creates a successful result.
+    /// </summary>
+    /// <param name="outputs">Optional output values.</param>
+    /// <returns>A successful result.</returns>
+    public static HonuaProcessJobResult Success(IReadOnlyDictionary<string, string>? outputs = null) => new()
+    {
+        State = HonuaProcessJobState.Succeeded,
+        Outputs = outputs ?? new Dictionary<string, string>(StringComparer.Ordinal)
+    };
+
+    /// <summary>
+    /// Creates a failed result.
+    /// </summary>
+    /// <param name="errorMessage">Failure message.</param>
+    /// <returns>A failed result.</returns>
+    public static HonuaProcessJobResult Failure(string errorMessage) => new()
+    {
+        State = HonuaProcessJobState.Failed,
+        ErrorMessage = errorMessage
+    };
+}
+
+/// <summary>
+/// Execution context surfaced to an <see cref="IHonuaProcessExecutor"/>.
+/// </summary>
+public interface IHonuaProcessExecutionContext
+{
+    /// <summary>
+    /// The job identifier currently executing.
+    /// </summary>
+    string JobId { get; }
+
+    /// <summary>
+    /// Reports execution progress.
+    /// </summary>
+    /// <param name="percentComplete">Optional completion percentage (0-100).</param>
+    /// <param name="phase">Optional phase description.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the progress is recorded.</returns>
+    Task ReportProgressAsync(double? percentComplete, string? phase, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Appends a log entry.
+    /// </summary>
+    /// <param name="message">Log message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the message is recorded.</returns>
+    Task AppendLogAsync(string message, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Publishes a produced artifact reference.
+    /// </summary>
+    /// <param name="artifactReference">Artifact reference (URI, layer id, or data URI).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the artifact is recorded.</returns>
+    Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessParameterValueType.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessParameterValueType.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Value types a Honua geoprocessing process parameter can declare. These mirror the
+/// server-side <c>ProcessParameterValueType</c> contract and determine how each parameter
+/// is projected into an OGC API Processes JSON Schema fragment.
+/// </summary>
+public enum HonuaProcessParameterValueType
+{
+    /// <summary>Free-form text value.</summary>
+    Text,
+
+    /// <summary>Integral whole number.</summary>
+    WholeNumber,
+
+    /// <summary>Floating-point number.</summary>
+    FloatingPoint,
+
+    /// <summary>Boolean flag.</summary>
+    Flag,
+
+    /// <summary>Well-known binary geometry encoded as a string.</summary>
+    Wkb,
+
+    /// <summary>Array of well-known binary geometries.</summary>
+    WkbArray,
+
+    /// <summary>Spatial reference identifier.</summary>
+    Srid,
+
+    /// <summary>Honua layer identifier.</summary>
+    LayerId
+}
+
+/// <summary>
+/// Output artifact kinds a process can declare it produces. Mirrors the server-side
+/// <c>ArtifactKind</c> contract.
+/// </summary>
+public enum HonuaProcessArtifactKind
+{
+    /// <summary>A single scalar value.</summary>
+    Scalar,
+
+    /// <summary>A feature layer.</summary>
+    FeatureLayer,
+
+    /// <summary>A tabular result.</summary>
+    Table,
+
+    /// <summary>A raster dataset.</summary>
+    Raster,
+
+    /// <summary>An opaque file.</summary>
+    File,
+
+    /// <summary>A rendered report.</summary>
+    Report,
+
+    /// <summary>A rendered map.</summary>
+    Map,
+
+    /// <summary>A packaged application bundle.</summary>
+    AppBundle
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessSchemaFactory.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessSchemaFactory.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Processes.Models;
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// Maps authoring value types and artifact kinds onto OGC API Processes JSON Schema
+/// fragments, matching the shapes the Honua Server emits in its process descriptions.
+/// </summary>
+internal static class HonuaProcessSchemaFactory
+{
+    private const string WkbMediaType = "application/wkb";
+
+    /// <summary>
+    /// Builds the JSON Schema fragment for an input parameter value type.
+    /// </summary>
+    /// <param name="valueType">The parameter value type.</param>
+    /// <returns>The schema fragment.</returns>
+    public static HonuaProcessIoSchema ForValueType(HonuaProcessParameterValueType valueType) => valueType switch
+    {
+        HonuaProcessParameterValueType.Text => new HonuaProcessIoSchema { Type = "string" },
+        HonuaProcessParameterValueType.WholeNumber => new HonuaProcessIoSchema { Type = "integer" },
+        HonuaProcessParameterValueType.FloatingPoint => new HonuaProcessIoSchema { Type = "number" },
+        HonuaProcessParameterValueType.Flag => new HonuaProcessIoSchema { Type = "boolean" },
+        HonuaProcessParameterValueType.Wkb => new HonuaProcessIoSchema { Type = "string", ContentMediaType = WkbMediaType },
+        HonuaProcessParameterValueType.WkbArray => new HonuaProcessIoSchema { Type = "array", ContentMediaType = WkbMediaType },
+        HonuaProcessParameterValueType.Srid => new HonuaProcessIoSchema { Type = "integer" },
+        HonuaProcessParameterValueType.LayerId => new HonuaProcessIoSchema { Type = "string" },
+        _ => new HonuaProcessIoSchema { Type = "string" }
+    };
+
+    /// <summary>
+    /// Builds the JSON Schema fragment for an output artifact kind.
+    /// </summary>
+    /// <param name="artifactKind">The artifact kind.</param>
+    /// <returns>The schema fragment.</returns>
+    public static HonuaProcessIoSchema ForArtifactKind(HonuaProcessArtifactKind artifactKind) => artifactKind switch
+    {
+        HonuaProcessArtifactKind.Scalar => new HonuaProcessIoSchema { Type = "string" },
+        _ => new HonuaProcessIoSchema { Type = "object" }
+    };
+}

--- a/src/Honua.Sdk.Processes/Authoring/HonuaProcessTestHarness.cs
+++ b/src/Honua.Sdk.Processes/Authoring/HonuaProcessTestHarness.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Sdk.Processes.Models;
+
+namespace Honua.Sdk.Processes.Authoring;
+
+/// <summary>
+/// In-process test harness for authoring and unit-testing an <see cref="IHonuaProcessExecutor"/>
+/// without a running Honua Server. The harness validates supplied inputs against the process
+/// definition (when one is provided), drives the executor with a capturing context, and returns
+/// the result alongside captured progress, logs, and artifacts.
+/// </summary>
+public sealed class HonuaProcessTestHarness
+{
+    private readonly IHonuaProcessExecutor _executor;
+    private readonly HonuaProcessDefinition? _definition;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaProcessTestHarness"/> class.
+    /// </summary>
+    /// <param name="executor">The executor under test.</param>
+    /// <param name="definition">
+    /// Optional process definition. When supplied, required-input validation runs before execution.
+    /// </param>
+    public HonuaProcessTestHarness(IHonuaProcessExecutor executor, HonuaProcessDefinition? definition = null)
+    {
+        ArgumentNullException.ThrowIfNull(executor);
+        if (definition is not null
+            && !string.Equals(definition.ProcessId, executor.ProcessId, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Definition process id '{definition.ProcessId}' does not match executor process id '{executor.ProcessId}'.",
+                nameof(definition));
+        }
+
+        _executor = executor;
+        _definition = definition;
+    }
+
+    /// <summary>
+    /// Runs the executor against the supplied parameters.
+    /// </summary>
+    /// <param name="parameters">Flattened string parameters.</param>
+    /// <param name="jobId">Optional job id; a deterministic test id is used when omitted.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The captured run, including the terminal result.</returns>
+    public async Task<HonuaProcessHarnessRun> RunAsync(
+        IReadOnlyDictionary<string, string> parameters,
+        string? jobId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+
+        var effectiveJobId = string.IsNullOrWhiteSpace(jobId) ? "harness-job" : jobId;
+        var missing = FindMissingRequiredInputs(parameters);
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Missing required inputs for process '{_executor.ProcessId}': {string.Join(", ", missing)}.");
+        }
+
+        var input = new HonuaProcessJobInput
+        {
+            JobId = effectiveJobId,
+            ProcessId = _executor.ProcessId,
+            Parameters = new Dictionary<string, string>(parameters, StringComparer.Ordinal)
+        };
+
+        var context = new CapturingExecutionContext(effectiveJobId);
+        var result = await _executor.ExecuteAsync(input, context, cancellationToken).ConfigureAwait(false);
+
+        return new HonuaProcessHarnessRun
+        {
+            Result = result,
+            Logs = context.Logs,
+            Artifacts = context.Artifacts,
+            Progress = context.Progress
+        };
+    }
+
+    /// <summary>
+    /// Runs the executor against inputs taken from an authored analysis-plan step.
+    /// </summary>
+    /// <param name="step">The plan step supplying the inputs.</param>
+    /// <param name="jobId">Optional job id.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The captured run.</returns>
+    public Task<HonuaProcessHarnessRun> RunAsync(
+        HonuaPlanStep step,
+        string? jobId = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        return RunAsync(step.Inputs, jobId ?? step.StepId, cancellationToken);
+    }
+
+    private List<string> FindMissingRequiredInputs(IReadOnlyDictionary<string, string> parameters)
+    {
+        var missing = new List<string>();
+        if (_definition is null)
+        {
+            return missing;
+        }
+
+        foreach (var parameter in _definition.Parameters)
+        {
+            if (parameter.Required && !parameters.ContainsKey(parameter.Name))
+            {
+                missing.Add(parameter.Name);
+            }
+        }
+
+        return missing;
+    }
+
+    private sealed class CapturingExecutionContext : IHonuaProcessExecutionContext
+    {
+        private readonly List<string> _logs = [];
+        private readonly List<string> _artifacts = [];
+        private readonly List<HonuaProcessHarnessProgress> _progress = [];
+
+        public CapturingExecutionContext(string jobId) => JobId = jobId;
+
+        public string JobId { get; }
+
+        public IReadOnlyList<string> Logs => _logs;
+
+        public IReadOnlyList<string> Artifacts => _artifacts;
+
+        public IReadOnlyList<HonuaProcessHarnessProgress> Progress => _progress;
+
+        public Task ReportProgressAsync(double? percentComplete, string? phase, CancellationToken cancellationToken = default)
+        {
+            _progress.Add(new HonuaProcessHarnessProgress
+            {
+                PercentComplete = percentComplete,
+                Phase = phase
+            });
+            return Task.CompletedTask;
+        }
+
+        public Task AppendLogAsync(string message, CancellationToken cancellationToken = default)
+        {
+            _logs.Add(message ?? string.Empty);
+            return Task.CompletedTask;
+        }
+
+        public Task PublishArtifactAsync(string artifactReference, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(artifactReference);
+            _artifacts.Add(artifactReference);
+            return Task.CompletedTask;
+        }
+    }
+}
+
+/// <summary>
+/// The captured outcome of a <see cref="HonuaProcessTestHarness"/> run.
+/// </summary>
+public sealed record HonuaProcessHarnessRun
+{
+    /// <summary>
+    /// The terminal execution result.
+    /// </summary>
+    public required HonuaProcessJobResult Result { get; init; }
+
+    /// <summary>
+    /// Log messages captured during execution.
+    /// </summary>
+    public IReadOnlyList<string> Logs { get; init; } = [];
+
+    /// <summary>
+    /// Artifact references published during execution.
+    /// </summary>
+    public IReadOnlyList<string> Artifacts { get; init; } = [];
+
+    /// <summary>
+    /// Progress reports captured during execution.
+    /// </summary>
+    public IReadOnlyList<HonuaProcessHarnessProgress> Progress { get; init; } = [];
+
+    /// <summary>
+    /// Whether the run succeeded.
+    /// </summary>
+    public bool Succeeded => Result.State == HonuaProcessJobState.Succeeded;
+
+    /// <summary>
+    /// Renders a single-line summary suitable for test diagnostics.
+    /// </summary>
+    /// <returns>A diagnostic summary.</returns>
+    public override string ToString()
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Result.State} (logs={Logs.Count}, artifacts={Artifacts.Count}, progress={Progress.Count})");
+}
+
+/// <summary>
+/// A single captured progress report.
+/// </summary>
+public sealed record HonuaProcessHarnessProgress
+{
+    /// <summary>
+    /// Reported completion percentage, when supplied.
+    /// </summary>
+    public double? PercentComplete { get; init; }
+
+    /// <summary>
+    /// Reported phase description, when supplied.
+    /// </summary>
+    public string? Phase { get; init; }
+}

--- a/src/Honua.Sdk.Processes/README.md
+++ b/src/Honua.Sdk.Processes/README.md
@@ -109,3 +109,41 @@ var bufferJob = await processes.SubmitJobAsync(
 Non-success responses throw `HonuaProcessesException`. When the server returns
 problem-details JSON, the exception preserves `StatusCode`, `ProblemType`,
 `ProblemTitle`, `ProblemDetail`, and the raw `ResponseBody`.
+
+## Authoring processes and plans
+
+The `Honua.Sdk.Processes.Authoring` namespace adds a fluent API for authoring
+Honua geoprocessing processes in C# and unit-testing executor logic locally,
+without a running server.
+
+```csharp
+using Honua.Sdk.Processes.Authoring;
+
+// Describe a process for the catalog.
+var definition = HonuaProcessAuthoring.DefineProcess("geometry.buffer")
+    .WithTitle("Buffer")
+    .AddInput("wkb", HonuaProcessParameterValueType.Wkb, p => p.Required())
+    .AddInput("distance", HonuaProcessParameterValueType.FloatingPoint, p => p.Required())
+    .AddOutput("outputFeatureLayer", HonuaProcessArtifactKind.FeatureLayer)
+    .Build();
+
+var ogcDescription = definition.ToOgcDescription(); // server process-description shape
+
+// Author a multi-step plan for the canonical honua-geoprocessing process.
+var request = HonuaProcessAuthoring.DefinePlan("plan-1")
+    .AddGeoprocessStep("buffer", "geometry.buffer", s => s.WithInput("distance", 100))
+    .BuildExecuteRequest();
+
+// Unit-test an IHonuaProcessExecutor in-process.
+var harness = new HonuaProcessTestHarness(myExecutor, definition);
+var run = await harness.RunAsync(new Dictionary<string, string>
+{
+    ["wkb"] = "AAAA",
+    ["distance"] = "100",
+});
+Assert.True(run.Succeeded);
+```
+
+See [`docs/process-authoring.md`](https://github.com/honua-io/honua-sdk-dotnet/blob/trunk/docs/process-authoring.md)
+for the full guide, including the ArcObjects/ArcPy GP migration mapping and the
+federate-bridge approach.

--- a/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaAnalysisPlanBuilderTests.cs
+++ b/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaAnalysisPlanBuilderTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Processes.Authoring;
+
+namespace Honua.Sdk.Processes.Tests.Authoring;
+
+public sealed class HonuaAnalysisPlanBuilderTests
+{
+    [Fact]
+    public void BuildExecuteRequest_SerializesCanonicalPlanShape()
+    {
+        var request = HonuaProcessAuthoring.DefinePlan("plan-1")
+            .WithWorkflowFamily("analyze")
+            .WithOutputs("featureLayer")
+            .AddGeoprocessStep("buffer", "geometry.buffer", step => step
+                .WithInput("wkb", "AAAA")
+                .WithInput("srid", 4326)
+                .WithInput("distance", 25.5))
+            .BuildExecuteRequest();
+
+        var json = JsonSerializer.Serialize(request, ProcessesJsonContext.Default.HonuaProcessExecuteRequest);
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal("document", root.GetProperty("response").GetString());
+        var plan = root.GetProperty("inputs").GetProperty("plan");
+        Assert.Equal("plan-1", plan.GetProperty("planId").GetString());
+        Assert.Equal("analyze", plan.GetProperty("workflowFamily").GetString());
+        Assert.Equal("featureLayer", plan.GetProperty("outputs")[0].GetString());
+
+        var step = plan.GetProperty("steps")[0];
+        Assert.Equal("buffer", step.GetProperty("stepId").GetString());
+        Assert.Equal("geoprocess", step.GetProperty("kind").GetString());
+        Assert.Equal("geometry.buffer", step.GetProperty("processId").GetString());
+        Assert.Equal("AAAA", step.GetProperty("inputs").GetProperty("wkb").GetString());
+        Assert.Equal("4326", step.GetProperty("inputs").GetProperty("srid").GetString());
+        Assert.Equal("25.5", step.GetProperty("inputs").GetProperty("distance").GetString());
+    }
+
+    [Fact]
+    public void Build_PreservesStepDependencies()
+    {
+        var plan = HonuaProcessAuthoring.DefinePlan("plan-dag")
+            .AddStep("query", "queryFeatures", s => s.WithInput("layerId", "parcels"))
+            .AddGeoprocessStep("buffer", "geometry.buffer", s => s
+                .WithInput("distance", "100")
+                .DependsOn("query"))
+            .Build();
+
+        Assert.Equal(2, plan.Steps.Count);
+        Assert.Equal("query", plan.Steps[1].DependsOn.Single());
+    }
+
+    [Fact]
+    public void Build_RejectsUnknownDependency()
+    {
+        var builder = HonuaProcessAuthoring.DefinePlan("plan-bad")
+            .AddGeoprocessStep("buffer", "geometry.buffer", s => s.DependsOn("missing"));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Contains("missing", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddStep_RejectsDuplicateStepIds()
+    {
+        var builder = HonuaProcessAuthoring.DefinePlan("plan-dup")
+            .AddStep("s", "queryFeatures");
+
+        Assert.Throws<InvalidOperationException>(() => builder.AddStep("s", "geoprocess"));
+    }
+
+    [Fact]
+    public void Build_RejectsSelfDependency()
+    {
+        var builder = HonuaProcessAuthoring.DefinePlan("plan-self")
+            .AddGeoprocessStep("s", "geometry.buffer", step => step.DependsOn("s"));
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+}

--- a/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaProcessBuilderTests.cs
+++ b/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaProcessBuilderTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.Processes.Authoring;
+using Honua.Sdk.Processes.Models;
+
+namespace Honua.Sdk.Processes.Tests.Authoring;
+
+public sealed class HonuaProcessBuilderTests
+{
+    [Fact]
+    public void Build_PopulatesDefinitionFields()
+    {
+        var definition = HonuaProcessAuthoring.DefineProcess("geometry.buffer")
+            .WithTitle("Buffer")
+            .WithDescription("Creates a polygon at a specified distance around each input geometry.")
+            .WithVersion("1.0.0")
+            .WithCategory("geometry")
+            .AddInput("wkb", HonuaProcessParameterValueType.Wkb, p => p
+                .WithDisplayName("Input Geometry")
+                .Required())
+            .AddInput("srid", HonuaProcessParameterValueType.Srid, p => p
+                .WithDisplayName("Spatial Reference")
+                .Required())
+            .AddInput("distance", HonuaProcessParameterValueType.FloatingPoint, p => p
+                .WithDisplayName("Buffer Distance")
+                .Required())
+            .AddInput("geodesic", HonuaProcessParameterValueType.Flag, p => p
+                .WithDisplayName("Geodesic")
+                .WithDefault("false"))
+            .AddOutput("outputFeatureLayer", HonuaProcessArtifactKind.FeatureLayer, o => o
+                .WithDisplayName("Output Feature Layer"))
+            .Build();
+
+        Assert.Equal("geometry.buffer", definition.ProcessId);
+        Assert.Equal("Buffer", definition.Title);
+        Assert.Equal("geometry", definition.Category);
+        Assert.Equal(4, definition.Parameters.Count);
+        Assert.Single(definition.Outputs);
+        Assert.Equal("wkb", definition.Parameters[0].Name);
+        Assert.True(definition.Parameters[0].Required);
+        Assert.False(definition.Parameters[3].Required);
+        Assert.Equal("false", definition.Parameters[3].DefaultValue);
+    }
+
+    [Fact]
+    public void ToOgcDescription_RoundTripsThroughProcessesJsonContext()
+    {
+        var definition = HonuaProcessAuthoring.DefineProcess("geometry.buffer")
+            .WithTitle("Buffer")
+            .WithDescription("Creates a polygon at a specified distance around each input geometry.")
+            .AddInput("wkb", HonuaProcessParameterValueType.Wkb, p => p.WithDisplayName("Input Geometry").Required())
+            .AddInput("srid", HonuaProcessParameterValueType.Srid, p => p.WithDisplayName("Spatial Reference").Required())
+            .AddInput("distance", HonuaProcessParameterValueType.FloatingPoint, p => p.WithDisplayName("Buffer Distance").Required())
+            .AddOutput("outputFeatureLayer", HonuaProcessArtifactKind.FeatureLayer, o => o.WithDisplayName("Output Feature Layer"))
+            .Build();
+
+        var ogc = definition.ToOgcDescription();
+        var json = JsonSerializer.Serialize(ogc, ProcessesJsonContext.Default.HonuaProcessDescription);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal("geometry.buffer", root.GetProperty("id").GetString());
+        Assert.Equal("Buffer", root.GetProperty("title").GetString());
+        Assert.Equal("1.0.0", root.GetProperty("version").GetString());
+        Assert.Equal("async-execute", root.GetProperty("jobControlOptions")[0].GetString());
+        Assert.Equal("value", root.GetProperty("outputTransmission")[0].GetString());
+
+        var wkb = root.GetProperty("inputs").GetProperty("wkb");
+        Assert.Equal("Input Geometry", wkb.GetProperty("title").GetString());
+        Assert.Equal("string", wkb.GetProperty("schema").GetProperty("type").GetString());
+        Assert.Equal("application/wkb", wkb.GetProperty("schema").GetProperty("contentMediaType").GetString());
+
+        Assert.Equal("integer", root.GetProperty("inputs").GetProperty("srid").GetProperty("schema").GetProperty("type").GetString());
+        Assert.Equal("number", root.GetProperty("inputs").GetProperty("distance").GetProperty("schema").GetProperty("type").GetString());
+        Assert.Equal("object", root.GetProperty("outputs").GetProperty("outputFeatureLayer").GetProperty("schema").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void ToOgcDescription_DeserializesBackToEquivalentDescription()
+    {
+        var definition = HonuaProcessAuthoring.DefineProcess("vector.dissolve")
+            .WithTitle("Dissolve")
+            .AddInput("layerId", HonuaProcessParameterValueType.LayerId, p => p.Required())
+            .AddInput("field", HonuaProcessParameterValueType.Text)
+            .AddOutput("result", HonuaProcessArtifactKind.FeatureLayer)
+            .Build();
+
+        var json = JsonSerializer.Serialize(definition.ToOgcDescription(), ProcessesJsonContext.Default.HonuaProcessDescription);
+        var restored = JsonSerializer.Deserialize(json, ProcessesJsonContext.Default.HonuaProcessDescription);
+
+        Assert.NotNull(restored);
+        Assert.Equal("vector.dissolve", restored!.Id);
+        Assert.Equal("Dissolve", restored.Title);
+        Assert.True(restored.Inputs.ContainsKey("layerId"));
+        Assert.True(restored.Inputs.ContainsKey("field"));
+        Assert.True(restored.Outputs.ContainsKey("result"));
+    }
+
+    [Fact]
+    public void AddInput_RejectsDuplicateNames()
+    {
+        var builder = HonuaProcessAuthoring.DefineProcess("p")
+            .AddInput("a", HonuaProcessParameterValueType.Text);
+
+        Assert.Throws<InvalidOperationException>(() => builder.AddInput("a", HonuaProcessParameterValueType.Text));
+    }
+
+    [Fact]
+    public void DefineProcess_RejectsBlankId()
+    {
+        Assert.Throws<ArgumentException>(() => HonuaProcessAuthoring.DefineProcess(" "));
+    }
+
+    [Theory]
+    [InlineData(HonuaProcessParameterValueType.Text, "string", null)]
+    [InlineData(HonuaProcessParameterValueType.WholeNumber, "integer", null)]
+    [InlineData(HonuaProcessParameterValueType.FloatingPoint, "number", null)]
+    [InlineData(HonuaProcessParameterValueType.Flag, "boolean", null)]
+    [InlineData(HonuaProcessParameterValueType.Wkb, "string", "application/wkb")]
+    [InlineData(HonuaProcessParameterValueType.WkbArray, "array", "application/wkb")]
+    [InlineData(HonuaProcessParameterValueType.Srid, "integer", null)]
+    [InlineData(HonuaProcessParameterValueType.LayerId, "string", null)]
+    public void Parameter_ProjectsExpectedSchema(
+        HonuaProcessParameterValueType valueType,
+        string expectedType,
+        string? expectedMediaType)
+    {
+        var schema = new HonuaProcessParameter { Name = "x", ValueType = valueType }.ToSchema();
+
+        Assert.Equal(expectedType, schema.Type);
+        Assert.Equal(expectedMediaType, schema.ContentMediaType);
+    }
+}

--- a/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaProcessTestHarnessTests.cs
+++ b/tests/Honua.Sdk.Processes.Tests/Authoring/HonuaProcessTestHarnessTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using Honua.Sdk.Processes.Authoring;
+
+namespace Honua.Sdk.Processes.Tests.Authoring;
+
+public sealed class HonuaProcessTestHarnessTests
+{
+    // A sample authored process: doubles a distance value and reports progress + an artifact.
+    private sealed class DoubleDistanceExecutor : IHonuaProcessExecutor
+    {
+        public string ProcessId => "sample.double-distance";
+
+        public async Task<HonuaProcessJobResult> ExecuteAsync(
+            HonuaProcessJobInput job,
+            IHonuaProcessExecutionContext context,
+            CancellationToken cancellationToken)
+        {
+            await context.ReportProgressAsync(0, "starting", cancellationToken);
+            await context.AppendLogAsync($"executing {job.ProcessId}", cancellationToken);
+
+            if (!double.TryParse(job.GetRequired("distance"), NumberStyles.Float, CultureInfo.InvariantCulture, out var distance))
+            {
+                return HonuaProcessJobResult.Failure("distance is not a number");
+            }
+
+            var doubled = (distance * 2).ToString(CultureInfo.InvariantCulture);
+            await context.PublishArtifactAsync($"data:text/plain,{doubled}", cancellationToken);
+            await context.ReportProgressAsync(100, "done", cancellationToken);
+
+            return HonuaProcessJobResult.Success(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["result"] = doubled
+            });
+        }
+    }
+
+    private static HonuaProcessDefinition SampleDefinition() =>
+        HonuaProcessAuthoring.DefineProcess("sample.double-distance")
+            .WithTitle("Double Distance")
+            .AddInput("distance", HonuaProcessParameterValueType.FloatingPoint, p => p.Required())
+            .AddOutput("result", HonuaProcessArtifactKind.Scalar)
+            .Build();
+
+    [Fact]
+    public async Task RunAsync_ExecutesAndCapturesContext()
+    {
+        var harness = new HonuaProcessTestHarness(new DoubleDistanceExecutor(), SampleDefinition());
+
+        var run = await harness.RunAsync(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["distance"] = "21"
+        });
+
+        Assert.True(run.Succeeded);
+        Assert.Equal("42", run.Result.Outputs["result"]);
+        Assert.Equal(2, run.Progress.Count);
+        Assert.Equal(100, run.Progress[^1].PercentComplete);
+        Assert.Single(run.Artifacts);
+        Assert.Contains("data:text/plain,42", run.Artifacts[0], StringComparison.Ordinal);
+        Assert.Contains(run.Logs, log => log.Contains("sample.double-distance", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidatesRequiredInputsAgainstDefinition()
+    {
+        var harness = new HonuaProcessTestHarness(new DoubleDistanceExecutor(), SampleDefinition());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => harness.RunAsync(new Dictionary<string, string>(StringComparer.Ordinal)));
+
+        Assert.Contains("distance", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RunAsync_SurfacesExecutorFailure()
+    {
+        var harness = new HonuaProcessTestHarness(new DoubleDistanceExecutor());
+
+        var run = await harness.RunAsync(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["distance"] = "not-a-number"
+        });
+
+        Assert.False(run.Succeeded);
+        Assert.Equal(HonuaProcessJobState.Failed, run.Result.State);
+        Assert.Equal("distance is not a number", run.Result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task RunAsync_AcceptsInputsFromAuthoredPlanStep()
+    {
+        var plan = HonuaProcessAuthoring.DefinePlan("plan-1")
+            .AddGeoprocessStep("double", "sample.double-distance", s => s.WithInput("distance", 5))
+            .Build();
+
+        var harness = new HonuaProcessTestHarness(new DoubleDistanceExecutor(), SampleDefinition());
+        var run = await harness.RunAsync(plan.Steps[0]);
+
+        Assert.True(run.Succeeded);
+        Assert.Equal("10", run.Result.Outputs["result"]);
+    }
+
+    [Fact]
+    public void Constructor_RejectsMismatchedDefinition()
+    {
+        var otherDefinition = HonuaProcessAuthoring.DefineProcess("other.process").Build();
+
+        Assert.Throws<ArgumentException>(
+            () => new HonuaProcessTestHarness(new DoubleDistanceExecutor(), otherDefinition));
+    }
+}


### PR DESCRIPTION
Implements #182 — a C# process-authoring SDK plus an ArcObjects/ArcPy GP -> Honua-process migration guide and federate-bridge doc.

## What this adds

A new `Honua.Sdk.Processes.Authoring` namespace so .NET developers can author Honua geoprocessing processes in C# and unit-test executor logic locally, without a running server.

**Authoring API**
- `HonuaProcessAuthoring.DefineProcess(...)` — fluent `HonuaProcessBuilder` building a `HonuaProcessDefinition` (id, title, description, version, category, runtime profile, typed inputs, output artifacts). `ToOgcDescription()` projects it to the server's OGC API Processes description shape (`GET /ogc/processes/processes/{id}`), with `HonuaProcessParameterValueType` mapping to matching JSON Schema fragments (e.g. `Wkb` -> `string` + `application/wkb`, `Srid` -> `integer`, `FloatingPoint` -> `number`).
- `HonuaProcessAuthoring.DefinePlan(...)` — `HonuaAnalysisPlanBuilder` authoring multi-step analysis plans (the DAG executed by the canonical `honua-geoprocessing` process). Validates `dependsOn` references and rejects duplicate/self-referential steps. `BuildExecuteRequest()` wraps the plan in a `HonuaProcessExecuteRequest` ready for `IHonuaProcessesClient.SubmitJobAsync`.

**Local test harness**
- `IHonuaProcessExecutor` mirrors the server's `IJobExecutor` contract so logic written against the SDK ports directly into a server-hosted executor.
- `HonuaProcessTestHarness` runs an executor in-process, validates required inputs against the definition, and captures progress, logs, and artifacts via a capturing `IHonuaProcessExecutionContext`.

**Docs**
- `docs/process-authoring.md` — authoring API + harness usage, the ArcObjects/ArcPy GP idiom -> Honua process mapping table (with a worked `arcpy.analysis.Buffer` example), and a federate-bridge section covering how to keep an existing compiled .NET GP service running behind Honua and migrate tool-by-tool. Notes the deferred-out codemod honestly.
- Wired into `docs/toc.yml` and the package `README.md`.

## Acceptance criteria
- A developer can author and test a Honua GP process in C# — `HonuaProcessBuilder` + `IHonuaProcessExecutor` + `HonuaProcessTestHarness`.
- ArcObjects GP idioms have a documented Honua mapping — `docs/process-authoring.md`.

## Testing
- 24 new tests in `tests/Honua.Sdk.Processes.Tests/Authoring/` (round-trip authored process -> OGC JSON via `ProcessesJsonContext`, plan-builder serialization, DAG validation, harness execution/validation/failure paths). Processes suite: 33 passing.
- Full solution builds clean with `TreatWarningsAsErrors=true` (AllEnabledByDefault analyzers); full test suite green.

Only additive public API plus docs — no existing signatures changed.

Closes #182.