### PR TITLE
feat(offline): scope extractChanges by server generation

### DIFF
--- a/src/Honua.Sdk.Abstractions/Offline/IReplicaSyncClient.cs
+++ b/src/Honua.Sdk.Abstractions/Offline/IReplicaSyncClient.cs
@@ -38,6 +38,33 @@ public interface IReplicaSyncClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Extracts feature changes (adds, updates, deletes) from the server, scoped to the changes
+    /// that occurred after the supplied server generation.
+    /// </summary>
+    /// <remarks>
+    /// The GeoServices replica protocol scopes <c>extractChanges</c> by the replica's last-known
+    /// server generation. Passing the persisted generation here yields only the delta since the
+    /// previous sync; omitting it (or using the parameterless overload) re-extracts the full change
+    /// set every run, which defeats delta sync. The default implementation delegates to the
+    /// generation-less overload for backward compatibility with existing implementations.
+    /// </remarks>
+    /// <param name="serviceId">The feature service identifier.</param>
+    /// <param name="replicaId">The replica ID obtained from <see cref="CreateReplicaAsync"/>.</param>
+    /// <param name="sinceServerGen">
+    /// The server generation the local replica last synchronized to, used as the lower bound
+    /// ("since") for the extract. When <see langword="null"/> or whitespace, the server returns
+    /// the full change set (equivalent to extracting from the replica's creation generation).
+    /// </param>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>Layer-level change sets and the current server generation number.</returns>
+    Task<ExtractChangesResult> ExtractChangesAsync(
+        string serviceId,
+        string replicaId,
+        string? sinceServerGen,
+        CancellationToken cancellationToken = default)
+        => ExtractChangesAsync(serviceId, replicaId, cancellationToken);
+
+    /// <summary>
     /// Acknowledges received changes and advances the replica's server generation number.
     /// </summary>
     /// <param name="serviceId">The feature service identifier.</param>

--- a/src/Honua.Sdk.Offline/ReplicaSyncClient.cs
+++ b/src/Honua.Sdk.Offline/ReplicaSyncClient.cs
@@ -60,9 +60,17 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
     }
 
     /// <inheritdoc />
+    public Task<ExtractChangesResult> ExtractChangesAsync(
+        string serviceId,
+        string replicaId,
+        CancellationToken cancellationToken = default)
+        => ExtractChangesAsync(serviceId, replicaId, sinceServerGen: null, cancellationToken);
+
+    /// <inheritdoc />
     public async Task<ExtractChangesResult> ExtractChangesAsync(
         string serviceId,
         string replicaId,
+        string? sinceServerGen,
         CancellationToken cancellationToken = default)
     {
         ValidateServiceId(serviceId);
@@ -72,6 +80,16 @@ public sealed class ReplicaSyncClient : IReplicaSyncClient
             ["replicaID"] = replicaId,
             ["f"] = "json",
         };
+
+        // Scope the extract to changes since the supplied server generation. The GeoServices
+        // replica protocol expects an array of per-layer generations; a single value is broadcast
+        // to all layers by the server. Without it the server returns the full change set every
+        // run, defeating delta sync.
+        if (!string.IsNullOrWhiteSpace(sinceServerGen))
+        {
+            parameters["serverGens"] = $"[{sinceServerGen}]";
+            parameters["replicaServerGen"] = sinceServerGen;
+        }
 
         using var doc = await PostAsync(url, parameters, cancellationToken).ConfigureAwait(false);
         var root = doc.RootElement;

--- a/tests/Honua.Sdk.Offline.Tests/ReplicaSyncClientTests.cs
+++ b/tests/Honua.Sdk.Offline.Tests/ReplicaSyncClientTests.cs
@@ -111,6 +111,54 @@ public sealed class ReplicaSyncClientTests
     }
 
     [Fact]
+    public async Task ExtractChangesAsync_WithServerGen_SendsServerGenParameters()
+    {
+        string? capturedBody = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            capturedBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"serverGen":70,"layerChanges":[]}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var client = new ReplicaSyncClient(new HttpClient(handler) { BaseAddress = new Uri("https://api.honua.test") });
+
+        await client.ExtractChangesAsync("assets", "replica-abc-123", "55");
+
+        Assert.NotNull(capturedBody);
+        // serverGens is URL-encoded ([55] -> %5B55%5D) and replicaServerGen carries the same value.
+        Assert.Contains("serverGens=%5B55%5D", capturedBody);
+        Assert.Contains("replicaServerGen=55", capturedBody);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ExtractChangesAsync_WithoutServerGen_OmitsServerGenParameters(string? serverGen)
+    {
+        string? capturedBody = null;
+        var handler = new StubHttpMessageHandler(async (request, cancellationToken) =>
+        {
+            capturedBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"serverGen":70,"layerChanges":[]}""", Encoding.UTF8, "application/json"),
+            };
+        });
+
+        var client = new ReplicaSyncClient(new HttpClient(handler) { BaseAddress = new Uri("https://api.honua.test") });
+
+        await client.ExtractChangesAsync("assets", "replica-abc-123", serverGen);
+
+        Assert.NotNull(capturedBody);
+        Assert.DoesNotContain("serverGens", capturedBody);
+        Assert.DoesNotContain("replicaServerGen", capturedBody);
+    }
+
+    [Fact]
     public async Task ExtractChangesAsync_EmptyChanges_ReturnsEmptyLayerChanges()
     {
         var responseJson = """


### PR DESCRIPTION
## Summary

Adds a server-generation-aware `ExtractChangesAsync` overload to `IReplicaSyncClient` / `ReplicaSyncClient` so delta sync can be scoped to changes since the last sync.

Previously `extractChanges` was always sent with only `replicaID` + `f=json` — no `serverGens`/`replicaServerGen`. In the GeoServices replica protocol `extractChanges` is scoped by the server generation; without it there is no "since" bound, so the server re-extracts the entire change set every run (or rejects the request on a strict server).

## Changes

- `IReplicaSyncClient`: new overload `ExtractChangesAsync(serviceId, replicaId, string? sinceServerGen, ct)`. It is a **default interface method** that delegates to the existing parameterless overload, so existing implementations stay source- and binary-compatible (apicompat passes — no breaking change, minor/`feat` bump).
- `ReplicaSyncClient`: the new overload sends `serverGens=[<gen>]` and `replicaServerGen=<gen>` when a non-empty generation is supplied; omits them otherwise (full extract). The original overload now delegates to it with `null`.
- Tests: asserts the generation params are sent when supplied and omitted for null/empty/whitespace.

## Validation

- `dotnet build` + `dotnet test tests/Honua.Sdk.Offline.Tests` — 38 passing.
- `scripts/validate-api-compat.sh` — `Honua.Sdk.Abstractions` reports "APICompat ran successfully without finding any breaking changes."
- `dotnet format` on `Honua.Sdk.Offline` and `Honua.Sdk.Abstractions` — clean.

Part of honua-io/honua-mobile#301. The consuming change in honua-mobile depends on this shipping as the next SDK package release (1.3.0).