### PR TITLE
Fix FeatureStreamEventBuffer completion/backpressure deadlocks (#201)

### DIFF
--- a/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventBuffer.cs
+++ b/src/Honua.Sdk.Abstractions/Features/FeatureStreamEventBuffer.cs
@@ -59,6 +59,7 @@ public sealed class FeatureStreamEventBuffer : IDisposable
     private readonly SemaphoreSlim _space;
     private readonly object _gate = new();
     private bool _completed;
+    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FeatureStreamEventBuffer"/> class.
@@ -71,7 +72,12 @@ public sealed class FeatureStreamEventBuffer : IDisposable
     {
         _options = NormalizeOptions(options);
         _processor = processor;
-        _space = new SemaphoreSlim(_options.Capacity, _options.Capacity);
+
+        // No maximum count: completion uses a baton-passing _space.Release() to wake parked
+        // writers, which can transiently leave the available-slot count above capacity. A bounded
+        // semaphore would throw SemaphoreFullException; capacity is still enforced by the queue
+        // and the matched acquire/release accounting on the write/dequeue paths.
+        _space = new SemaphoreSlim(_options.Capacity);
     }
 
     /// <summary>
@@ -100,6 +106,31 @@ public sealed class FeatureStreamEventBuffer : IDisposable
                 };
             }
 
+            // In Wait mode the _space semaphore is the single source of truth for capacity:
+            // a non-blocking acquire both tests for free space and reserves it atomically,
+            // avoiding the divergence a separate _queue.Count pre-check could introduce under
+            // concurrent producers. Every successful acquire is matched by a _space.Release()
+            // when the event is dequeued in ReadAllAsync, keeping the count balanced.
+            if (_options.Mode == FeatureStreamBackpressureMode.Wait)
+            {
+                if (!_space.Wait(0))
+                {
+                    return new FeatureStreamBufferWriteResult
+                    {
+                        Decision = FeatureStreamBufferWriteDecision.BackpressureRejected,
+                        SequenceResult = sequenceResult
+                    };
+                }
+
+                _queue.Enqueue(featureEvent);
+                _items.Release();
+                return new FeatureStreamBufferWriteResult
+                {
+                    Decision = FeatureStreamBufferWriteDecision.Accepted,
+                    SequenceResult = sequenceResult
+                };
+            }
+
             if (_queue.Count >= _options.Capacity)
             {
                 return _options.Mode switch
@@ -115,15 +146,6 @@ public sealed class FeatureStreamEventBuffer : IDisposable
                         Decision = FeatureStreamBufferWriteDecision.BackpressureRejected,
                         SequenceResult = sequenceResult
                     }
-                };
-            }
-
-            if (_options.Mode == FeatureStreamBackpressureMode.Wait && !_space.Wait(0))
-            {
-                return new FeatureStreamBufferWriteResult
-                {
-                    Decision = FeatureStreamBufferWriteDecision.BackpressureRejected,
-                    SequenceResult = sequenceResult
                 };
             }
 
@@ -165,7 +187,14 @@ public sealed class FeatureStreamEventBuffer : IDisposable
         {
             if (_completed)
             {
-                _space.Release();
+                // We consumed a completion wakeup, not a real capacity slot. Pass the baton on to
+                // the next parked writer so every waiter wakes, unless the buffer is already being
+                // disposed (the semaphore may be gone). Done under _gate to order against Dispose().
+                if (!_disposed)
+                {
+                    _space.Release();
+                }
+
                 return new FeatureStreamBufferWriteResult
                 {
                     Decision = FeatureStreamBufferWriteDecision.Completed,
@@ -218,6 +247,10 @@ public sealed class FeatureStreamEventBuffer : IDisposable
 
             if (shouldStop)
             {
+                // Completed with an empty queue. Complete() only released _items once, so a
+                // single reader was woken. Pass the wakeup on to the next blocked reader before
+                // exiting so every concurrent reader drains rather than hanging on a lost wakeup.
+                _items.Release();
                 yield break;
             }
 
@@ -229,14 +262,24 @@ public sealed class FeatureStreamEventBuffer : IDisposable
             yield return featureEvent;
             if (completeAfterYield)
             {
+                // We drained the final queued item after completion. Baton-pass a wakeup so any
+                // other readers blocked on an empty, completed queue also wake and exit.
+                _items.Release();
                 yield break;
             }
         }
     }
 
     /// <summary>
-    /// Completes the buffer and wakes pending readers.
+    /// Completes the buffer and wakes pending readers and writers.
     /// </summary>
+    /// <remarks>
+    /// When the queue is empty a single reader wakeup is released; that reader observes
+    /// completion and passes the wakeup on to the next blocked reader (baton passing) so
+    /// all blocked readers drain. A writer parked in <see cref="FeatureStreamBackpressureMode.Wait"/>
+    /// mode is woken by releasing <c>_space</c>; it then observes completion under the gate and
+    /// returns <see cref="FeatureStreamBufferWriteDecision.Completed"/> instead of faulting.
+    /// </remarks>
     public void Complete()
     {
         lock (_gate)
@@ -247,9 +290,21 @@ public sealed class FeatureStreamEventBuffer : IDisposable
             }
 
             _completed = true;
+
+            // Wake one reader when nothing is queued; it baton-passes the wakeup to peers.
             if (_queue.Count == 0)
             {
                 _items.Release();
+            }
+
+            // Wake a writer parked on _space.WaitAsync so it observes completion gracefully
+            // instead of faulting with ObjectDisposedException once the semaphore is disposed.
+            // The woken writer re-checks _completed under the gate and releases _space again,
+            // which keeps the wakeup propagating to any further parked writers without
+            // permanently inflating the capacity count.
+            if (_options.Mode == FeatureStreamBackpressureMode.Wait)
+            {
+                _space.Release();
             }
         }
     }
@@ -259,7 +314,19 @@ public sealed class FeatureStreamEventBuffer : IDisposable
     /// </summary>
     public void Dispose()
     {
+        // Complete() (under _gate) wakes parked readers/writers before any semaphore is disposed.
         Complete();
+
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
         _items.Dispose();
         _space.Dispose();
     }

--- a/tests/Honua.Sdk.Abstractions.Tests/FeatureStreamEventBufferCompletionTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/FeatureStreamEventBufferCompletionTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions.Features;
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class FeatureStreamEventBufferCompletionTests
+{
+    [Fact]
+    public async Task Complete_WakesAllConcurrentReadersWhenQueueIsEmpty()
+    {
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 4,
+            Mode = FeatureStreamBackpressureMode.Wait
+        });
+
+        using var failFast = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Start several readers that immediately block on an empty queue.
+        var readers = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(() => DrainAsync(buffer.ReadAllAsync(failFast.Token)), failFast.Token))
+            .ToArray();
+
+        // Give the readers a moment to park on _items.WaitAsync.
+        await Task.Delay(50, failFast.Token);
+
+        buffer.Complete();
+
+        // All readers must complete; a lost wakeup would hang here until the 5s timeout fires.
+        var results = await Task.WhenAll(readers).WaitAsync(failFast.Token);
+
+        Assert.All(results, items => Assert.Empty(items));
+    }
+
+    [Fact]
+    public async Task Complete_WakesAllConcurrentReadersAfterFinalDrain()
+    {
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 4,
+            Mode = FeatureStreamBackpressureMode.Wait
+        });
+
+        using var failFast = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        var readers = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(() => DrainAsync(buffer.ReadAllAsync(failFast.Token)), failFast.Token))
+            .ToArray();
+
+        await Task.Delay(50, failFast.Token);
+
+        // Enqueue a single item, then complete. One reader drains it; the rest must still wake.
+        var write = await buffer.WriteAsync(Event("only"), failFast.Token);
+        buffer.Complete();
+
+        var results = await Task.WhenAll(readers).WaitAsync(failFast.Token);
+
+        Assert.True(write.Accepted);
+        Assert.Single(results.SelectMany(items => items));
+    }
+
+    [Fact]
+    public async Task Complete_ReleasesWriterParkedInWaitMode()
+    {
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 1,
+            Mode = FeatureStreamBackpressureMode.Wait
+        });
+
+        using var failFast = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Fill the buffer so the next writer parks on _space.WaitAsync.
+        var first = await buffer.WriteAsync(Event("first"), failFast.Token);
+        Assert.True(first.Accepted);
+
+        var parkedWriter = Task.Run(() => buffer.WriteAsync(Event("second"), failFast.Token).AsTask(), failFast.Token);
+
+        // Ensure the writer is genuinely parked before completing.
+        await Task.Delay(50, failFast.Token);
+        Assert.False(parkedWriter.IsCompleted);
+
+        buffer.Complete();
+
+        // The parked writer must observe completion gracefully (no ObjectDisposedException).
+        var result = await parkedWriter.WaitAsync(failFast.Token);
+
+        Assert.Equal(FeatureStreamBufferWriteDecision.Completed, result.Decision);
+    }
+
+    [Fact]
+    public async Task Dispose_DoesNotFaultParkedWriter()
+    {
+        var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = 1,
+            Mode = FeatureStreamBackpressureMode.Wait
+        });
+
+        using var failFast = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        Assert.True((await buffer.WriteAsync(Event("first"), failFast.Token)).Accepted);
+
+        var parkedWriter = Task.Run(() => buffer.WriteAsync(Event("second"), failFast.Token).AsTask(), failFast.Token);
+        await Task.Delay(50, failFast.Token);
+
+        // Dispose calls Complete() before disposing the semaphores, so the parked writer
+        // is woken and returns Completed rather than throwing ObjectDisposedException.
+        buffer.Dispose();
+
+        var result = await parkedWriter.WaitAsync(failFast.Token);
+        Assert.Equal(FeatureStreamBufferWriteDecision.Completed, result.Decision);
+    }
+
+    [Fact]
+    public async Task TryWrite_WaitMode_DoesNotSpuriouslyRejectWhenCapacityAvailable()
+    {
+        const int capacity = 64;
+        const int producers = 8;
+
+        using var buffer = new FeatureStreamEventBuffer(new FeatureStreamBackpressureOptions
+        {
+            Capacity = capacity,
+            Mode = FeatureStreamBackpressureMode.Wait
+        });
+
+        using var failFast = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // Concurrent producers write exactly `capacity` events total. Since no reader drains,
+        // every slot is real capacity. With the single-gate fix none should be spuriously rejected.
+        var perProducer = capacity / producers;
+        var writers = Enumerable.Range(0, producers)
+            .Select(p => Task.Run(
+                () =>
+                {
+                    var results = new List<FeatureStreamBufferWriteResult>();
+                    for (var i = 0; i < perProducer; i++)
+                    {
+                        results.Add(buffer.TryWrite(Event($"p{p}-{i}")));
+                    }
+
+                    return results;
+                },
+                failFast.Token))
+            .ToArray();
+
+        var all = (await Task.WhenAll(writers).WaitAsync(failFast.Token)).SelectMany(r => r).ToList();
+
+        Assert.Equal(capacity, all.Count);
+        Assert.All(all, r => Assert.True(r.Accepted, $"unexpected decision {r.Decision}"));
+
+        // The (capacity+1)th write must now be rejected: capacity is genuinely exhausted.
+        var overflow = buffer.TryWrite(Event("overflow"));
+        Assert.Equal(FeatureStreamBufferWriteDecision.BackpressureRejected, overflow.Decision);
+
+        buffer.Complete();
+        var drained = await DrainAsync(buffer.ReadAllAsync(failFast.Token));
+        Assert.Equal(capacity, drained.Count);
+    }
+
+    private static FeatureStreamEvent Event(string featureId)
+        => new()
+        {
+            ProviderName = "test",
+            SubscriptionId = "sub-1",
+            Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+            Kind = FeatureStreamEventKind.Update,
+            FeatureId = featureId,
+            Timestamp = new DateTimeOffset(2026, 4, 30, 0, 0, 0, TimeSpan.Zero)
+        };
+
+    private static async Task<List<T>> DrainAsync<T>(IAsyncEnumerable<T> source)
+    {
+        var items = new List<T>();
+        await foreach (var item in source)
+        {
+            items.Add(item);
+        }
+
+        return items;
+    }
+}


### PR DESCRIPTION
Closes #201

- Complete() now wakes all blocked readers (baton-passing release) instead of only one
- Complete() releases parked Wait-mode writers gracefully (Completed decision, no ObjectDisposedException)
- TryWrite Wait mode uses _space semaphore as single capacity gate, removing the double-gate that caused spurious BackpressureRejected
- Adds concurrency tests for multi-reader completion, writer release, and capacity accounting