### PR TITLE
Pagination safety + STAC POST continuation (#202, #204)

### DIFF
--- a/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClient.cs
+++ b/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClient.cs
@@ -17,6 +17,12 @@ public sealed class HonuaOgcRecordsClient : IHonuaOgcRecordsClient
 {
     private const string BasePath = "/ogc/records";
 
+    /// <summary>
+    /// Safety cap on the number of pages auto-pagination will fetch before throwing,
+    /// guarding against servers that emit self-referential or cyclic next-links.
+    /// </summary>
+    private const int MaxAutoPages = 100;
+
     private readonly HttpClient _http;
 
     /// <summary>
@@ -111,7 +117,9 @@ public sealed class HonuaOgcRecordsClient : IHonuaOgcRecordsClient
         var page = await GetRecordsAsync(collectionId, query, cancellationToken).ConfigureAwait(false);
         yield return page;
 
-        while (true)
+        var visitedHrefs = new HashSet<string>(StringComparer.Ordinal);
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var nextLink = page.Links?.FirstOrDefault(static link =>
                 string.Equals(link.Rel, "next", StringComparison.OrdinalIgnoreCase));
@@ -123,6 +131,13 @@ public sealed class HonuaOgcRecordsClient : IHonuaOgcRecordsClient
 
             ValidateNextLinkOrigin(nextLink.Href);
 
+            // A next-link that points back to a page already fetched (or to itself) would
+            // loop forever. Track visited hrefs and stop on a repeat.
+            if (!visitedHrefs.Add(nextLink.Href))
+            {
+                yield break;
+            }
+
             var body = await GetStringAsync(nextLink.Href, cancellationToken).ConfigureAwait(false);
             page = JsonSerializer.Deserialize(body, OgcRecordsJsonContext.Default.OgcRecordCollection)
                 ?? throw new HonuaOgcRecordsException(HttpStatusCode.OK, "Failed to deserialize paged Records response.", body);
@@ -133,7 +148,12 @@ public sealed class HonuaOgcRecordsClient : IHonuaOgcRecordsClient
             }
 
             yield return page;
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with GetRecordsAsync for larger result sets.");
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
@@ -18,6 +18,12 @@ public sealed class HonuaStacClient : IHonuaStacClient
 {
     private const string BasePath = "/stac";
 
+    /// <summary>
+    /// Safety cap on the number of pages auto-pagination will fetch before throwing,
+    /// guarding against servers that emit self-referential or cyclic next-links.
+    /// </summary>
+    private const int MaxAutoPages = 100;
+
     private readonly HttpClient _http;
 
     /// <summary>
@@ -119,10 +125,17 @@ public sealed class HonuaStacClient : IHonuaStacClient
         var page = await GetItemsAsync(collectionId, query, cancellationToken).ConfigureAwait(false);
         yield return page;
 
-        while (true)
+        var visitedHrefs = new HashSet<string>(StringComparer.Ordinal);
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var nextLink = FindNextLink(page);
             if (nextLink is null)
+            {
+                yield break;
+            }
+
+            if (!visitedHrefs.Add(nextLink.Href))
             {
                 yield break;
             }
@@ -136,7 +149,12 @@ public sealed class HonuaStacClient : IHonuaStacClient
             }
 
             yield return page;
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with GetItemsAsync for larger result sets.");
     }
 
     /// <inheritdoc />
@@ -147,10 +165,17 @@ public sealed class HonuaStacClient : IHonuaStacClient
         var page = await SearchAsync(query, cancellationToken).ConfigureAwait(false);
         yield return page;
 
-        while (true)
+        var visitedHrefs = new HashSet<string>(StringComparer.Ordinal);
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var nextLink = FindNextLink(page);
             if (nextLink is null)
+            {
+                yield break;
+            }
+
+            if (!visitedHrefs.Add(nextLink.Href))
             {
                 yield break;
             }
@@ -164,7 +189,12 @@ public sealed class HonuaStacClient : IHonuaStacClient
             }
 
             yield return page;
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with SearchAsync for larger result sets.");
     }
 
     /// <inheritdoc />
@@ -172,10 +202,18 @@ public sealed class HonuaStacClient : IHonuaStacClient
         StacSearchRequest? request,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var page = await PostSearchAsync(request, cancellationToken).ConfigureAwait(false);
+        var searchRequest = request ?? new StacSearchRequest();
+
+        // Serialize the original request body once so POST continuation links can merge their
+        // continuation token onto it, per the STAC API pagination spec.
+        var requestBody = JsonSerializer.SerializeToElement(searchRequest, StacJsonContext.Default.StacSearchRequest);
+
+        var page = await PostSearchAsync(searchRequest, cancellationToken).ConfigureAwait(false);
         yield return page;
 
-        while (true)
+        var visitedHrefs = new HashSet<string>(StringComparer.Ordinal);
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var nextLink = FindNextLink(page);
             if (nextLink is null)
@@ -183,7 +221,12 @@ public sealed class HonuaStacClient : IHonuaStacClient
                 yield break;
             }
 
-            var body = await GetNextPageStringAsync(nextLink, cancellationToken).ConfigureAwait(false);
+            if (!visitedHrefs.Add(nextLink.Href))
+            {
+                yield break;
+            }
+
+            var body = await FollowNextLinkAsync(nextLink, requestBody, cancellationToken).ConfigureAwait(false);
             page = DeserializeItemCollection(body, "Failed to deserialize paged STAC search response.");
 
             if (page.Features is null or { Count: 0 })
@@ -192,7 +235,12 @@ public sealed class HonuaStacClient : IHonuaStacClient
             }
 
             yield return page;
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with PostSearchAsync for larger result sets.");
     }
 
     /// <inheritdoc />
@@ -280,6 +328,97 @@ public sealed class HonuaStacClient : IHonuaStacClient
     {
         ValidateNextLinkOrigin(nextLink.Href);
         return await GetStringAsync(nextLink.Href, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Follows a STAC pagination link, honoring its advertised HTTP method, headers, and body.
+    /// When the link advertises <c>method:POST</c> the continuation body (typically carrying the
+    /// continuation token) is merged onto the original search request body and re-POSTed; otherwise
+    /// the href is fetched with a plain GET (current behavior).
+    /// </summary>
+    private async Task<string> FollowNextLinkAsync(
+        StacLink nextLink,
+        JsonElement originalBody,
+        CancellationToken cancellationToken)
+    {
+        ValidateNextLinkOrigin(nextLink.Href);
+
+        if (!string.Equals(nextLink.Method, "POST", StringComparison.OrdinalIgnoreCase))
+        {
+            return await GetStringAsync(nextLink.Href, cancellationToken).ConfigureAwait(false);
+        }
+
+        // STAC API pagination: a POST next-link's body should be merged onto the original
+        // request body (link members override). The default merge behavior is to merge unless
+        // the link explicitly sets merge:false.
+        var mergedBody = nextLink.Merge == false
+            ? nextLink.Body ?? originalBody
+            : MergeJsonObjects(originalBody, nextLink.Body);
+
+        var payload = JsonSerializer.SerializeToUtf8Bytes(mergedBody, StacJsonContext.Default.JsonElement);
+        using var content = new ByteArrayContent(payload);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, CreateRequestUri(nextLink.Href))
+        {
+            Content = content,
+        };
+
+        if (nextLink.Headers is not null)
+        {
+            foreach (var header in nextLink.Headers)
+            {
+                requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        using var response = await _http.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, responseBody);
+        return responseBody;
+    }
+
+    /// <summary>
+    /// Merges the members of <paramref name="overlay"/> onto <paramref name="baseline"/>, with overlay
+    /// members overriding. Both are expected to be JSON objects; non-object inputs degrade gracefully.
+    /// </summary>
+    private static JsonElement MergeJsonObjects(JsonElement baseline, JsonElement? overlay)
+    {
+        if (overlay is not { ValueKind: JsonValueKind.Object } overlayElement)
+        {
+            return baseline;
+        }
+
+        if (baseline.ValueKind != JsonValueKind.Object)
+        {
+            return overlayElement;
+        }
+
+        var merged = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (var property in baseline.EnumerateObject())
+        {
+            merged[property.Name] = property.Value;
+        }
+
+        foreach (var property in overlayElement.EnumerateObject())
+        {
+            merged[property.Name] = property.Value;
+        }
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            foreach (var entry in merged)
+            {
+                writer.WritePropertyName(entry.Key);
+                entry.Value.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return JsonSerializer.Deserialize(buffer.ToArray(), StacJsonContext.Default.JsonElement);
     }
 
     private static StacItemCollection DeserializeItemCollection(string body, string errorMessage)

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -28,6 +28,13 @@ public sealed class HonuaFeatureServerClient :
     IHonuaFeatureAttachmentClient
 {
     private const int PostFallbackThreshold = 2000;
+
+    /// <summary>
+    /// Safety cap on the number of pages auto-pagination will fetch before throwing,
+    /// guarding against servers that never signal termination.
+    /// </summary>
+    private const int MaxAutoPages = 100;
+
     private static readonly FeatureEditCapabilities ProviderEditCapabilities = new()
     {
         SupportsAdds = true,
@@ -447,22 +454,40 @@ public sealed class HonuaFeatureServerClient :
         ArgumentNullException.ThrowIfNull(query);
 
         var currentQuery = query;
-        while (true)
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var page = await QueryAsync(serviceId, layerId, currentQuery, cancellationToken).ConfigureAwait(false);
             yield return page;
 
-            var count = currentQuery.ReturnIdsOnly is true
+            // Evaluate the continuation signal BEFORE the empty-page check so a non-final
+            // page that legitimately returns 0 features (but still reports more pending) is
+            // not prematurely dropped.
+            if (!page.ExceededTransferLimit)
+            {
+                yield break;
+            }
+
+            // Advance by the ACTUAL returned record count, never a server-reported total.
+            var returnedCount = currentQuery.ReturnIdsOnly is true
                 ? page.ObjectIds?.Count ?? 0
                 : page.Features?.Count ?? 0;
-            if (count == 0 || !page.ExceededTransferLimit)
+
+            // A non-advancing cursor means the server ignored resultOffset (real Esri-compat
+            // behavior) and would re-yield page 1 forever. Stop rather than loop on duplicates.
+            if (returnedCount == 0)
             {
                 yield break;
             }
 
             var currentOffset = currentQuery.ResultOffset ?? 0;
-            currentQuery = currentQuery with { ResultOffset = currentOffset + count };
+            currentQuery = currentQuery with { ResultOffset = currentOffset + returnedCount };
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with QueryAsync for larger result sets.");
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -26,6 +26,12 @@ public sealed class HonuaOgcFeaturesClient :
     IHonuaFeatureAttachmentClient
 {
     private const string BasePath = "/ogc/features";
+
+    /// <summary>
+    /// Safety cap on the number of pages auto-pagination will fetch before throwing,
+    /// guarding against servers that emit self-referential or cyclic next-links.
+    /// </summary>
+    private const int MaxAutoPages = 100;
     private const string RollbackUnsupportedReason =
         "OGC API Features create, update, and delete endpoints do not support rollback-on-failure edit batches.";
     private const string UnsupportedAttachmentReason =
@@ -299,7 +305,9 @@ public sealed class HonuaOgcFeaturesClient :
         var page = await GetItemsAsync(collectionId, query, cancellationToken).ConfigureAwait(false);
         yield return page;
 
-        while (true)
+        var visitedHrefs = new HashSet<string>(StringComparer.Ordinal);
+        var pageCount = 0;
+        while (pageCount < MaxAutoPages)
         {
             var nextLink = page.Links?.FirstOrDefault(l =>
                 string.Equals(l.Rel, "next", StringComparison.OrdinalIgnoreCase));
@@ -311,6 +319,13 @@ public sealed class HonuaOgcFeaturesClient :
 
             ValidateNextLinkOrigin(nextLink.Href);
 
+            // A next-link that points back to a page already fetched (or to itself) would
+            // loop forever. Track visited hrefs and stop on a repeat.
+            if (!visitedHrefs.Add(nextLink.Href))
+            {
+                yield break;
+            }
+
             var body = await GetStringAsync(nextLink.Href, cancellationToken).ConfigureAwait(false);
             page = JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeatureCollection)
                 ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize paged items.", body);
@@ -321,7 +336,12 @@ public sealed class HonuaOgcFeaturesClient :
             }
 
             yield return page;
+            pageCount++;
         }
+
+        throw new InvalidOperationException(
+            $"Auto-pagination safety limit reached ({MaxAutoPages} pages). " +
+            "Use manual paging with GetItemsAsync for larger result sets.");
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClient.cs
@@ -177,12 +177,15 @@ public sealed class HonuaWfsClient :
             var page = await GetFeaturesAsync(BuildWfsQuery(current), cancellationToken).ConfigureAwait(false);
             yield return ToFeatureQueryResult(page);
 
-            if (page.NumberReturned == 0)
+            // Advance by the ACTUAL number of features in the page, not the server-reported
+            // numberReturned (which may be 0 or larger than the body, skipping or dropping records).
+            var returnedCount = page.Features.Count;
+            if (returnedCount == 0)
             {
                 yield break;
             }
 
-            startIndex += page.NumberReturned;
+            startIndex += returnedCount;
             if (page.NumberMatched.HasValue && startIndex >= page.NumberMatched.Value)
             {
                 yield break;
@@ -359,12 +362,15 @@ public sealed class HonuaWfsClient :
                 yield return feature;
             }
 
-            if (page.NumberReturned == 0)
+            // Advance by the ACTUAL number of features in the page, not the server-reported
+            // numberReturned (which may be 0 or larger than the body, skipping or dropping records).
+            var returnedCount = page.Features.Count;
+            if (returnedCount == 0)
             {
                 yield break;
             }
 
-            startIndex += page.NumberReturned;
+            startIndex += returnedCount;
 
             if (page.NumberMatched.HasValue && startIndex >= page.NumberMatched.Value)
             {

--- a/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
+++ b/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
@@ -396,6 +396,100 @@ public sealed class HonuaStacClientTests
     }
 
     [Fact]
+    public async Task PostSearchPagesAsync_PostNextLink_RePostsWithMergedBody()
+    {
+        // STAC API POST pagination: the next link advertises method:POST with a body carrying
+        // the continuation token. The pager must re-POST (not GET) and merge the link body onto
+        // the original search request body (token overrides/adds, original collections retained).
+        var calls = 0;
+        var methods = new List<HttpMethod>();
+        var requestBodies = new List<string>();
+        var client = TestHelpers.CreateStacClient(async req =>
+        {
+            calls++;
+            methods.Add(req.Method);
+            requestBodies.Add(req.Content is null
+                ? string.Empty
+                : await req.Content.ReadAsStringAsync(CancellationToken.None));
+
+            var json = calls == 1
+                ? """
+                  {
+                      "type": "FeatureCollection",
+                      "features": [{ "type": "Feature", "id": "scene-001" }],
+                      "links": [
+                          {
+                              "href": "https://honua.example.test/stac/search",
+                              "rel": "next",
+                              "method": "POST",
+                              "body": { "token": "page-2-token" }
+                          }
+                      ]
+                  }
+                  """
+                : """
+                  {
+                      "type": "FeatureCollection",
+                      "features": [{ "type": "Feature", "id": "scene-002" }]
+                  }
+                  """;
+            return TestHelpers.CreateRawJsonResponse(json);
+        });
+
+        var pages = new List<StacItemCollection>();
+        await foreach (var page in client.PostSearchPagesAsync(new StacSearchRequest
+        {
+            Collections = ["imagery"],
+            Limit = 1
+        }))
+        {
+            pages.Add(page);
+        }
+
+        Assert.Equal(2, pages.Count);
+        Assert.Equal([HttpMethod.Post, HttpMethod.Post], methods);
+
+        // The second (continuation) request must be a POST whose body merges the original search
+        // parameters with the link's continuation token.
+        using var continuationBody = JsonDocument.Parse(requestBodies[1]);
+        Assert.Equal("page-2-token", continuationBody.RootElement.GetProperty("token").GetString());
+        var collections = continuationBody.RootElement.GetProperty("collections");
+        Assert.Equal("imagery", collections[0].GetString());
+    }
+
+    [Fact]
+    public async Task SearchPagesAsync_SelfReferentialNextLink_TerminatesWithoutInfiniteLoop()
+    {
+        // Adversarial server: every page returns a next link equal to its own href.
+        // Visited-href tracking must stop paging instead of looping forever.
+        var calls = 0;
+        var client = TestHelpers.CreateStacClient(_ =>
+        {
+            calls++;
+            var json = """
+            {
+                "type": "FeatureCollection",
+                "features": [{ "type": "Feature", "id": "scene-001" }],
+                "links": [
+                    { "href": "https://honua.example.test/stac/search?limit=1&offset=1", "rel": "next" }
+                ]
+            }
+            """;
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<StacItemCollection>();
+        await foreach (var page in client.SearchPagesAsync(new StacSearchQuery { Limit = 1 }))
+        {
+            pages.Add(page);
+        }
+
+        // First page + one fetch of the next href, then the repeated href is detected and paging stops.
+        Assert.Equal(2, pages.Count);
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
     public async Task SearchPagesAsync_RejectsCrossOriginNextLink()
     {
         var json = """

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -1053,6 +1053,76 @@ public class HonuaFeatureServerClientTests
         Assert.Equal(2, callCount);
     }
 
+    [Fact]
+    public async Task QueryPagesAsync_ServerIgnoresOffset_StopsAtMaxAutoPagesWithoutInfiniteLoop()
+    {
+        // Adversarial server: always returns the same page-1 with exceededTransferLimit=true,
+        // ignoring resultOffset. Must terminate at the MaxAutoPages cap (100), not loop forever.
+        var callCount = 0;
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+        {
+            callCount++;
+            var json = """
+            {
+                "features": [{ "attributes": { "ID": 1 } }, { "attributes": { "ID": 2 } }],
+                "exceededTransferLimit": true
+            }
+            """;
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<FeatureServerQueryResponse>();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var page in client.QueryPagesAsync("svc", 0, new FeatureServerQueryParams { Where = "1=1" }))
+            {
+                pages.Add(page);
+            }
+        });
+
+        // Bounded by MaxAutoPages (100): exactly 100 pages are yielded before the cap throws,
+        // proving the loop terminates instead of running forever on duplicates.
+        Assert.Equal(100, pages.Count);
+        Assert.Equal(100, callCount);
+    }
+
+    [Fact]
+    public async Task QueryPagesAsync_NonFinalEmptyPageWithExceededLimit_StopsWithoutDuplicates()
+    {
+        // A non-final page that returns 0 features while exceededTransferLimit=true must not
+        // advance forever; the non-advancing cursor terminates paging cleanly.
+        var callCount = 0;
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+        {
+            callCount++;
+            var json = callCount switch
+            {
+                1 => """
+                {
+                    "features": [{ "attributes": { "ID": 1 } }],
+                    "exceededTransferLimit": true
+                }
+                """,
+                // Non-final page: 0 features but still exceededTransferLimit=true.
+                _ => """{ "features": [], "exceededTransferLimit": true }"""
+            };
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<FeatureServerQueryResponse>();
+        await foreach (var page in client.QueryPagesAsync("svc", 0, new FeatureServerQueryParams { Where = "1=1" }))
+        {
+            pages.Add(page);
+        }
+
+        // Page 1 (1 feature, exceeded) is yielded and continues; page 2 (0 features) is yielded
+        // because the continuation signal is evaluated first, then the non-advancing cursor stops.
+        Assert.Equal(2, pages.Count);
+        Assert.Single(pages[0].Features!);
+        Assert.Empty(pages[1].Features!);
+        Assert.Equal(2, callCount);
+    }
+
     // ── QueryStatisticsAsync ────────────────────────────────────────
 
     [Fact]

--- a/tests/Honua.Sdk.OgcFeatures.WfsTests/PaginationTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.WfsTests/PaginationTests.cs
@@ -129,6 +129,60 @@ public sealed class PaginationTests
     }
 
     [Fact]
+    public async Task AutoPage_ServerReportsZeroReturnedButHasFeatures_AdvancesByActualCount()
+    {
+        // Adversarial/buggy server: numberReturned=0 on page 1 even though the body carries
+        // features. The pager must advance by the ACTUAL feature count (2), request STARTINDEX=2,
+        // and not break prematurely on the bogus numberReturned=0.
+        var page1 = """
+            {
+                "type": "FeatureCollection",
+                "numberMatched": 3,
+                "numberReturned": 0,
+                "features": [
+                    { "type": "Feature", "id": "1", "geometry": null, "properties": {} },
+                    { "type": "Feature", "id": "2", "geometry": null, "properties": {} }
+                ]
+            }
+            """;
+
+        var page2 = """
+            {
+                "type": "FeatureCollection",
+                "numberMatched": 3,
+                "numberReturned": 99,
+                "features": [
+                    { "type": "Feature", "id": "3", "geometry": null, "properties": {} }
+                ]
+            }
+            """;
+
+        var observedStartIndexes = new List<string>();
+        var callCount = 0;
+        var client = TestHelpers.CreateClient(req =>
+        {
+            callCount++;
+            observedStartIndexes.Add(req.RequestUri!.Query);
+            var query = req.RequestUri!.Query;
+            return Task.FromResult(TestHelpers.CreateGeoJsonResponse(
+                query.Contains("STARTINDEX=2") ? page2 : page1));
+        });
+
+        var features = new List<WfsFeature>();
+        await foreach (var feature in client.GetFeaturesAsyncEnumerable(
+            new GetFeaturesRequest { TypeNames = "parcels", StartIndex = 0 }))
+        {
+            features.Add(feature);
+        }
+
+        // All 3 features delivered; advancement used the actual count (2), so STARTINDEX=2 fetched
+        // page 2, and over-advancing by numberReturned=99 did not skip records.
+        Assert.Equal(3, features.Count);
+        Assert.Equal(["1", "2", "3"], features.Select(f => f.Id));
+        Assert.Contains(observedStartIndexes, q => q.Contains("STARTINDEX=2"));
+    }
+
+    [Fact]
     public void HasMoreResults_AllReturned_ReturnsFalse()
     {
         var collection = new WfsFeatureCollection


### PR DESCRIPTION
Closes #202
Closes #204

## #202 — Auto-pagination safety

Several auto-pagers lacked the `MaxAutoPages=100` cap and loop-prevention the WFS client already had. Mirrored that convention (private const per client) and added:

- **GeoServices FeatureServer `QueryPagesAsync`** — now evaluates `exceededTransferLimit` *before* the empty-page break (no longer drops trailing pages when a non-final page returns 0 features), advances by the actual returned record count, and breaks when the cursor does not advance (a server ignoring `resultOffset` no longer loops forever re-yielding duplicates). Throws at the `MaxAutoPages` cap.
- **OGC API Features `GetItemsPagesAsync`, OGC Records `GetRecordsPagesAsync`, STAC `GetItemsPagesAsync`/`SearchPagesAsync`** — added the page cap plus a `HashSet` of visited next-hrefs; a self-referential or already-seen `next` link terminates paging instead of looping. Missing-next/empty termination retained.
- **WFS `QueryPagesAsync` + `GetFeaturesAsyncEnumerable`** — advance `startIndex` by the actual `page.Features.Count` rather than the server-reported `numberReturned` (no more dropped pages on a bogus `numberReturned=0`, no more skipped records on over-reported counts).

## #204 — STAC POST-search pagination

`PostSearchPagesAsync` followed `next` via an unconditional GET, which 405s / repeats page 1 against spec-compliant servers. It now honors the next link's `method`/`headers`/`body`: when `method:POST`, it re-POSTs to the href with the link body merged onto the original search request body (link members override, per the STAC API pagination spec; `merge:false` is respected). GET behavior is retained when no method is advertised. `StacLink` already carried `Method`/`Headers`/`Body`/`Merge`.

## Tests

Added focused xUnit tests:
- GeoServices: server ignoring `resultOffset` terminates at the cap (no infinite loop/duplicates); a non-final 0-feature page with `exceededTransferLimit=true` still continues then stops cleanly.
- STAC: self-referential `next` href terminates; a `method:POST` next link re-POSTs with the merged body (asserts outgoing method + merged body) instead of GETting.
- WFS: a page with `numberReturned=0` but actual features advances by the real count and delivers all records.

All affected test projects pass (GeoServices 124, OgcFeatures 107, WFS 95, STAC 46, Records 43). Changes are purely internal (private consts/methods), so no public-API surface change and `validate-api-compat.sh` was not required.