### PR TITLE
Disable HTTP auto-redirect by default to stop X-API-Key leak

### DIFF
--- a/src/Honua.Sdk.Abstractions/HonuaHttpHandlerDefaults.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaHttpHandlerDefaults.cs
@@ -25,19 +25,41 @@ namespace Honua.Sdk.Abstractions;
 /// <see cref="IHonuaClientOptions.PrimaryHttpMessageHandlerFactory"/> and accept
 /// the responsibility for the credential-forwarding semantics that entails.
 /// </para>
+/// <para>
+/// On the browser/WASM runtime there is no managed socket stack:
+/// <c>SocketsHttpHandler</c> is not supported and constructing one throws
+/// <see cref="System.PlatformNotSupportedException"/>. There, requests are issued
+/// through the browser <c>fetch</c> API, which enforces the same-origin policy and
+/// CORS for cross-origin redirects (the user agent — not this SDK — controls
+/// whether custom headers survive a redirect), so the desktop/server credential
+/// leak vector does not apply. On that platform this factory returns the default
+/// browser-backed handler unchanged.
+/// </para>
 /// </remarks>
 public static class HonuaHttpHandlerDefaults
 {
     /// <summary>
     /// Creates the default primary HTTP message handler used when a consumer does
     /// not supply a <see cref="IHonuaClientOptions.PrimaryHttpMessageHandlerFactory"/>.
-    /// Automatic redirect following is disabled so the custom <c>X-API-Key</c>
-    /// header is never forwarded to a redirect target host.
+    /// On desktop/server runtimes automatic redirect following is disabled so the
+    /// custom <c>X-API-Key</c> header is never forwarded to a redirect target host.
+    /// On the browser/WASM runtime the platform default handler is returned
+    /// unchanged, because <c>SocketsHttpHandler</c> is not supported there and the
+    /// browser already governs cross-origin redirect credential forwarding.
     /// </summary>
-    /// <returns>A fresh <see cref="System.Net.Http.HttpMessageHandler"/> with auto-redirect disabled.</returns>
+    /// <returns>A fresh <see cref="System.Net.Http.HttpMessageHandler"/>.</returns>
     public static System.Net.Http.HttpMessageHandler CreateNoRedirectPrimaryHandler()
-        => new System.Net.Http.SocketsHttpHandler
+    {
+        if (System.OperatingSystem.IsBrowser())
+        {
+            // SocketsHttpHandler is unsupported on WASM; the browser fetch stack
+            // handles redirects and cross-origin credential rules itself.
+            return new System.Net.Http.HttpClientHandler();
+        }
+
+        return new System.Net.Http.SocketsHttpHandler
         {
             AllowAutoRedirect = false,
         };
+    }
 }

--- a/src/Honua.Sdk.Abstractions/HonuaHttpHandlerDefaults.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaHttpHandlerDefaults.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions;
+
+/// <summary>
+/// Shared defaults for the primary HTTP message handler used by every Honua SDK
+/// REST client registration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Honua REST clients attach the API key as a custom <c>X-API-Key</c> header
+/// (and a bearer token via <c>Authorization</c>). <see cref="System.Net.Http.HttpClient"/>
+/// strips <c>Authorization</c> on cross-origin auto-redirects, but it forwards
+/// custom headers such as <c>X-API-Key</c> to the redirect <c>Location</c> host.
+/// An attacker-controlled <c>30x</c> response could therefore exfiltrate the API
+/// key to an arbitrary host.
+/// </para>
+/// <para>
+/// To close that hole, every Honua SDK client disables automatic redirect
+/// following by default. A <c>30x</c> response surfaces to the caller as a
+/// redirect status code (handled like any other non-success response) rather
+/// than being silently followed with credentials attached. Consumers that
+/// genuinely need redirect following can supply their own
+/// <see cref="IHonuaClientOptions.PrimaryHttpMessageHandlerFactory"/> and accept
+/// the responsibility for the credential-forwarding semantics that entails.
+/// </para>
+/// </remarks>
+public static class HonuaHttpHandlerDefaults
+{
+    /// <summary>
+    /// Creates the default primary HTTP message handler used when a consumer does
+    /// not supply a <see cref="IHonuaClientOptions.PrimaryHttpMessageHandlerFactory"/>.
+    /// Automatic redirect following is disabled so the custom <c>X-API-Key</c>
+    /// header is never forwarded to a redirect target host.
+    /// </summary>
+    /// <returns>A fresh <see cref="System.Net.Http.HttpMessageHandler"/> with auto-redirect disabled.</returns>
+    public static System.Net.Http.HttpMessageHandler CreateNoRedirectPrimaryHandler()
+        => new System.Net.Http.SocketsHttpHandler
+        {
+            AllowAutoRedirect = false,
+        };
+}

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -169,6 +169,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
@@ -48,6 +48,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
@@ -49,6 +49,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
@@ -83,6 +83,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -166,6 +166,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -55,6 +55,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {
@@ -81,6 +88,13 @@ public static class ServiceCollectionExtensions
         if (snapshot.PrimaryHttpMessageHandlerFactory is { } stylesPrimaryHandlerFactory)
         {
             stylesBuilder.ConfigurePrimaryHttpMessageHandler(stylesPrimaryHandlerFactory);
+        }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            stylesBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
         }
 
         if (snapshot.EnableRetry)

--- a/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -52,6 +52,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
@@ -49,6 +49,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
@@ -47,6 +47,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
@@ -41,6 +41,13 @@ public static class ServiceCollectionExtensions
         {
             httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
         }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
 
         if (snapshot.EnableRetry)
         {

--- a/tests/Honua.Sdk.OgcFeatures.Tests/RedirectApiKeyLeakTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/RedirectApiKeyLeakTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Honua.Sdk.OgcFeatures.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.OgcFeatures.Tests;
+
+/// <summary>
+/// Regression coverage for issue #214: the custom <c>X-API-Key</c> header must
+/// never be forwarded to a cross-origin redirect target. The default primary
+/// HTTP handler disables auto-redirect, so a <c>30x</c> response surfaces to the
+/// caller instead of being silently followed with credentials attached.
+/// </summary>
+public sealed class RedirectApiKeyLeakTests
+{
+    [Fact]
+    public void DefaultPrimaryHandler_DisablesAutoRedirect()
+    {
+        using var handler = Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler();
+
+        var socketsHandler = Assert.IsType<SocketsHttpHandler>(handler);
+        Assert.False(socketsHandler.AllowAutoRedirect);
+    }
+
+    [Fact]
+    public async Task ConfiguredClient_DoesNotFollowRedirect_AndDoesNotLeakApiKey()
+    {
+        // "Attacker" origin records every header it receives.
+        var receivedApiKeys = new ConcurrentBag<string?>();
+        using var attacker = new LoopbackServer(context =>
+        {
+            receivedApiKeys.Add(context.Request.Headers["X-API-Key"]);
+            context.Response.StatusCode = (int)HttpStatusCode.OK;
+        });
+
+        // Legit origin issues a cross-origin 302 to the attacker.
+        using var legit = new LoopbackServer(context =>
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.Found;
+            context.Response.Headers["Location"] = attacker.BaseAddress.ToString();
+        });
+
+        var services = new ServiceCollection();
+        services.AddHonuaOgcFeatures(options =>
+        {
+            options.BaseAddress = legit.BaseAddress;
+            options.ApiKey = "super-secret-key";
+            // Keep the test deterministic — no retry pipeline wrapping the response.
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        // The typed client registration uses the client type name as the logical name.
+        using var client = factory.CreateClient(nameof(HonuaOgcFeaturesClient));
+        client.BaseAddress = legit.BaseAddress;
+
+        using var response = await client.GetAsync("collections");
+
+        // The redirect is surfaced, NOT auto-followed.
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+
+        // The attacker origin must never have been contacted, and certainly must
+        // never have received the API key.
+        Assert.Empty(receivedApiKeys);
+    }
+
+    private sealed class LoopbackServer : IDisposable
+    {
+        private readonly HttpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _loop;
+
+        public LoopbackServer(Action<HttpListenerContext> handle)
+        {
+            // Bind to an ephemeral loopback port. Loopback HTTP is permitted by
+            // the auth handler, so the X-API-Key header is attached on send.
+            var port = GetFreePort();
+            BaseAddress = new Uri($"http://127.0.0.1:{port}/");
+            _listener = new HttpListener();
+            _listener.Prefixes.Add(BaseAddress.ToString());
+            _listener.Start();
+            _loop = Task.Run(() => AcceptLoop(handle, _cts.Token));
+        }
+
+        public Uri BaseAddress { get; }
+
+        private async Task AcceptLoop(Action<HttpListenerContext> handle, CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync();
+                }
+                catch (Exception)
+                {
+                    return;
+                }
+
+                try
+                {
+                    handle(context);
+                }
+                finally
+                {
+                    context.Response.Close();
+                }
+            }
+        }
+
+        private static int GetFreePort()
+        {
+            using var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            try
+            {
+                _loop.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception)
+            {
+                // Best-effort shutdown.
+            }
+
+            _listener.Close();
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Closes #214.

## Problem
The SDK adds the API key as a custom `X-API-Key` header via `TryAddWithoutValidation`. `HttpClient` strips `Authorization` on cross-origin auto-redirects but **forwards custom headers** to the redirect `Location` host. No client disabled auto-redirect (the `PrimaryHttpMessageHandlerFactory` hook is applied only when the consumer supplies one), so the DI default handler with `AllowAutoRedirect = true` was used across every REST package. An attacker-controlled `30x` response could therefore exfiltrate the API key to an arbitrary host.

## Fix
- New shared helper `Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler()` returns a `SocketsHttpHandler` with `AllowAutoRedirect = false`.
- Every `Honua.Sdk.*` REST client registration now applies it as the **default** primary handler when the consumer supplies no `PrimaryHttpMessageHandlerFactory` (Admin/Geocoding/Catalog, GeoServices FeatureServer/Routing/Image/Geometry, OGC API Features + Styles, WFS, Processes, Scenes, Spec, Studio, STAC, Records, ConsoleShare).
- Consumers that supply their own factory keep full control and accept the credential-forwarding semantics that entails.
- A `30x` now surfaces to the caller as a redirect status code rather than being silently followed with credentials attached.

gRPC packages are unaffected: `GrpcChannel.ForAddress` does not auto-follow HTTP 30x redirects.

## Tests
Added `tests/Honua.Sdk.OgcFeatures.Tests/RedirectApiKeyLeakTests.cs`:
- asserts the default primary handler has `AllowAutoRedirect == false`;
- end-to-end over loopback HTTP: a configured client issued against a server that returns a cross-origin `302` does **not** follow it (returns `302`) and the attacker origin never receives `X-API-Key`.

## Validation
- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true` — clean (0 warnings, 0 errors).
- `dotnet test Honua.Sdk.sln -c Release --no-build` — 0 failures across all projects.
- `scripts/validate-api-compat.sh` — "APICompat ran successfully without finding any breaking changes" (the new public type is additive).