### PR TITLE
Fix default resilience config that broke clients on first use (#200)

### DIFF
--- a/src/Honua.Sdk.Abstractions/HonuaResilienceTimeouts.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaResilienceTimeouts.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions;
+
+/// <summary>
+/// Centralizes the timeout math shared by every package's
+/// <c>AddStandardResilienceHandler</c> registration so the standard resilience
+/// pipeline validates successfully and leaves real budget for retries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AddStandardResilienceHandler</c> validates that the circuit-breaker
+/// <c>SamplingDuration</c> (default 30 s) is at least <em>double</em> the
+/// per-attempt timeout. With the default option <see cref="IHonuaClientOptions.Timeout"/>
+/// of 100 s, naively setting <c>AttemptTimeout = Timeout</c> fails that check and
+/// throws <c>OptionsValidationException</c> the first time any client is resolved.
+/// </para>
+/// <para>
+/// This helper treats <see cref="IHonuaClientOptions.Timeout"/> as the
+/// <em>overall</em> request budget (matching its documented meaning, "including
+/// retry attempts") and derives a per-attempt timeout that (a) stays strictly
+/// below half the circuit-breaker sampling window and (b) leaves room for retries
+/// when the overall budget allows it.
+/// </para>
+/// </remarks>
+public static class HonuaResilienceTimeouts
+{
+    /// <summary>
+    /// The standard resilience handler's default circuit-breaker sampling
+    /// duration. The handler requires <c>SamplingDuration &gt;= 2 * AttemptTimeout</c>.
+    /// </summary>
+    public static readonly TimeSpan CircuitBreakerSamplingDuration = TimeSpan.FromSeconds(30);
+
+    // A small margin below SamplingDuration/2 (15 s) keeps the validator happy
+    // even accounting for any internal rounding, and is a sane per-attempt ceiling.
+    private static readonly TimeSpan MaxAttemptTimeout = TimeSpan.FromSeconds(14);
+
+    /// <summary>
+    /// Computes the per-attempt timeout for the standard resilience handler from
+    /// the caller's overall <paramref name="totalTimeout"/> budget. The result is
+    /// always strictly less than half of <see cref="CircuitBreakerSamplingDuration"/>
+    /// (so handler validation passes) and never exceeds the overall budget. When
+    /// the overall budget is large, the per-attempt timeout is capped so multiple
+    /// attempts fit inside the budget.
+    /// </summary>
+    /// <param name="totalTimeout">The overall request budget (the option <c>Timeout</c>).</param>
+    /// <returns>A per-attempt timeout suitable for <c>AttemptTimeout.Timeout</c>.</returns>
+    public static TimeSpan AttemptTimeout(TimeSpan totalTimeout)
+    {
+        if (totalTimeout <= MaxAttemptTimeout)
+        {
+            // Budget already fits within a single valid attempt; leave a little
+            // headroom for at least a second attempt when the budget is not tiny.
+            return totalTimeout;
+        }
+
+        return MaxAttemptTimeout;
+    }
+
+    /// <summary>
+    /// Computes the overall request timeout for the standard resilience handler's
+    /// <c>TotalRequestTimeout</c>. This is the caller's overall budget, which is
+    /// guaranteed to be at least the per-attempt timeout.
+    /// </summary>
+    /// <param name="totalTimeout">The overall request budget (the option <c>Timeout</c>).</param>
+    /// <returns>A total request timeout suitable for <c>TotalRequestTimeout.Timeout</c>.</returns>
+    public static TimeSpan TotalRequestTimeout(TimeSpan totalTimeout) => totalTimeout;
+
+    /// <summary>
+    /// Computes the <see cref="System.Net.Http.HttpClient.Timeout"/> to apply to the typed
+    /// client. When the resilience pipeline is enabled it owns all timing, so the
+    /// outer <c>HttpClient.Timeout</c> must not pre-empt the total budget (otherwise
+    /// a 100 s budget is silently capped at the same single value used for one
+    /// attempt). When retry is disabled, the option <paramref name="totalTimeout"/>
+    /// is honored directly.
+    /// </summary>
+    /// <param name="totalTimeout">The overall request budget (the option <c>Timeout</c>).</param>
+    /// <param name="resilienceEnabled">Whether the standard resilience pipeline is registered.</param>
+    /// <returns>The value to assign to <c>HttpClient.Timeout</c>.</returns>
+    public static TimeSpan HttpClientTimeout(TimeSpan totalTimeout, bool resilienceEnabled)
+        => resilienceEnabled ? System.Threading.Timeout.InfiniteTimeSpan : totalTimeout;
+}

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
         httpBuilder.AddTypedClient<IHonuaCatalogClient>(httpClient => new HonuaCatalogClient(httpClient));
@@ -104,7 +104,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
 
@@ -142,7 +142,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaAdminClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
         httpBuilder.AddTypedClient<IHonuaGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
@@ -174,8 +174,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaOgcRecordsClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaOgcRecordsAuthHandler>();
         services.AddTransient<IHonuaOgcRecordsClient>(sp => sp.GetRequiredService<HonuaOgcRecordsClient>());
@@ -53,8 +53,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaStacClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaStacAuthHandler>();
         services.AddTransient<IHonuaStacClient>(sp => sp.GetRequiredService<HonuaStacClient>());
@@ -54,8 +54,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaConsoleShareClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaConsoleShareAuthHandler>();
 
@@ -68,7 +68,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaConsoleShareClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaConsoleShareAuthHandler>();
 
@@ -88,8 +88,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaFeatureServerClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
@@ -85,7 +85,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
@@ -118,7 +118,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
 
@@ -150,7 +150,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
 
@@ -171,8 +171,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaOgcFeaturesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcFeaturesClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
@@ -60,8 +60,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();
@@ -73,7 +73,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaOgcFeaturesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcStylesClient>(sp => sp.GetRequiredService<HonuaOgcStylesClient>());
@@ -87,8 +87,8 @@ public static class ServiceCollectionExtensions
         {
             stylesBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaWfsClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaWfsAuthHandler>();
         services.AddTransient<IHonuaWfsClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
@@ -57,8 +57,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaProcessesClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaProcessesAuthHandler>();
 
@@ -46,8 +46,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaSceneClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaSceneAuthHandler>();
         services.AddTransient<IHonuaSceneClient>(sp => sp.GetRequiredService<HonuaSceneClient>());
@@ -54,8 +54,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaSpecClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaSpecAuthHandler>();
 
@@ -52,8 +52,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
         {
             var options = sp.GetRequiredService<IOptions<HonuaStudioClientOptions>>().Value;
             client.BaseAddress = options.BaseAddress;
-            client.Timeout = options.Timeout;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
         })
         .AddHttpMessageHandler<HonuaStudioAuthHandler>();
 
@@ -46,8 +46,8 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.AddStandardResilienceHandler(options =>
             {
-                options.TotalRequestTimeout.Timeout = snapshot.Timeout;
-                options.AttemptTimeout.Timeout = snapshot.Timeout;
+                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
+                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/tests/Honua.Sdk.OgcFeatures.Tests/DefaultResilienceTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/DefaultResilienceTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.OgcFeatures.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.OgcFeatures.Tests;
+
+/// <summary>
+/// Regression tests for issue #200: registering and using a client with the
+/// SDK's default options (retry enabled, 100 s timeout) must not throw
+/// <c>OptionsValidationException</c> when the standard resilience pipeline is
+/// built on first use.
+/// </summary>
+public sealed class DefaultResilienceTests
+{
+    private static IServiceProvider BuildDefaultProvider(HttpStatusCode responseStatus)
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaOgcFeatures(options =>
+        {
+            // Only the required BaseAddress is configured. EnableRetry (true) and
+            // Timeout (100 s) keep their defaults so the resilience pipeline is
+            // built with the exact configuration that previously threw.
+            options.BaseAddress = new Uri("https://example.test");
+            options.PrimaryHttpMessageHandlerFactory =
+                () => new StubHandler(responseStatus);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task DefaultConfiguredClient_ResolvesAndSendsWithoutValidationException()
+    {
+        using var provider = (ServiceProvider)BuildDefaultProvider(HttpStatusCode.OK);
+
+        // Resolving builds the typed client; the standard resilience pipeline is
+        // materialized and validated lazily on the first send. Both steps must
+        // succeed with default options.
+        var client = provider.GetRequiredService<HonuaOgcFeaturesClient>();
+        Assert.NotNull(client);
+
+        var http = GetHttpClient(client);
+        using var response = await http.GetAsync(
+            new Uri("https://example.test/collections"), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DefaultConfiguredClient_RetriesTransientFailures()
+    {
+        var services = new ServiceCollection();
+        var handler = new CountingTransientHandler(failuresBeforeSuccess: 2);
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = new Uri("https://example.test");
+            options.PrimaryHttpMessageHandlerFactory = () => handler;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<HonuaOgcFeaturesClient>();
+        var http = GetHttpClient(client);
+
+        using var response = await http.GetAsync(
+            new Uri("https://example.test/collections"), CancellationToken.None);
+
+        // The two 503s should have been retried and then succeeded, proving the
+        // total budget actually leaves room for retry attempts.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, handler.Attempts);
+    }
+
+    private static HttpClient GetHttpClient(HonuaOgcFeaturesClient client)
+    {
+        var field = typeof(HonuaOgcFeaturesClient).GetField(
+            "_http",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        return Assert.IsType<HttpClient>(field!.GetValue(client));
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public StubHandler(HttpStatusCode status) => _status = status;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(_status));
+    }
+
+    private sealed class CountingTransientHandler : HttpMessageHandler
+    {
+        private readonly int _failuresBeforeSuccess;
+        private int _attempts;
+
+        public CountingTransientHandler(int failuresBeforeSuccess)
+            => _failuresBeforeSuccess = failuresBeforeSuccess;
+
+        public int Attempts => _attempts;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var attempt = Interlocked.Increment(ref _attempts);
+            var status = attempt <= _failuresBeforeSuccess
+                ? HttpStatusCode.ServiceUnavailable
+                : HttpStatusCode.OK;
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+}


### PR DESCRIPTION
## Problem (#200, P0)

`AddStandardResilienceHandler` validates that the circuit-breaker `SamplingDuration` (default 30s) is at least **double** the `AttemptTimeout`. Every package configured:

```csharp
options.TotalRequestTimeout.Timeout = snapshot.Timeout;
options.AttemptTimeout.Timeout      = snapshot.Timeout;   // same value
```

With the default `Timeout` of 100s and `EnableRetry = true`, resolving/using **any** client threw `OptionsValidationException` on first use ("Sampling Duration: 30s, Attempt Timeout: 100s"). The SDK shipped broken by default. Secondary defect: even with a valid sub-15s timeout, `TotalRequestTimeout == AttemptTimeout` left zero budget for retries, and `HttpClient.Timeout` pinned to the same value pre-empted the pipeline.

## Fix

New `Honua.Sdk.Abstractions.HonuaResilienceTimeouts` centralizes the timeout math:

- Treats the option `Timeout` as the **overall** request budget (matching its documented meaning, "including retry attempts").
- `AttemptTimeout` is capped at 14s — strictly below half the 30s sampling window — so handler validation always passes and retries keep budget. (Small budgets pass through unchanged.)
- `TotalRequestTimeout` = the overall budget, so retries have room.
- `HttpClient.Timeout` is set to infinite when the resilience pipeline is enabled (the pipeline owns all timing); honored directly when retry is disabled.

Applied across all 11 packages' `ServiceCollectionExtensions.cs` (Admin, Records, Stac, ConsoleShare, GeoServices, OgcFeatures, Wfs, Processes, Scenes, Spec, Studio).

## Test

`DefaultResilienceTests` registers a default-configured `HonuaOgcFeaturesClient` and asserts it (a) resolves + sends without `OptionsValidationException`, and (b) retries transient 503s and succeeds — proving the total budget actually leaves room for retries.

## Verification

- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.
- OgcFeatures tests: 112 passed (incl. 2 new). MetaSmoke (umbrella registration): 3 passed.

Closes #200