### PR TITLE
Minor correctness: antimeridian bbox, geocoding null-island, attachment dispose (#207)

### DIFF
--- a/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
@@ -91,13 +91,18 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
             return [];
         }
 
-        return result.Candidates.Select(c => new GeocodeResult(
-            Address: c.Address,
-            Latitude: c.Location?.Y ?? 0,
-            Longitude: c.Location?.X ?? 0,
-            Score: c.Score,
-            Attributes: FlattenAttributes(c.Attributes)
-        )).ToList().AsReadOnly();
+        // Skip candidates without a location rather than emitting (0, 0) "Null Island":
+        // GeocodeResult exposes non-nullable coordinates, so a missing location would otherwise
+        // surface as a false match at the equator/prime-meridian intersection.
+        return result.Candidates
+            .Where(c => c.Location is not null)
+            .Select(c => new GeocodeResult(
+                Address: c.Address,
+                Latitude: c.Location!.Y,
+                Longitude: c.Location!.X,
+                Score: c.Score,
+                Attributes: FlattenAttributes(c.Attributes)
+            )).ToList().AsReadOnly();
     }
 
     /// <inheritdoc />

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -299,9 +299,18 @@ public sealed class HonuaFeatureServerClient :
         var response = await _http.GetAsync(CreateRequestUri(path), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
+            // Read the body and run the status check while the response is still alive,
+            // then dispose. EnsureSuccess reads response.StatusCode, so it must run before
+            // Dispose to remain correct under refactoring.
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            response.Dispose();
-            EnsureSuccess(response, body);
+            try
+            {
+                EnsureSuccess(response, body);
+            }
+            finally
+            {
+                response.Dispose();
+            }
         }
 
         var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Honua.Sdk.Geometry/GeographicBoundingBox.cs
+++ b/src/Honua.Sdk.Geometry/GeographicBoundingBox.cs
@@ -24,16 +24,22 @@ public sealed record GeographicBoundingBox
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GeographicBoundingBox"/> record, validating
-    /// that the minimum coordinates are strictly less than the corresponding maximum coordinates.
+    /// that all coordinates are finite and within the WGS84 ranges, and that the southern
+    /// boundary is strictly less than the northern boundary.
     /// </summary>
-    /// <param name="minLongitude">Western boundary in decimal degrees.</param>
-    /// <param name="minLatitude">Southern boundary in decimal degrees.</param>
-    /// <param name="maxLongitude">Eastern boundary in decimal degrees.</param>
-    /// <param name="maxLatitude">Northern boundary in decimal degrees.</param>
+    /// <param name="minLongitude">Western boundary in decimal degrees, within [-180, 180].</param>
+    /// <param name="minLatitude">Southern boundary in decimal degrees, within [-90, 90].</param>
+    /// <param name="maxLongitude">Eastern boundary in decimal degrees, within [-180, 180].</param>
+    /// <param name="maxLatitude">Northern boundary in decimal degrees, within [-90, 90].</param>
+    /// <remarks>
+    /// A box whose <paramref name="minLongitude"/> is greater than its <paramref name="maxLongitude"/>
+    /// is interpreted as an extent that crosses the antimeridian (±180°), spanning eastward from
+    /// the western edge across 180° to the eastern edge. See <see cref="CrossesAntimeridian"/>.
+    /// </remarks>
     /// <exception cref="ArgumentException">
-    /// Thrown when any coordinate is not finite, when <paramref name="minLongitude"/> is not
-    /// strictly less than <paramref name="maxLongitude"/>, or when <paramref name="minLatitude"/>
-    /// is not strictly less than <paramref name="maxLatitude"/>.
+    /// Thrown when any coordinate is not finite, when a longitude falls outside [-180, 180],
+    /// when a latitude falls outside [-90, 90], or when <paramref name="minLatitude"/> is not
+    /// strictly less than <paramref name="maxLatitude"/>.
     /// </exception>
     public GeographicBoundingBox(
         double minLongitude,
@@ -46,14 +52,13 @@ public sealed record GeographicBoundingBox
         ValidateFinite(maxLongitude, nameof(maxLongitude));
         ValidateFinite(maxLatitude, nameof(maxLatitude));
 
-        if (!(minLongitude < maxLongitude))
-        {
-            throw new ArgumentException(
-                string.Create(
-                    CultureInfo.InvariantCulture,
-                    $"{nameof(minLongitude)} ({minLongitude}) must be strictly less than {nameof(maxLongitude)} ({maxLongitude})."),
-                nameof(maxLongitude));
-        }
+        ValidateLongitudeRange(minLongitude, nameof(minLongitude));
+        ValidateLongitudeRange(maxLongitude, nameof(maxLongitude));
+        ValidateLatitudeRange(minLatitude, nameof(minLatitude));
+        ValidateLatitudeRange(maxLatitude, nameof(maxLatitude));
+
+        // Longitude ordering is intentionally NOT enforced: minLongitude > maxLongitude denotes
+        // an antimeridian-crossing extent (e.g. west=170, east=-170 spans the Pacific across 180°).
 
         if (!(minLatitude < maxLatitude))
         {
@@ -91,7 +96,25 @@ public sealed record GeographicBoundingBox
     public double MaxLatitude { get; }
 
     /// <summary>
-    /// Determines whether the supplied WGS84 coordinate lies on or within this bounding box.
+    /// Gets a value indicating whether this bounding box crosses the antimeridian (±180°),
+    /// which is the case when <see cref="MinLongitude"/> is greater than <see cref="MaxLongitude"/>.
+    /// When <see langword="true"/>, the longitudinal extent wraps eastward from
+    /// <see cref="MinLongitude"/> across 180° to <see cref="MaxLongitude"/>.
+    /// </summary>
+    public bool CrossesAntimeridian => MinLongitude > MaxLongitude;
+
+    /// <summary>
+    /// Gets the longitudinal span of this bounding box in decimal degrees, accounting for
+    /// antimeridian wrapping. For a non-crossing box this is <c>MaxLongitude - MinLongitude</c>;
+    /// for an antimeridian-crossing box it is <c>(180 - MinLongitude) + (MaxLongitude - (-180))</c>.
+    /// </summary>
+    public double LongitudeSpan => CrossesAntimeridian
+        ? (360.0 - MinLongitude) + MaxLongitude
+        : MaxLongitude - MinLongitude;
+
+    /// <summary>
+    /// Determines whether the supplied WGS84 coordinate lies on or within this bounding box,
+    /// accounting for antimeridian wrapping.
     /// </summary>
     /// <param name="longitude">Longitude in decimal degrees.</param>
     /// <param name="latitude">Latitude in decimal degrees.</param>
@@ -101,10 +124,16 @@ public sealed record GeographicBoundingBox
     /// </returns>
     public bool Contains(double longitude, double latitude)
     {
-        return longitude >= MinLongitude
-            && longitude <= MaxLongitude
-            && latitude >= MinLatitude
-            && latitude <= MaxLatitude;
+        if (latitude < MinLatitude || latitude > MaxLatitude)
+        {
+            return false;
+        }
+
+        // For an antimeridian-crossing box the valid longitude band is the union of
+        // [MinLongitude, 180] and [-180, MaxLongitude].
+        return CrossesAntimeridian
+            ? longitude >= MinLongitude || longitude <= MaxLongitude
+            : longitude >= MinLongitude && longitude <= MaxLongitude;
     }
 
     /// <summary>
@@ -120,10 +149,50 @@ public sealed record GeographicBoundingBox
     public bool Intersects(GeographicBoundingBox other)
     {
         ArgumentNullException.ThrowIfNull(other);
-        return MinLongitude <= other.MaxLongitude
-            && MaxLongitude >= other.MinLongitude
-            && MinLatitude <= other.MaxLatitude
-            && MaxLatitude >= other.MinLatitude;
+
+        if (MinLatitude > other.MaxLatitude || MaxLatitude < other.MinLatitude)
+        {
+            return false;
+        }
+
+        return LongitudeBandsOverlap(this, other);
+    }
+
+    /// <summary>
+    /// Tests whether the longitude bands of two boxes overlap, accounting for antimeridian
+    /// wrapping on either box. A crossing box is treated as the union of two non-crossing
+    /// half-bands split at ±180°.
+    /// </summary>
+    private static bool LongitudeBandsOverlap(GeographicBoundingBox a, GeographicBoundingBox b)
+    {
+        foreach (var (aMin, aMax) in LongitudeBands(a))
+        {
+            foreach (var (bMin, bMax) in LongitudeBands(b))
+            {
+                if (aMin <= bMax && aMax >= bMin)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decomposes a box's longitude extent into one or two non-wrapping [min, max] bands.
+    /// </summary>
+    private static IEnumerable<(double Min, double Max)> LongitudeBands(GeographicBoundingBox box)
+    {
+        if (box.CrossesAntimeridian)
+        {
+            yield return (box.MinLongitude, 180.0);
+            yield return (-180.0, box.MaxLongitude);
+        }
+        else
+        {
+            yield return (box.MinLongitude, box.MaxLongitude);
+        }
     }
 
     /// <summary>
@@ -199,6 +268,30 @@ public sealed record GeographicBoundingBox
         if (!double.IsFinite(value))
         {
             throw new ArgumentException($"{paramName} must be a finite number.", paramName);
+        }
+    }
+
+    private static void ValidateLongitudeRange(double value, string paramName)
+    {
+        if (value < -180.0 || value > 180.0)
+        {
+            throw new ArgumentException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{paramName} ({value}) must be within [-180, 180]."),
+                paramName);
+        }
+    }
+
+    private static void ValidateLatitudeRange(double value, string paramName)
+    {
+        if (value < -90.0 || value > 90.0)
+        {
+            throw new ArgumentException(
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{paramName} ({value}) must be within [-90, 90]."),
+                paramName);
         }
     }
 }

--- a/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
@@ -74,6 +74,42 @@ public sealed class HonuaGeocodingClientTests
     }
 
     [Fact]
+    public async Task ForwardGeocode_CandidateWithNullLocation_IsSkipped()
+    {
+        var responseJson = """
+        {
+            "spatialReference": { "wkid": 4326, "latestWkid": 4326 },
+            "candidates": [
+                {
+                    "address": "No location candidate",
+                    "location": null,
+                    "score": 50.0,
+                    "attributes": {}
+                },
+                {
+                    "address": "123 Main St, Springfield, IL",
+                    "location": { "x": -89.6501, "y": 39.7817 },
+                    "score": 97.5,
+                    "attributes": {}
+                }
+            ]
+        }
+        """;
+
+        var client = CreateGeocodingClient(_ =>
+            Task.FromResult(CreateGeoJsonResponse(responseJson)));
+
+        var results = await client.ForwardGeocodeAsync("123 Main St");
+
+        // The null-location candidate is dropped (no false (0, 0) "Null Island" result).
+        Assert.Single(results);
+        Assert.Equal("123 Main St, Springfield, IL", results[0].Address);
+        Assert.Equal(39.7817, results[0].Latitude);
+        Assert.Equal(-89.6501, results[0].Longitude);
+        Assert.DoesNotContain(results, r => r.Latitude == 0 && r.Longitude == 0);
+    }
+
+    [Fact]
     public async Task ForwardGeocode_EmptyResults_ReturnsEmptyList()
     {
         var responseJson = """
@@ -180,7 +216,7 @@ public sealed class HonuaGeocodingClientTests
     }
 
     [Fact]
-    public async Task ForwardGeocode_CandidateWithNullLocation_DefaultsToZero()
+    public async Task ForwardGeocode_CandidateWithNullLocation_IsSkippedNotNullIsland()
     {
         var responseJson = """
         {
@@ -201,9 +237,9 @@ public sealed class HonuaGeocodingClientTests
 
         var results = await client.ForwardGeocodeAsync("test");
 
-        Assert.Single(results);
-        Assert.Equal(0, results[0].Latitude);
-        Assert.Equal(0, results[0].Longitude);
+        // A candidate without a location must not surface as a (0, 0) "Null Island" match;
+        // it is dropped entirely.
+        Assert.Empty(results);
     }
 
     // ── ReverseGeocodeAsync ─────────────────────────────────────────────

--- a/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
@@ -106,7 +106,7 @@ public sealed class HonuaGeocodingClientTests
         Assert.Equal("123 Main St, Springfield, IL", results[0].Address);
         Assert.Equal(39.7817, results[0].Latitude);
         Assert.Equal(-89.6501, results[0].Longitude);
-        Assert.DoesNotContain(results, r => r.Latitude == 0 && r.Longitude == 0);
+        Assert.DoesNotContain(results, r => Math.Abs(r.Latitude) < 1e-9 && Math.Abs(r.Longitude) < 1e-9);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -795,6 +795,27 @@ public class HonuaFeatureServerClientTests
     }
 
     [Fact]
+    public async Task DownloadAttachmentAsync_HttpError_ThrowsWithStatusCode()
+    {
+        // Verifies the status code is read correctly (EnsureSuccess runs before the response
+        // is disposed) when the download responds with a non-success status.
+        var client = TestHelpers.CreateFeatureServerClient(_ =>
+            Task.FromResult(TestHelpers.CreateErrorResponse(HttpStatusCode.Forbidden, "Access denied")));
+
+        var attachments = (IHonuaFeatureAttachmentClient)client;
+
+        var ex = await Assert.ThrowsAsync<HonuaFeatureServerException>(
+            () => attachments.DownloadAttachmentAsync(new FeatureAttachmentDownloadRequest
+            {
+                Source = new FeatureSource { ServiceId = "parks", LayerId = 0 },
+                ObjectId = 42,
+                AttachmentId = 7
+            }));
+
+        Assert.Equal(HttpStatusCode.Forbidden, ex.StatusCode);
+    }
+
+    [Fact]
     public async Task GetEditCapabilitiesAsync_ParsesLayerCapabilities()
     {
         var client = TestHelpers.CreateFeatureServerClient(_ =>

--- a/tests/Honua.Sdk.Geometry.Tests/GeographicBoundingBoxTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GeographicBoundingBoxTests.cs
@@ -20,12 +20,85 @@ public class GeographicBoundingBoxTests
     }
 
     [Fact]
-    public void Construction_WithMinLongitudeNotLessThanMax_Throws()
+    public void Construction_WithMinLongitudeGreaterThanMax_DenotesAntimeridianCrossing()
+    {
+        // west=170, east=-170 spans the Pacific across ±180°; this is now a valid extent.
+        var bbox = new GeographicBoundingBox(170.0, -10.0, -170.0, 10.0);
+
+        Assert.True(bbox.CrossesAntimeridian);
+        Assert.Equal(170.0, bbox.MinLongitude);
+        Assert.Equal(-170.0, bbox.MaxLongitude);
+
+        // Span wraps: (360 - 170) + (-170) = 20 degrees.
+        Assert.Equal(20.0, bbox.LongitudeSpan);
+    }
+
+    [Fact]
+    public void Construction_WithEqualLongitudes_DoesNotCrossAntimeridian()
+    {
+        var bbox = new GeographicBoundingBox(10.0, 0.0, 10.0, 1.0);
+
+        Assert.False(bbox.CrossesAntimeridian);
+        Assert.Equal(0.0, bbox.LongitudeSpan);
+    }
+
+    [Fact]
+    public void Construction_NormalBox_IsNotFlaggedAntimeridian()
+    {
+        var bbox = new GeographicBoundingBox(-122.5, 37.5, -122.0, 38.0);
+
+        Assert.False(bbox.CrossesAntimeridian);
+        Assert.Equal(0.5, bbox.LongitudeSpan, 10);
+    }
+
+    [Fact]
+    public void Construction_WithOutOfRangeLongitude_Throws()
     {
         Assert.Throws<ArgumentException>(
-            () => new GeographicBoundingBox(10.0, 0.0, 10.0, 1.0));
+            () => new GeographicBoundingBox(-181.0, 0.0, 1.0, 1.0));
         Assert.Throws<ArgumentException>(
-            () => new GeographicBoundingBox(11.0, 0.0, 10.0, 1.0));
+            () => new GeographicBoundingBox(0.0, 0.0, 181.0, 1.0));
+    }
+
+    [Fact]
+    public void Construction_WithOutOfRangeLatitude_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new GeographicBoundingBox(0.0, -91.0, 1.0, 1.0));
+        Assert.Throws<ArgumentException>(
+            () => new GeographicBoundingBox(0.0, 0.0, 1.0, 91.0));
+    }
+
+    [Fact]
+    public void Contains_AntimeridianCrossingBox_HandlesWrap()
+    {
+        var bbox = new GeographicBoundingBox(170.0, -10.0, -170.0, 10.0);
+
+        // Inside the wrapped band (either side of 180°).
+        Assert.True(bbox.Contains(175.0, 0.0));
+        Assert.True(bbox.Contains(-175.0, 0.0));
+        Assert.True(bbox.Contains(180.0, 0.0));
+
+        // Outside the longitude band.
+        Assert.False(bbox.Contains(0.0, 0.0));
+        Assert.False(bbox.Contains(160.0, 0.0));
+
+        // Outside the latitude band.
+        Assert.False(bbox.Contains(175.0, 20.0));
+    }
+
+    [Fact]
+    public void Intersects_AntimeridianCrossingBoxes_OverlapAcrossSeam()
+    {
+        var crossing = new GeographicBoundingBox(170.0, -10.0, -170.0, 10.0);
+        var nearSeam = new GeographicBoundingBox(178.0, -5.0, 179.0, 5.0);
+        var otherSide = new GeographicBoundingBox(-179.0, -5.0, -178.0, 5.0);
+        var disjoint = new GeographicBoundingBox(0.0, -5.0, 10.0, 5.0);
+
+        Assert.True(crossing.Intersects(nearSeam));
+        Assert.True(nearSeam.Intersects(crossing));
+        Assert.True(crossing.Intersects(otherSide));
+        Assert.False(crossing.Intersects(disjoint));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #207

Three minor correctness fixes from the org-wide bug-bounty sweep.

## 1. Antimeridian bbox — `src/Honua.Sdk.Geometry/GeographicBoundingBox.cs`
The constructor required `minLon < maxLon` and threw, so an extent crossing ±180° (e.g. west=170, east=-170) could not be built. The longitude ordering check is removed; `minLon > maxLon` now denotes an antimeridian-crossing extent. Added range validation (`[-180,180]` lon, `[-90,90]` lat) and kept `minLat < maxLat`. New `CrossesAntimeridian` and `LongitudeSpan` members (XML-documented). `Contains` and `Intersects` now handle the seam via a two-band split.

## 2. Geocoding null-island — `src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs`
`ForwardGeocodeAsync` emitted `Latitude:0, Longitude:0` when `c.Location` was null. Since `GeocodeResult` has non-nullable coordinates, candidates without a location are now skipped (`Where(c => c.Location is not null)`) so callers never see a false (0,0) match.

## 3. Attachment dispose ordering — `src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs`
`DownloadAttachmentAsync` disposed the response before `EnsureSuccess` read `response.StatusCode`. Reordered so the status check runs while the response is alive, then dispose in a `finally`.

## Tests
- Geometry: antimeridian construction + `CrossesAntimeridian`/`LongitudeSpan`, normal-box not flagged, out-of-range lon/lat throws, wrapped `Contains`/`Intersects`.
- Geocoding: null-location candidate skipped (no (0,0)); mixed list returns only valid candidates.
- Attachment: download on a non-success response throws with the correct status code.

All affected test projects pass (Geometry 81, GeoServices 123, Admin 178). Strict build (`TreatWarningsAsErrors`) clean; `validate-api-compat.sh` reports no breaking changes (relaxing a constructor + added members are non-breaking).