### PR TITLE
Geometry CRS/axis/bbox correctness + tolerant numberMatched (#203, #205, #206)

### DIFF
--- a/src/Honua.Sdk.Catalogs/Records/Models/OgcRecord.cs
+++ b/src/Honua.Sdk.Catalogs/Records/Models/OgcRecord.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Honua.Sdk.Catalogs.Serialization;
 
 namespace Honua.Sdk.Catalogs.Records.Models;
 
@@ -53,6 +54,7 @@ public sealed class OgcRecordCollection
 
     /// <summary>Total number of records matching the query when reported by the server.</summary>
     [JsonPropertyName("numberMatched")]
+    [JsonConverter(typeof(TolerantNullableInt64Converter))]
     public long? NumberMatched { get; init; }
 
     /// <summary>Number of records returned in this page.</summary>

--- a/src/Honua.Sdk.Catalogs/Serialization/TolerantNullableInt64Converter.cs
+++ b/src/Honua.Sdk.Catalogs/Serialization/TolerantNullableInt64Converter.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Catalogs.Serialization;
+
+/// <summary>
+/// A tolerant <see cref="long"/>? converter for fields such as <c>numberMatched</c>
+/// that some OGC drafts and servers emit as the string <c>"unknown"</c> (or another
+/// non-numeric token) instead of a number. Numeric values parse to a <see cref="long"/>;
+/// numeric strings parse to a <see cref="long"/>; <c>null</c>, <c>"unknown"</c>, and any
+/// other non-numeric value deserialize to <c>null</c> rather than throwing.
+/// </summary>
+/// <remarks>
+/// This mirrors the converter in <c>Honua.Sdk.OgcFeatures</c>; it is duplicated here
+/// because <c>Honua.Sdk.Catalogs</c> does not reference that package.
+/// </remarks>
+internal sealed class TolerantNullableInt64Converter : JsonConverter<long?>
+{
+    /// <inheritdoc />
+    public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.Number:
+                return reader.TryGetInt64(out var number) ? number : null;
+            case JsonTokenType.String:
+                var text = reader.GetString();
+                return long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                    ? parsed
+                    : null;
+            default:
+                reader.Skip();
+                return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (value.HasValue)
+        {
+            writer.WriteNumberValue(value.Value);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/src/Honua.Sdk.Catalogs/Stac/Models/StacItem.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/Models/StacItem.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Honua.Sdk.Catalogs.Serialization;
 
 namespace Honua.Sdk.Catalogs.Stac.Models;
 
@@ -109,6 +110,7 @@ public sealed class StacItemCollection
 
     /// <summary>Total number of items matching the query when reported by the server.</summary>
     [JsonPropertyName("numberMatched")]
+    [JsonConverter(typeof(TolerantNullableInt64Converter))]
     public long? NumberMatched { get; init; }
 
     /// <summary>Number of items returned in this page.</summary>

--- a/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
@@ -196,19 +196,34 @@ public static class GeoServicesGeometryConverter
         foreach (var ring in rings.EnumerateArray())
         {
             var linearRing = factory.CreateLinearRing(CloseRing(ReadCoordinates(ring, hasZ, hasM)));
-            if (shells.Count == 0 || !Orientation.IsCCW(linearRing.Coordinates))
+
+            // Esri JSON uses clockwise-outer ring orientation: clockwise (NOT CCW)
+            // rings are outer shells and counter-clockwise rings are holes. Classify
+            // strictly by orientation/signed area rather than ring position, so a
+            // leading hole is not mistakenly promoted to a shell and a later shell
+            // keeps its hole.
+            if (Orientation.IsCCW(linearRing.CoordinateSequence))
             {
-                shells.Add(new PolygonShell(linearRing));
+                holeRings.Add(linearRing);
             }
             else
             {
-                holeRings.Add(linearRing);
+                shells.Add(new PolygonShell(linearRing));
             }
         }
 
         if (shells.Count == 0)
         {
-            return factory.CreatePolygon();
+            // No clockwise (outer) rings were found. Rather than discarding the
+            // geometry, treat every counter-clockwise ring as a shell so the
+            // coordinates survive round-tripping.
+            if (holeRings.Count == 0)
+            {
+                return factory.CreatePolygon();
+            }
+
+            shells.AddRange(holeRings.Select(ring => new PolygonShell(ring)));
+            holeRings.Clear();
         }
 
         foreach (var holeRing in holeRings)

--- a/src/Honua.Sdk.Geometry/Vector/EsriJsonVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/EsriJsonVectorPayloadReader.cs
@@ -105,7 +105,7 @@ public sealed class EsriJsonVectorPayloadReader : IVectorPayloadReader
                 Geometry = geometry,
                 GeometryJson = geometryJson,
                 Crs = geometry?.SRID > 0
-                    ? string.Create(CultureInfo.InvariantCulture, $"EPSG:{geometry.SRID}")
+                    ? FormatWkidAuthority(geometry.SRID)
                     : null
             };
         }
@@ -213,18 +213,49 @@ public sealed class EsriJsonVectorPayloadReader : IVectorPayloadReader
             return null;
         }
 
+        // Esri provides latestWkid as the EPSG-correct code when the wkid is an
+        // Esri-proprietary identifier; prefer it when present.
         if (TryGetInt32(spatialReference, "latestWkid", out var latestWkid) && latestWkid > 0)
         {
-            return string.Create(CultureInfo.InvariantCulture, $"EPSG:{latestWkid}");
+            return FormatWkidAuthority(latestWkid);
         }
 
         if (TryGetInt32(spatialReference, "wkid", out var wkid) && wkid > 0)
         {
-            return string.Create(CultureInfo.InvariantCulture, $"EPSG:{wkid}");
+            return FormatWkidAuthority(wkid);
         }
 
         return TryGetString(spatialReference, "wkt");
     }
+
+    /// <summary>
+    /// Formats an Esri WKID as an authority-qualified CRS identifier. Known
+    /// Esri-proprietary WKIDs are mapped to their EPSG equivalents (e.g. 102100 and
+    /// 102113 to Web Mercator EPSG:3857). WKIDs that fall in Esri-only ranges with no
+    /// EPSG equivalent are emitted with an <c>ESRI:</c> authority prefix so EPSG-based
+    /// resolvers do not choke; all other codes are treated as standard EPSG codes.
+    /// </summary>
+    private static string FormatWkidAuthority(int wkid)
+    {
+        switch (wkid)
+        {
+            case 102100:
+            case 102113:
+                return "EPSG:3857";
+        }
+
+        return IsEsriProprietaryWkid(wkid)
+            ? string.Create(CultureInfo.InvariantCulture, $"ESRI:{wkid}")
+            : string.Create(CultureInfo.InvariantCulture, $"EPSG:{wkid}");
+    }
+
+    /// <summary>
+    /// Returns whether the given WKID falls in a range reserved for Esri-proprietary
+    /// spatial references that are not EPSG codes (the 53xxx, 54xxx, and 102xxx
+    /// ranges), excluding codes already mapped to an EPSG equivalent.
+    /// </summary>
+    private static bool IsEsriProprietaryWkid(int wkid)
+        => wkid is (>= 53000 and <= 54999) or (>= 102000 and <= 103999);
 
     private static bool TryReadSrid(string? spatialReference, out int srid)
     {

--- a/src/Honua.Sdk.Geometry/Vector/GeoJsonVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/GeoJsonVectorPayloadReader.cs
@@ -158,11 +158,20 @@ public sealed class GeoJsonVectorPayloadReader : IVectorPayloadReader
         var coordinates = bboxElement.EnumerateArray()
             .Where(item => item.ValueKind == JsonValueKind.Number)
             .Select(item => item.GetDouble())
-            .Take(4)
             .ToArray();
-        return coordinates.Length >= 4
-            ? new Envelope(coordinates[0], coordinates[2], coordinates[1], coordinates[3])
-            : null;
+
+        // RFC 7946 section 5: a 2D bbox is [west, south, east, north] (4 elements);
+        // a 3D bbox is [west, south, minElev, east, north, maxElev] (6 elements).
+        // For 3D, the horizontal coordinates live at indices 0,1,3,4 and the
+        // elevation values at indices 2,5 are ignored. Other lengths are rejected.
+        // Envelope(double x1, double x2, double y1, double y2) takes
+        // (west, east, south, north).
+        return coordinates.Length switch
+        {
+            4 => new Envelope(coordinates[0], coordinates[2], coordinates[1], coordinates[3]),
+            6 => new Envelope(coordinates[0], coordinates[3], coordinates[1], coordinates[4]),
+            _ => null,
+        };
     }
 
     private static string? ReadCrs(JsonElement root)

--- a/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
@@ -200,8 +200,66 @@ public sealed class GmlVectorPayloadReader : IVectorPayloadReader
         GeometryFactory? geometryFactory)
     {
         var reader = new GMLReader(geometryFactory ?? DefaultGeometryFactory);
-        return reader.Read(new XDocument(new XElement(geometryElement)));
+        var geometry = reader.Read(new XDocument(new XElement(geometryElement)));
+
+        // GML 3.2 / OGC URN axis-order handling. NTS GMLReader always reads
+        // coordinates in document order (X then Y) and never swaps based on the
+        // declared CRS. However, when the CRS is referenced in OGC URN form for a
+        // geographic CRS that mandates a lat,lon (Y,X) axis order — notably
+        // urn:ogc:def:crs:EPSG::4326 — the GML coordinates are encoded lat,lon and
+        // must be swapped to NTS's lon,lat (X,Y) convention. The legacy, non-URN
+        // forms (EPSG:4326, http://www.opengis.net/gml/srs/epsg.xml#4326) are
+        // interpreted by clients as lon,lat and must NOT be swapped. Be conservative:
+        // only swap for URN-form geographic EPSG CRSes.
+        if (ShouldSwapAxes(ReadSrsName(geometryElement)))
+        {
+            geometry.Apply(SwapXyCoordinateFilter.Instance);
+        }
+
+        return geometry;
     }
+
+    /// <summary>
+    /// Determines whether a parsed geometry's X/Y coordinates should be swapped to
+    /// honor a CRS-mandated lat,lon axis order. Only OGC URN-form geographic EPSG
+    /// CRSes (e.g. <c>urn:ogc:def:crs:EPSG::4326</c>, <c>urn:x-ogc:def:crs:EPSG:4326</c>)
+    /// trigger a swap; legacy short or HTTP forms are treated as lon,lat.
+    /// </summary>
+    private static bool ShouldSwapAxes(string? srsName)
+    {
+        if (string.IsNullOrWhiteSpace(srsName))
+        {
+            return false;
+        }
+
+        var trimmed = srsName.Trim();
+        var isUrn = trimmed.StartsWith("urn:ogc:def:crs:EPSG:", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("urn:x-ogc:def:crs:EPSG:", StringComparison.OrdinalIgnoreCase);
+        if (!isUrn)
+        {
+            return false;
+        }
+
+        return TryReadSrid(trimmed, out var srid) && IsLatLonGeographicCrs(srid);
+    }
+
+    /// <summary>
+    /// Returns whether the given EPSG code is a geographic CRS whose authoritative
+    /// axis order is lat,lon (Y,X). The common geographic CRSes used in OGC services
+    /// are enumerated; this errs on the side of not swapping for unknown codes.
+    /// </summary>
+    private static bool IsLatLonGeographicCrs(int srid)
+        => srid switch
+        {
+            4326 or // WGS 84
+            4269 or // NAD83
+            4258 or // ETRS89
+            4267 or // NAD27
+            4283 or // GDA94
+            4019 or // GRS 1980 ensemble
+            4979 => true, // WGS 84 (3D)
+            _ => false,
+        };
 
     private static Envelope? ReadEnvelope(XElement root, GeometryFactory? geometryFactory)
     {
@@ -367,5 +425,27 @@ public sealed class GmlVectorPayloadReader : IVectorPayloadReader
     {
         using var document = JsonDocument.Parse(bytes);
         return document.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// An NTS coordinate filter that swaps the X and Y ordinates of every coordinate
+    /// in place, used to convert lat,lon-ordered geographic GML coordinates into
+    /// NTS's lon,lat (X,Y) convention.
+    /// </summary>
+    private sealed class SwapXyCoordinateFilter : ICoordinateSequenceFilter
+    {
+        public static SwapXyCoordinateFilter Instance { get; } = new();
+
+        public bool Done => false;
+
+        public bool GeometryChanged => true;
+
+        public void Filter(CoordinateSequence seq, int i)
+        {
+            var x = seq.GetX(i);
+            var y = seq.GetY(i);
+            seq.SetX(i, y);
+            seq.SetY(i, x);
+        }
     }
 }

--- a/src/Honua.Sdk.OgcFeatures/Conversion/TolerantNullableInt64Converter.cs
+++ b/src/Honua.Sdk.OgcFeatures/Conversion/TolerantNullableInt64Converter.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.OgcFeatures.Conversion;
+
+/// <summary>
+/// A tolerant <see cref="long"/>? converter for fields such as <c>numberMatched</c>
+/// that some OGC drafts and servers emit as the string <c>"unknown"</c> (or another
+/// non-numeric token) instead of a number. Numeric values parse to a <see cref="long"/>;
+/// numeric strings parse to a <see cref="long"/>; <c>null</c>, <c>"unknown"</c>, and any
+/// other non-numeric value deserialize to <c>null</c> rather than throwing.
+/// </summary>
+internal sealed class TolerantNullableInt64Converter : JsonConverter<long?>
+{
+    /// <inheritdoc />
+    public override long? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.Null:
+                return null;
+            case JsonTokenType.Number:
+                return reader.TryGetInt64(out var number) ? number : null;
+            case JsonTokenType.String:
+                var text = reader.GetString();
+                return long.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+                    ? parsed
+                    : null;
+            default:
+                reader.Skip();
+                return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, long? value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (value.HasValue)
+        {
+            writer.WriteNumberValue(value.Value);
+        }
+        else
+        {
+            writer.WriteNullValue();
+        }
+    }
+}

--- a/src/Honua.Sdk.OgcFeatures/Models/OgcFeatureCollection.cs
+++ b/src/Honua.Sdk.OgcFeatures/Models/OgcFeatureCollection.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Text.Json.Serialization;
+using Honua.Sdk.OgcFeatures.Conversion;
 
 namespace Honua.Sdk.OgcFeatures.Models;
 
@@ -20,6 +21,7 @@ public sealed class OgcFeatureCollection
 
     /// <summary>Total number of features matching the query (server-reported).</summary>
     [JsonPropertyName("numberMatched")]
+    [JsonConverter(typeof(TolerantNullableInt64Converter))]
     public long? NumberMatched { get; init; }
 
     /// <summary>Number of features returned in this page.</summary>

--- a/tests/Honua.Sdk.Catalogs.RecordsTests/TolerantNumberMatchedTests.cs
+++ b/tests/Honua.Sdk.Catalogs.RecordsTests/TolerantNumberMatchedTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Catalogs.RecordsTests;
+
+public sealed class TolerantNumberMatchedTests
+{
+    [Fact]
+    public void Deserialize_NumberMatchedUnknown_ReturnsNull()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": "unknown", "numberReturned": 0, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, OgcRecordsJsonContext.Default.OgcRecordCollection);
+
+        Assert.NotNull(collection);
+        Assert.Null(collection!.NumberMatched);
+    }
+
+    [Fact]
+    public void Deserialize_NumberMatchedNumeric_ReturnsValue()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": 13, "numberReturned": 1, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, OgcRecordsJsonContext.Default.OgcRecordCollection);
+
+        Assert.NotNull(collection);
+        Assert.Equal(13, collection!.NumberMatched);
+    }
+}

--- a/tests/Honua.Sdk.Catalogs.StacTests/TolerantNumberMatchedTests.cs
+++ b/tests/Honua.Sdk.Catalogs.StacTests/TolerantNumberMatchedTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Catalogs.StacTests;
+
+public sealed class TolerantNumberMatchedTests
+{
+    [Fact]
+    public void Deserialize_NumberMatchedUnknown_ReturnsNull()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": "unknown", "numberReturned": 0, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, StacJsonContext.Default.StacItemCollection);
+
+        Assert.NotNull(collection);
+        Assert.Null(collection!.NumberMatched);
+    }
+
+    [Fact]
+    public void Deserialize_NumberMatchedNumeric_ReturnsValue()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": 7, "numberReturned": 1, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, StacJsonContext.Default.StacItemCollection);
+
+        Assert.NotNull(collection);
+        Assert.Equal(7, collection!.NumberMatched);
+    }
+}

--- a/tests/Honua.Sdk.Geometry.Tests/GeoServicesGeometryConverterTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GeoServicesGeometryConverterTests.cs
@@ -80,6 +80,33 @@ public class GeoServicesGeometryConverterTests
     }
 
     [Fact]
+    public void ReadGeometry_LeadingHoleRing_ClassifiesByOrientationNotPosition()
+    {
+        // The CCW hole ring is listed FIRST, before the CW outer shell. Esri JSON does
+        // not mandate shell-before-hole ordering; classification must be by orientation
+        // (CW = shell, CCW = hole), so the hole must not be promoted to the exterior.
+        using var document = JsonDocument.Parse(
+            """
+            {
+                "rings": [
+                    [[2,2],[8,2],[8,8],[2,8],[2,2]],
+                    [[0,0],[0,10],[10,10],[10,0],[0,0]]
+                ],
+                "spatialReference": { "wkid": 4326 }
+            }
+            """);
+
+        var geometry = GeoServicesGeometryConverter.ReadGeometry(document.RootElement);
+
+        var polygon = Assert.IsType<Polygon>(geometry);
+        Assert.True(polygon.IsValid);
+        Assert.Equal(1, polygon.NumInteriorRings);
+        // Exterior is the 10x10 outer ring; the 6x6 hole is subtracted -> area 100 - 36 = 64.
+        Assert.Equal(5, polygon.ExteriorRing.NumPoints);
+        Assert.Equal(64.0, polygon.Area, 6);
+    }
+
+    [Fact]
     public void WriteGeometry_WritesLinePathWithDimensionality()
     {
         var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);

--- a/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
@@ -121,6 +121,181 @@ public sealed class VectorPayloadReaderTests
         Assert.Equal(21.267, point.Y, 3);
     }
 
+    [Fact]
+    public async Task GeoJsonReader_Parses3DBbox_MapsHorizontalExtentIgnoringElevation()
+    {
+        // RFC 7946 section 5: a 3D bbox is [west, south, minElev, east, north, maxElev].
+        const string json = """
+            {
+              "type": "FeatureCollection",
+              "bbox": [-158, 21, 0, -157, 22, 1500],
+              "features": []
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.GeoJson);
+
+        Assert.NotNull(result.Extent);
+        Assert.Equal(-158, result.Extent!.MinX, 6); // west
+        Assert.Equal(-157, result.Extent.MaxX, 6);  // east
+        Assert.Equal(21, result.Extent.MinY, 6);    // south
+        Assert.Equal(22, result.Extent.MaxY, 6);    // north
+    }
+
+    [Fact]
+    public async Task GeoJsonReader_Parses2DBbox_Unchanged()
+    {
+        const string json = """
+            {
+              "type": "FeatureCollection",
+              "bbox": [-158, 21, -157, 22],
+              "features": []
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.GeoJson);
+
+        Assert.NotNull(result.Extent);
+        Assert.Equal(-158, result.Extent!.MinX, 6);
+        Assert.Equal(-157, result.Extent.MaxX, 6);
+        Assert.Equal(21, result.Extent.MinY, 6);
+        Assert.Equal(22, result.Extent.MaxY, 6);
+    }
+
+    [Fact]
+    public async Task GmlReader_UrnGeographicCrs_SwapsAxesToLonLat()
+    {
+        // urn:ogc:def:crs:EPSG::4326 mandates lat,lon axis order; the pos below is
+        // "lat lon" (21.267 -157.819) and must come back as lon,lat (X=-157.819).
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <wfs:member>
+                <honua:park gml:id="parks.1">
+                  <honua:shape>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+                      <gml:pos>21.267 -157.819</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:park>
+              </wfs:member>
+            </wfs:FeatureCollection>
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(gml), VectorPayloadFormat.Gml);
+
+        var point = Assert.IsType<Point>(Assert.Single(result.Features).Geometry);
+        Assert.Equal(4326, point.SRID);
+        Assert.Equal(-157.819, point.X, 3); // longitude, western hemisphere
+        Assert.Equal(21.267, point.Y, 3);   // latitude, northern hemisphere
+    }
+
+    [Fact]
+    public async Task GmlReader_NonUrnGeographicCrs_DoesNotSwapAxes()
+    {
+        // The short EPSG:4326 form is interpreted as lon,lat and must NOT be swapped.
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <wfs:member>
+                <honua:park gml:id="parks.1">
+                  <honua:shape>
+                    <gml:Point srsName="EPSG:4326">
+                      <gml:pos>-157.819 21.267</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:park>
+              </wfs:member>
+            </wfs:FeatureCollection>
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(gml), VectorPayloadFormat.Gml);
+
+        var point = Assert.IsType<Point>(Assert.Single(result.Features).Geometry);
+        Assert.Equal(-157.819, point.X, 3);
+        Assert.Equal(21.267, point.Y, 3);
+    }
+
+    [Fact]
+    public async Task EsriJsonReader_WebMercatorWkid_MapsToEpsg3857()
+    {
+        const string json = """
+            {
+              "spatialReference": { "wkid": 102100 },
+              "features": [
+                { "attributes": { "OBJECTID": 1 }, "geometry": { "x": -17578142.0, "y": 2428724.0 } }
+              ]
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.EsriJson);
+
+        Assert.Equal("EPSG:3857", result.Crs);
+        Assert.Equal("EPSG:3857", Assert.Single(result.Features).Crs);
+    }
+
+    [Fact]
+    public async Task EsriJsonReader_LatestWkidPreferred_MapsToEpsg()
+    {
+        const string json = """
+            {
+              "spatialReference": { "wkid": 102100, "latestWkid": 3857 },
+              "features": [
+                { "attributes": { "OBJECTID": 1 }, "geometry": { "x": -17578142.0, "y": 2428724.0 } }
+              ]
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.EsriJson);
+
+        Assert.Equal("EPSG:3857", result.Crs);
+    }
+
+    [Fact]
+    public async Task EsriJsonReader_UnknownEsriProprietaryWkid_UsesEsriAuthority()
+    {
+        const string json = """
+            {
+              "spatialReference": { "wkid": 53034 },
+              "features": [
+                { "attributes": { "OBJECTID": 1 }, "geometry": { "x": 0.0, "y": 0.0 } }
+              ]
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.EsriJson);
+
+        Assert.Equal("ESRI:53034", result.Crs);
+        Assert.Equal("ESRI:53034", Assert.Single(result.Features).Crs);
+    }
+
+    [Fact]
+    public async Task EsriJsonReader_StandardEpsgWkid_UsesEpsgAuthority()
+    {
+        const string json = """
+            {
+              "spatialReference": { "wkid": 4326 },
+              "features": [
+                { "attributes": { "OBJECTID": 1 }, "geometry": { "x": -157.8, "y": 21.3 } }
+              ]
+            }
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(json), VectorPayloadFormat.EsriJson);
+
+        Assert.Equal("EPSG:4326", result.Crs);
+    }
+
     private static Stream ToStream(string payload)
         => new MemoryStream(Encoding.UTF8.GetBytes(payload));
 }

--- a/tests/Honua.Sdk.OgcFeatures.Tests/Models/TolerantNumberMatchedTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/Models/TolerantNumberMatchedTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+using Honua.Sdk.OgcFeatures;
+
+namespace Honua.Sdk.OgcFeatures.Tests.Models;
+
+public sealed class TolerantNumberMatchedTests
+{
+    [Fact]
+    public void Deserialize_NumberMatchedUnknown_ReturnsNull()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": "unknown", "numberReturned": 0, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, OgcFeaturesJsonContext.Default.OgcFeatureCollection);
+
+        Assert.NotNull(collection);
+        Assert.Null(collection!.NumberMatched);
+        Assert.Equal(0, collection.NumberReturned);
+    }
+
+    [Fact]
+    public void Deserialize_NumberMatchedNumeric_ReturnsValue()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": 42, "numberReturned": 1, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, OgcFeaturesJsonContext.Default.OgcFeatureCollection);
+
+        Assert.NotNull(collection);
+        Assert.Equal(42, collection!.NumberMatched);
+    }
+
+    [Fact]
+    public void Deserialize_NumberMatchedNumericString_ReturnsValue()
+    {
+        const string json = """
+            { "type": "FeatureCollection", "numberMatched": "42", "numberReturned": 1, "features": [] }
+            """;
+
+        var collection = JsonSerializer.Deserialize(json, OgcFeaturesJsonContext.Default.OgcFeatureCollection);
+
+        Assert.NotNull(collection);
+        Assert.Equal(42, collection!.NumberMatched);
+    }
+}


### PR DESCRIPTION
Closes #203
Closes #205
Closes #206

## Summary

### #203 — GeoJSON 3D bbox parsed as 2D
`GeoJsonVectorPayloadReader.ReadBbox` now detects bbox length per RFC 7946 §5: a 6-element 3D bbox `[west,south,minElev,east,north,maxElev]` maps horizontal coords from indices 0/3/1/4 (elevation ignored); 4-element 2D bbox keeps the existing 0/1/2/3 mapping; other lengths return null.

### #205 — tolerant `numberMatched` converter
Added an internal `TolerantNullableInt64Converter` (`JsonConverter<long?>`) in `Honua.Sdk.OgcFeatures` and a package-local copy in `Honua.Sdk.Catalogs` (which does not reference OgcFeatures). Numeric/numeric-string → `long`; `"unknown"`/null/non-numeric → `null` instead of throwing. Applied via `[JsonConverter]` to `OgcFeatureCollection.NumberMatched`, `StacItemCollection.NumberMatched`, and `OgcRecordCollection.NumberMatched`. Mirrors the existing WFS handling. Compatible with source-generated `JsonSerializerContext`.

### #206 — geometry/CRS correctness
1. **GML 3.2 axis order:** `GmlVectorPayloadReader` swaps X/Y for OGC URN-form geographic EPSG CRSes (e.g. `urn:ogc:def:crs:EPSG::4326`) that mandate lat,lon; legacy short/HTTP forms are left as lon,lat. Implemented with an NTS `ICoordinateSequenceFilter`.
2. **GeoServices ring classification:** `GeoServicesGeometryConverter.ReadRings` now classifies rings strictly by orientation (Esri clockwise-outer: CW = shell, CCW = hole), removing the positional first-ring override so a leading hole is no longer promoted to a shell.
3. **Esri WKID → EPSG:** `EsriJsonVectorPayloadReader` maps known Esri WKIDs (102100/102113 → EPSG:3857), prefers `latestWkid` when present, emits `ESRI:{wkid}` for Esri-proprietary ranges (53xxx/54xxx/102xxx), and `EPSG:{wkid}` otherwise.

## Tests
New xUnit tests added: 3D/2D bbox, GML URN-swap + non-URN no-swap, leading-hole ring assembly, Esri WKID mapping (102100→3857, latestWkid, unknown→ESRI:, standard EPSG), and tolerant `numberMatched` for OgcFeatureCollection / StacItemCollection / OgcRecordCollection.

All pass: Geometry 84, OgcFeatures 110, Stac 46, Records 45. Strict build (`TreatWarningsAsErrors`) clean.

## API compatibility
APICompat ran successfully without finding any breaking changes. All new types are internal/private; public models only gained `[JsonConverter]` attributes.