### PR TITLE
feat(raster): reach raster client via AddHonua DI and implement IHonuaRasterDataClient

### DIFF
--- a/src/Honua.Sdk.Abstractions/Data/IHonuaRasterDataClient.cs
+++ b/src/Honua.Sdk.Abstractions/Data/IHonuaRasterDataClient.cs
@@ -31,4 +31,20 @@ public interface IHonuaRasterDataClient
     Task<RasterCoverageStatisticsResponse> GetCoverageStatisticsAsync(
         RasterCoverageStatisticsRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads a windowed subset of a raster: the cells covered by a bounding-box
+    /// extent, sampled to a target pixel size. This is the read path a raster
+    /// geoprocessing tool uses to pull a clipped extent of a large raster
+    /// (analogous to <c>arcpy</c> reading a clipped raster window) instead of
+    /// transferring the entire dataset. The returned
+    /// <see cref="RasterWindowReadResult"/> owns a response-backed stream and
+    /// must be disposed by the caller.
+    /// </summary>
+    /// <param name="request">Windowed read request (extent + target size).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The raster window result; the caller owns and disposes the stream.</returns>
+    Task<RasterWindowReadResult> ReadWindowAsync(
+        RasterWindowReadRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Honua.Sdk.Abstractions/Data/RasterDataModels.cs
+++ b/src/Honua.Sdk.Abstractions/Data/RasterDataModels.cs
@@ -95,6 +95,13 @@ public sealed record RasterDataCapabilities
     /// <summary>Whether no-data masks or no-data counts can be returned.</summary>
     public bool SupportsNoDataMasks { get; init; }
 
+    /// <summary>
+    /// Whether a windowed/subset raster read (bbox extent sampled to a target
+    /// pixel size) is supported. Required for a raster geoprocessing tool to
+    /// read a clipped window of a large raster instead of the whole dataset.
+    /// </summary>
+    public bool SupportsWindowReads { get; init; }
+
     /// <summary>Native provider surface backing the implementation.</summary>
     public string? NativeSurface { get; init; }
 
@@ -328,4 +335,139 @@ public sealed record RasterCoverageStatisticsResponse
 
     /// <summary>Whether the response does not contain provider errors.</summary>
     public bool Succeeded => !Messages.Any(static message => message.Severity == SpatialDataMessageSeverity.Error);
+}
+
+/// <summary>
+/// Request for a windowed/subset raster read: the cells covered by an extent,
+/// sampled to a target pixel size. Mirrors a clipped-extent raster read used by
+/// geoprocessing tools so a large raster can be windowed rather than transferred
+/// whole.
+/// </summary>
+public sealed record RasterWindowReadRequest
+{
+    /// <summary>Provider-specific raster source identifiers.</summary>
+    public SpatialDataSource Source { get; init; } = new();
+
+    /// <summary>Bounding extent of the window to read. Required.</summary>
+    public required FeatureBoundingBox Extent { get; init; }
+
+    /// <summary>
+    /// Target window width in pixels. Required and must be positive. Combined
+    /// with <see cref="Height"/> this is the sampled raster size returned for
+    /// the requested extent.
+    /// </summary>
+    public required int Width { get; init; }
+
+    /// <summary>Target window height in pixels. Required and must be positive.</summary>
+    public required int Height { get; init; }
+
+    /// <summary>
+    /// Output spatial reference identifier for the returned window. When null
+    /// the provider returns the window in the dataset / extent CRS.
+    /// </summary>
+    public string? OutputSpatialReference { get; init; }
+
+    /// <summary>
+    /// Requested output format. <see cref="RasterWindowFormat.GeoTiff"/> yields
+    /// a georeferenced window suitable for writing to disk; provider defaults
+    /// apply for <see cref="RasterWindowFormat.ProviderDefault"/>.
+    /// </summary>
+    public RasterWindowFormat Format { get; init; } = RasterWindowFormat.ProviderDefault;
+
+    /// <summary>Band indexes to include. Empty or null means provider default.</summary>
+    public IReadOnlyList<int>? BandIndexes { get; init; }
+
+    /// <summary>No-data value(s) to apply to the returned window, when supported.</summary>
+    public string? NoData { get; init; }
+
+    /// <summary>Resampling method used when sampling the window to the target size.</summary>
+    public RasterResamplingMethod ResamplingMethod { get; init; } = RasterResamplingMethod.ProviderDefault;
+
+    /// <summary>Optional provider mosaic rule, raster item filter, or version selector.</summary>
+    public JsonElement? Selector { get; init; }
+
+    /// <summary>Additional provider parameters that do not affect SDK display behavior.</summary>
+    public IReadOnlyDictionary<string, string?>? AdditionalParameters { get; init; }
+}
+
+/// <summary>
+/// Output encoding requested for a windowed raster read.
+/// </summary>
+public enum RasterWindowFormat
+{
+    /// <summary>Use the provider default encoding.</summary>
+    ProviderDefault = 0,
+
+    /// <summary>Georeferenced GeoTIFF, suitable for writing to disk.</summary>
+    GeoTiff = 1,
+
+    /// <summary>PNG raster.</summary>
+    Png = 2,
+
+    /// <summary>JPEG raster.</summary>
+    Jpeg = 3,
+}
+
+/// <summary>
+/// Result of a windowed raster read. Owns the response-backed content stream;
+/// dispose it when done.
+/// </summary>
+public sealed class RasterWindowReadResult : IDisposable, IAsyncDisposable
+{
+    private readonly Stream _content;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RasterWindowReadResult"/> class.
+    /// </summary>
+    /// <param name="content">The raster window content stream (owned by this result).</param>
+    /// <param name="source">Source that produced the window.</param>
+    /// <param name="extent">Extent covered by the returned window.</param>
+    /// <param name="width">Window width in pixels.</param>
+    /// <param name="height">Window height in pixels.</param>
+    /// <param name="contentType">Response content type.</param>
+    /// <param name="contentLength">Response content length, when reported.</param>
+    public RasterWindowReadResult(
+        Stream content,
+        SpatialDataSource source,
+        FeatureBoundingBox? extent,
+        int? width,
+        int? height,
+        string? contentType,
+        long? contentLength)
+    {
+        _content = content ?? throw new ArgumentNullException(nameof(content));
+        Source = source ?? new SpatialDataSource();
+        Extent = extent;
+        Width = width;
+        Height = height;
+        ContentType = contentType;
+        ContentLength = contentLength;
+    }
+
+    /// <summary>Source that produced the window.</summary>
+    public SpatialDataSource Source { get; }
+
+    /// <summary>The raster window stream. Disposing this result disposes the stream.</summary>
+    public Stream Content => _content;
+
+    /// <summary>Extent covered by the returned window, when known.</summary>
+    public FeatureBoundingBox? Extent { get; }
+
+    /// <summary>Window width in pixels, when known.</summary>
+    public int? Width { get; }
+
+    /// <summary>Window height in pixels, when known.</summary>
+    public int? Height { get; }
+
+    /// <summary>Response content type (e.g. <c>image/tiff</c>).</summary>
+    public string? ContentType { get; }
+
+    /// <summary>Response content length, when reported by the provider.</summary>
+    public long? ContentLength { get; }
+
+    /// <inheritdoc />
+    public void Dispose() => _content.Dispose();
+
+    /// <inheritdoc />
+    public ValueTask DisposeAsync() => _content.DisposeAsync();
 }

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -122,6 +122,12 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
 
+        // Provider-neutral raster data client (metadata, coverage statistics, windowed
+        // reads) so a raster geoprocessing tool can resolve IHonuaRasterDataClient from DI.
+        services.AddTransient<HonuaImageServerRasterDataClient>();
+        services.AddTransient<Honua.Sdk.Abstractions.Data.IHonuaRasterDataClient>(
+            sp => sp.GetRequiredService<HonuaImageServerRasterDataClient>());
+
         ApplyHandlerAndResilience(httpBuilder, snapshot);
         return services;
     }

--- a/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerClient.cs
@@ -145,6 +145,27 @@ public sealed class HonuaImageServerClient
     }
 
     /// <summary>
+    /// Computes raster statistics and histograms over an optional area of interest
+    /// (<c>POST .../ImageServer/computeStatisticsHistograms</c> with <c>f=json</c>).
+    /// Returns the raw GeoServices statistics/histograms JSON payload.
+    /// </summary>
+    /// <param name="serviceId">The ImageServer service id.</param>
+    /// <param name="parameters">Form parameters (geometry, mosaicRule, pixelSize, etc.).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Parsed statistics/histograms JSON document; the caller owns and disposes it.</returns>
+    public async Task<JsonDocument> ComputeStatisticsHistogramsAsync(
+        string serviceId,
+        IEnumerable<(string Key, string? Value)> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(parameters);
+        var resolved = RequireServiceId(serviceId);
+        var path = $"{ServicePath(resolved)}/computeStatisticsHistograms";
+        var body = await GeoServicesHttp.PostFormAsync(_http, path, parameters, cancellationToken).ConfigureAwait(false);
+        return JsonDocument.Parse(body);
+    }
+
+    /// <summary>
     /// Identifies the pixel value at a point (<c>GET .../ImageServer/identify</c>).
     /// </summary>
     /// <param name="request">Identify parameters.</param>

--- a/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerRasterDataClient.cs
+++ b/src/Honua.Sdk.GeoServices/ImageServer/HonuaImageServerRasterDataClient.cs
@@ -1,0 +1,402 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Data;
+using Honua.Sdk.Abstractions.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.ImageServer;
+
+/// <summary>
+/// <see cref="IHonuaRasterDataClient"/> implementation backed by the Honua
+/// GeoServices ImageServer surface. Adapts the provider-neutral raster contract
+/// (metadata, coverage statistics, windowed reads) onto the read-only ImageServer
+/// endpoints (<c>?f=json</c> service metadata, <c>computeStatisticsHistograms</c>,
+/// and <c>exportImage</c>). The windowed read (<see cref="ReadWindowAsync"/>) maps a
+/// bbox extent plus a target pixel size onto an <c>exportImage</c> call so a raster
+/// geoprocessing tool can pull a clipped window of a large raster rather than the
+/// whole dataset.
+/// </summary>
+/// <remarks>
+/// This client is read-only. The Honua server does expose a raster <i>write</i>
+/// path — the admin multipart raster import endpoint
+/// (<c>POST /api/v1/admin/import/raster</c>, GeoTIFF / world-file upload into
+/// PostGIS) — but it lives on the privileged Admin surface and is not part of the
+/// raster-data read contract. A geoprocessing tool that produces a raster should
+/// write a GeoTIFF locally (e.g. from a <see cref="ReadWindowAsync"/> window or a
+/// computed result) and register it through the admin raster import endpoint
+/// exposed by the Admin client surface. See the package README for the raster
+/// output stance.
+/// </remarks>
+public sealed class HonuaImageServerRasterDataClient : IHonuaRasterDataClient
+{
+    private static readonly RasterDataCapabilities CapabilitiesValue = new()
+    {
+        SupportsMetadata = true,
+        SupportsBandMetadata = true,
+        SupportsCoverageStatistics = true,
+        SupportsHistograms = true,
+        SupportsMosaicRules = true,
+        SupportsTimeSlices = false,
+        SupportsNoDataMasks = true,
+        SupportsWindowReads = true,
+        NativeSurface = "GeoServices/ImageServer",
+    };
+
+    private readonly HonuaImageServerClient _imageServer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaImageServerRasterDataClient"/> class.
+    /// </summary>
+    /// <param name="imageServer">The underlying ImageServer client.</param>
+    [ActivatorUtilitiesConstructor]
+    public HonuaImageServerRasterDataClient(HonuaImageServerClient imageServer)
+    {
+        _imageServer = imageServer ?? throw new ArgumentNullException(nameof(imageServer));
+    }
+
+    /// <inheritdoc />
+    public string ProviderName => "honua.geoservices.imageserver";
+
+    /// <inheritdoc />
+    public RasterDataCapabilities RasterCapabilities => CapabilitiesValue;
+
+    /// <inheritdoc />
+    public async Task<RasterDatasetMetadata> GetRasterMetadataAsync(
+        RasterMetadataRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var serviceId = RequireServiceId(request.Source);
+
+        var metadata = await _imageServer.GetServiceMetadataAsync(serviceId, cancellationToken).ConfigureAwait(false);
+
+        var bands = request.IncludeBands ? BuildBands(metadata) : [];
+
+        return new RasterDatasetMetadata
+        {
+            Source = request.Source,
+            DatasetId = serviceId,
+            Name = metadata.Name ?? metadata.ServiceId,
+            Description = metadata.ServiceDescription,
+            SpatialReference = metadata.Extent?.SpatialReferenceWkid?.ToString(CultureInfo.InvariantCulture),
+            Extent = ToBoundingBox(metadata.Extent),
+            PixelType = ParsePixelType(metadata.PixelType),
+            Bands = bands,
+            Capabilities = BuildCapabilityNames(metadata),
+            RawMetadata = metadata.RawResponse,
+        };
+    }
+
+    /// <inheritdoc />
+    public async Task<RasterCoverageStatisticsResponse> GetCoverageStatisticsAsync(
+        RasterCoverageStatisticsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var serviceId = RequireServiceId(request.Source);
+
+        var form = new List<(string Key, string? Value)>
+        {
+            ("f", "json"),
+            ("mosaicRule", SelectorToString(request.Selector)),
+        };
+
+        if (request.Extent is { } extent)
+        {
+            form.Add(("geometryType", "esriGeometryEnvelope"));
+            form.Add(("geometry", BuildEnvelopeGeometry(extent)));
+        }
+
+        if (request.CellSize is { } cellSize)
+        {
+            var size = Num(cellSize);
+            form.Add(("pixelSize", $"{size},{size}"));
+        }
+
+        AddAdditional(form, request.AdditionalParameters);
+
+        using var document = await _imageServer
+            .ComputeStatisticsHistogramsAsync(serviceId, form, cancellationToken)
+            .ConfigureAwait(false);
+        var root = document.RootElement;
+        var bands = ParseBandStatistics(root, request.BandIndexes);
+
+        return new RasterCoverageStatisticsResponse
+        {
+            Source = request.Source,
+            Bands = bands,
+            Extent = request.Extent,
+            CellSize = request.CellSize,
+            RawResponse = root.Clone(),
+        };
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "The ExportImageResult's content stream is transferred to and owned by the returned RasterWindowReadResult; disposing the wrapper here would dispose the caller's stream.")]
+    public async Task<RasterWindowReadResult> ReadWindowAsync(
+        RasterWindowReadRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Width <= 0 || request.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request), "Raster window size must be positive on both axes.");
+        }
+
+        var serviceId = RequireServiceId(request.Source);
+        var exportRequest = new ExportImageRequest
+        {
+            ServiceId = serviceId,
+            BoundingBox = ToImageServerExtent(request.Extent),
+            BoundingBoxSpatialReference = ParseWkid(request.Extent.Crs),
+            ImageSpatialReference = ParseWkid(request.OutputSpatialReference),
+            Width = request.Width,
+            Height = request.Height,
+            Format = MapFormat(request.Format),
+            NoData = request.NoData,
+            Interpolation = MapInterpolation(request.ResamplingMethod),
+            MosaicRule = SelectorToString(request.Selector),
+            AdditionalParameters = BuildWindowAdditional(request),
+        };
+
+        var export = await _imageServer.ExportImageAsync(exportRequest, cancellationToken).ConfigureAwait(false);
+
+        // Transfer stream ownership from the export result to the window result.
+        return new RasterWindowReadResult(
+            export.Content,
+            request.Source,
+            request.Extent,
+            request.Width,
+            request.Height,
+            export.ContentType,
+            export.ContentLength);
+    }
+
+    private static Dictionary<string, string?>? BuildWindowAdditional(RasterWindowReadRequest request)
+    {
+        Dictionary<string, string?>? additional = null;
+        if (request.BandIndexes is { Count: > 0 } bands)
+        {
+            additional = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["bandIds"] = string.Join(',', bands.Select(static b => b.ToString(CultureInfo.InvariantCulture))),
+            };
+        }
+
+        if (request.AdditionalParameters is { Count: > 0 } extra)
+        {
+            additional ??= new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var pair in extra)
+            {
+                additional[pair.Key] = pair.Value;
+            }
+        }
+
+        return additional;
+    }
+
+    private static List<RasterBandStatistics> ParseBandStatistics(
+        JsonElement root, IReadOnlyList<int>? bandIndexes)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty("statistics", out var statistics) ||
+            statistics.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        var bands = new List<RasterBandStatistics>();
+        var index = 0;
+        foreach (var band in statistics.EnumerateArray())
+        {
+            var bandIndex = bandIndexes is { Count: > 0 } && index < bandIndexes.Count
+                ? bandIndexes[index]
+                : index;
+
+            bands.Add(new RasterBandStatistics
+            {
+                BandIndex = bandIndex,
+                Minimum = ReadDouble(band, "min"),
+                Maximum = ReadDouble(band, "max"),
+                Mean = ReadDouble(band, "mean"),
+                StandardDeviation = ReadDouble(band, "standardDeviation"),
+                Count = ReadLong(band, "count"),
+            });
+            index++;
+        }
+
+        return bands;
+    }
+
+    private static List<RasterBandMetadata> BuildBands(ImageServerMetadata metadata)
+    {
+        var bandCount = metadata.BandCount ?? 0;
+        if (bandCount <= 0)
+        {
+            return [];
+        }
+
+        var pixelType = ParsePixelType(metadata.PixelType);
+        var bands = new List<RasterBandMetadata>(bandCount);
+        for (var band = 0; band < bandCount; band++)
+        {
+            bands.Add(new RasterBandMetadata
+            {
+                BandIndex = band,
+                PixelType = pixelType,
+                DataType = metadata.PixelType,
+                Minimum = ValueAt(metadata.MinValues, band),
+                Maximum = ValueAt(metadata.MaxValues, band),
+            });
+        }
+
+        return bands;
+    }
+
+    private static List<string> BuildCapabilityNames(ImageServerMetadata metadata)
+    {
+        var names = new List<string> { "Image", "Metadata" };
+        if (metadata.HasHistograms == true)
+        {
+            names.Add("Histograms");
+        }
+
+        if (metadata.HasRasterAttributeTable == true)
+        {
+            names.Add("RasterAttributeTable");
+        }
+
+        return names;
+    }
+
+    private static double? ValueAt(IReadOnlyList<double>? values, int index)
+        => values is not null && index < values.Count ? values[index] : null;
+
+    private static FeatureBoundingBox? ToBoundingBox(ImageServerExtent? extent)
+        => extent is null
+            ? null
+            : new FeatureBoundingBox
+            {
+                MinX = extent.XMin,
+                MinY = extent.YMin,
+                MaxX = extent.XMax,
+                MaxY = extent.YMax,
+                Crs = extent.SpatialReferenceWkid?.ToString(CultureInfo.InvariantCulture),
+            };
+
+    private static ImageServerExtent ToImageServerExtent(FeatureBoundingBox extent)
+        => new()
+        {
+            XMin = extent.MinX,
+            YMin = extent.MinY,
+            XMax = extent.MaxX,
+            YMax = extent.MaxY,
+            SpatialReferenceWkid = ParseWkid(extent.Crs),
+        };
+
+    private static string BuildEnvelopeGeometry(FeatureBoundingBox extent)
+    {
+        var wkid = ParseWkid(extent.Crs);
+        var sr = wkid is { } w
+            ? $",\"spatialReference\":{{\"wkid\":{w.ToString(CultureInfo.InvariantCulture)}}}"
+            : string.Empty;
+        return $"{{\"xmin\":{Num(extent.MinX)},\"ymin\":{Num(extent.MinY)},\"xmax\":{Num(extent.MaxX)},\"ymax\":{Num(extent.MaxY)}{sr}}}";
+    }
+
+    private static string MapFormat(RasterWindowFormat format) => format switch
+    {
+        RasterWindowFormat.GeoTiff => "tiff",
+        RasterWindowFormat.Png => "png",
+        RasterWindowFormat.Jpeg => "jpg",
+        _ => "tiff",
+    };
+
+    private static string? MapInterpolation(RasterResamplingMethod method) => method switch
+    {
+        RasterResamplingMethod.Nearest => "RSP_NearestNeighbor",
+        RasterResamplingMethod.Bilinear => "RSP_BilinearInterpolation",
+        RasterResamplingMethod.Cubic => "RSP_CubicConvolution",
+        RasterResamplingMethod.Majority => "RSP_Majority",
+        _ => null,
+    };
+
+    private static RasterPixelType ParsePixelType(string? pixelType) => pixelType?.ToUpperInvariant() switch
+    {
+        "U1" or "U2" or "U4" or "U8" => RasterPixelType.UnsignedByte,
+        "S8" => RasterPixelType.SignedByte,
+        "U16" => RasterPixelType.UnsignedShort,
+        "S16" => RasterPixelType.SignedShort,
+        "U32" => RasterPixelType.UnsignedInteger,
+        "S32" => RasterPixelType.SignedInteger,
+        "F32" => RasterPixelType.SinglePrecision,
+        "F64" => RasterPixelType.DoublePrecision,
+        "C64" => RasterPixelType.ComplexSinglePrecision,
+        "C128" => RasterPixelType.ComplexDoublePrecision,
+        _ => RasterPixelType.Unknown,
+    };
+
+    private static int? ParseWkid(string? crs)
+    {
+        if (string.IsNullOrWhiteSpace(crs))
+        {
+            return null;
+        }
+
+        // Accept a bare wkid ("4326") or an EPSG-prefixed form ("EPSG:4326").
+        var token = crs.Contains(':', StringComparison.Ordinal)
+            ? crs[(crs.LastIndexOf(':') + 1)..]
+            : crs;
+        return int.TryParse(token, NumberStyles.Integer, CultureInfo.InvariantCulture, out var wkid) ? wkid : null;
+    }
+
+    private static string? SelectorToString(JsonElement? selector)
+        => selector is { } element && element.ValueKind is not JsonValueKind.Null and not JsonValueKind.Undefined
+            ? element.GetRawText()
+            : null;
+
+    private static void AddAdditional(
+        List<(string Key, string? Value)> form, IReadOnlyDictionary<string, string?>? additional)
+    {
+        if (additional is null)
+        {
+            return;
+        }
+
+        foreach (var pair in additional)
+        {
+            form.Add((pair.Key, pair.Value));
+        }
+    }
+
+    private static string RequireServiceId(SpatialDataSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var serviceId = source.ServiceId ?? source.DatasetId ?? source.RasterId;
+        return string.IsNullOrWhiteSpace(serviceId)
+            ? throw new InvalidOperationException(
+                "Raster source must provide a ServiceId (or DatasetId / RasterId) to address the ImageServer.")
+            : serviceId;
+    }
+
+    private static string Num(double value) => value.ToString("R", CultureInfo.InvariantCulture);
+
+    private static double? ReadDouble(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.Number &&
+           value.TryGetDouble(out var number)
+            ? number
+            : null;
+
+    private static long? ReadLong(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.Number &&
+           value.TryGetInt64(out var number)
+            ? number
+            : null;
+}

--- a/src/Honua.Sdk.GeoServices/README.md
+++ b/src/Honua.Sdk.GeoServices/README.md
@@ -62,6 +62,59 @@ var route = await router.GetDirectionsAsync(
     cancellationToken);
 ```
 
+### Raster (ImageServer)
+
+`AddHonuaImageServer` registers the read-only ImageServer client plus the
+provider-neutral `IHonuaRasterDataClient` (raster metadata, coverage statistics,
+and a windowed/subset read). A raster geoprocessing tool can resolve
+`IHonuaRasterDataClient` from DI and read a clipped window of a large raster
+rather than transferring the whole dataset:
+
+```csharp
+using Honua.Sdk.Abstractions.Data;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.Extensions;
+
+services.AddHonuaImageServer(o => o.BaseAddress = new Uri("https://your-honua-server"));
+
+var raster = provider.GetRequiredService<IHonuaRasterDataClient>();
+
+var metadata = await raster.GetRasterMetadataAsync(
+    new RasterMetadataRequest { Source = new SpatialDataSource { ServiceId = "Elevation" } },
+    cancellationToken);
+
+// Read a clipped window (bbox extent sampled to a target pixel size) as GeoTIFF.
+await using var window = await raster.ReadWindowAsync(
+    new RasterWindowReadRequest
+    {
+        Source = new SpatialDataSource { ServiceId = "Elevation" },
+        Extent = new FeatureBoundingBox { MinX = -158, MinY = 21, MaxX = -157, MaxY = 22, Crs = "4326" },
+        Width = 512,
+        Height = 512,
+        Format = RasterWindowFormat.GeoTiff,
+    },
+    cancellationToken);
+
+await using var file = File.Create("window.tif");
+await window.Content.CopyToAsync(file, cancellationToken);
+```
+
+The umbrella `Honua.Sdk` package exposes this via the `UseImageServer` flag on
+`AddHonua(...)`.
+
+#### Raster output (write) stance
+
+`IHonuaRasterDataClient` is **read-only** by design: it covers raster metadata,
+coverage statistics, and windowed reads. The Honua server does expose a raster
+*write* path — the admin multipart raster import endpoint
+(`POST /api/v1/admin/import/raster`, GeoTIFF / world-file upload into PostGIS) —
+but it lives on the privileged Admin surface and is not part of the raster-data
+read contract. A geoprocessing tool that produces a raster should write a GeoTIFF
+locally (for example from a `ReadWindowAsync` window or a computed result) and
+register it through that admin raster import endpoint. A typed SDK wrapper for the
+admin raster import endpoint on the Admin client surface is tracked as a
+follow-up.
+
 ## Documentation
 
 - [Quickstart](https://github.com/honua-io/honua-sdk-dotnet/blob/trunk/docs/quickstart.md)

--- a/src/Honua.Sdk/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk/Extensions/ServiceCollectionExtensions.cs
@@ -74,7 +74,7 @@ public static class ServiceCollectionExtensions
             throw new HonuaConfigurationException(
                 "Configure at least one Honua module via AddHonua(...) before resolving clients. " +
                 "Every Use* flag (UseGrpc, UseAdmin, UseGeocoding, UseOgcFeatures, UseWfs, UseGeoServices, " +
-                "UseProcesses, UseRouting, UseScenes, UseSpec, UseStac, UseOgcRecords, UseStudio, UseConsoleShare) is currently false.");
+                "UseProcesses, UseRouting, UseImageServer, UseScenes, UseSpec, UseStac, UseOgcRecords, UseStudio, UseConsoleShare) is currently false.");
         }
 
         if (snapshot.UseGrpc)
@@ -115,6 +115,11 @@ public static class ServiceCollectionExtensions
         if (snapshot.UseRouting)
         {
             services.AddHonuaRouting(options => ApplyGeoServices(options, snapshot));
+        }
+
+        if (snapshot.UseImageServer)
+        {
+            services.AddHonuaImageServer(options => ApplyGeoServices(options, snapshot));
         }
 
         if (snapshot.UseScenes)

--- a/src/Honua.Sdk/HonuaSdkOptions.cs
+++ b/src/Honua.Sdk/HonuaSdkOptions.cs
@@ -28,8 +28,9 @@ namespace Honua.Sdk;
 /// <see cref="UseProcesses"/>, and <see cref="UseWfs"/>) default to
 /// <c>true</c> for the common query, edit, admin, geocoding, OGC API Features,
 /// OGC API Processes, and WFS client set. The more situational sub-packages
-/// (<see cref="UseGeoServices"/>, <see cref="UseRouting"/>, <see cref="UseScenes"/>,
-/// <see cref="UseSpec"/>, <see cref="UseStac"/>, <see cref="UseOgcRecords"/>)
+/// (<see cref="UseGeoServices"/>, <see cref="UseRouting"/>, <see cref="UseImageServer"/>,
+/// <see cref="UseScenes"/>, <see cref="UseSpec"/>, <see cref="UseStac"/>,
+/// <see cref="UseOgcRecords"/>)
 /// default to <c>false</c> so callers who want the smallest registration footprint
 /// don't get every client they don't use.
 /// </para>
@@ -192,6 +193,15 @@ public sealed class HonuaSdkOptions
     public bool UseRouting { get; set; }
 
     /// <summary>
+    /// When <c>true</c>, registers the GeoServices ImageServer raster client
+    /// (<c>HonuaImageServerClient</c>) and the provider-neutral raster data
+    /// client (<c>IHonuaRasterDataClient</c>) for raster metadata, coverage
+    /// statistics, and windowed reads. Ships in the GeoServices package and
+    /// reuses its options / auth handler. Defaults to <c>false</c>.
+    /// </summary>
+    public bool UseImageServer { get; set; }
+
+    /// <summary>
     /// When <c>true</c>, registers the scene metadata client
     /// (<c>IHonuaSceneClient</c>). Defaults to <c>false</c>.
     /// </summary>
@@ -236,6 +246,7 @@ public sealed class HonuaSdkOptions
         UseWfs ||
         UseGeoServices ||
         UseRouting ||
+        UseImageServer ||
         UseScenes ||
         UseSpec ||
         UseStac ||

--- a/tests/Honua.Sdk.Abstractions.Tests/RasterElevationEnrichmentContractTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/RasterElevationEnrichmentContractTests.cs
@@ -225,6 +225,14 @@ public sealed class RasterElevationEnrichmentContractTests
             Source = RasterSource(),
             BandIndexes = [1],
         });
+        await using var window = await client.ReadWindowAsync(new RasterWindowReadRequest
+        {
+            Source = RasterSource(),
+            Extent = new FeatureBoundingBox { MinX = -158, MinY = 21, MaxX = -157, MaxY = 22, Crs = "4326" },
+            Width = 256,
+            Height = 256,
+            Format = RasterWindowFormat.GeoTiff,
+        });
         var elevation = await client.SampleElevationAsync(new ElevationSamplingRequest
         {
             Source = new SpatialDataSource { ServiceId = "terrain" },
@@ -248,6 +256,10 @@ public sealed class RasterElevationEnrichmentContractTests
         Assert.True(client.EnrichmentCapabilities.SupportsFeatureEnrichment);
         Assert.Equal("landcover-2025", metadata.DatasetId);
         Assert.True(statistics.Succeeded);
+        Assert.True(client.RasterCapabilities.SupportsWindowReads);
+        Assert.Equal("image/tiff", window.ContentType);
+        Assert.Equal(256, window.Width);
+        Assert.Equal(4, window.ContentLength);
         Assert.Single(elevation.Samples);
         Assert.Single(enrichmentMetadata.Attributes);
         Assert.True(enrichment.Succeeded);
@@ -280,6 +292,7 @@ public sealed class RasterElevationEnrichmentContractTests
             SupportsBandMetadata = true,
             SupportsCoverageStatistics = true,
             SupportsNoDataMasks = true,
+            SupportsWindowReads = true,
             NativeSurface = "honua-server-raster",
         };
 
@@ -343,6 +356,22 @@ public sealed class RasterElevationEnrichmentContractTests
                     },
                 ],
             });
+        }
+
+        public Task<RasterWindowReadResult> ReadWindowAsync(
+            RasterWindowReadRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var stream = new MemoryStream([0x49, 0x49, 0x2A, 0x00]);
+            return Task.FromResult(new RasterWindowReadResult(
+                stream,
+                request.Source,
+                request.Extent,
+                request.Width,
+                request.Height,
+                "image/tiff",
+                stream.Length));
         }
 
         public Task<ElevationSamplingResponse> SampleElevationAsync(ElevationSamplingRequest request, CancellationToken cancellationToken = default)

--- a/tests/Honua.Sdk.GeoServices.Tests/ImageServer/HonuaImageServerRasterDataClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/ImageServer/HonuaImageServerRasterDataClientTests.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.Abstractions.Data;
+using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.ImageServer;
+using Honua.Sdk.GeoServices.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.GeoServices.Tests.ImageServer;
+
+public sealed class HonuaImageServerRasterDataClientTests
+{
+    [Fact]
+    public void AddHonuaImageServer_RegistersRasterDataClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaImageServer(options =>
+        {
+            options.BaseAddress = new Uri("http://localhost:5000");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var raster = provider.GetService<IHonuaRasterDataClient>();
+        Assert.NotNull(raster);
+        Assert.Equal("honua.geoservices.imageserver", raster!.ProviderName);
+        Assert.True(raster.RasterCapabilities.SupportsWindowReads);
+        Assert.True(raster.RasterCapabilities.SupportsCoverageStatistics);
+        Assert.Equal("GeoServices/ImageServer", raster.RasterCapabilities.NativeSurface);
+    }
+
+    [Fact]
+    public async Task GetRasterMetadataAsync_MapsServiceMetadataToDatasetMetadata()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("""
+        {
+          "serviceDescription": "Elevation",
+          "name": "Elevation",
+          "pixelType": "F32",
+          "bandCount": 1,
+          "minValues": [0.0],
+          "maxValues": [4207.5],
+          "extent": {
+            "xmin": -160.3, "ymin": 18.9, "xmax": -154.8, "ymax": 22.3,
+            "spatialReference": { "wkid": 4326, "latestWkid": 4326 }
+          },
+          "hasHistograms": true
+        }
+        """)));
+
+        var metadata = await client.GetRasterMetadataAsync(new RasterMetadataRequest
+        {
+            Source = new SpatialDataSource { ServiceId = "Elevation" },
+        });
+
+        Assert.Equal("Elevation", metadata.DatasetId);
+        Assert.Equal("Elevation", metadata.Name);
+        Assert.Equal(RasterPixelType.SinglePrecision, metadata.PixelType);
+        Assert.NotNull(metadata.Extent);
+        Assert.Equal(-160.3, metadata.Extent!.MinX, precision: 4);
+        Assert.Equal("4326", metadata.SpatialReference);
+        Assert.Single(metadata.Bands);
+        Assert.Equal(0, metadata.Bands[0].BandIndex);
+        Assert.Equal(0.0, metadata.Bands[0].Minimum);
+        Assert.Equal(4207.5, metadata.Bands[0].Maximum);
+        Assert.Contains("Histograms", metadata.Capabilities);
+    }
+
+    [Fact]
+    public async Task GetRasterMetadataAsync_WithoutServiceId_Throws()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("{}")));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.GetRasterMetadataAsync(new RasterMetadataRequest
+            {
+                Source = new SpatialDataSource(),
+            }));
+    }
+
+    [Fact]
+    public async Task GetCoverageStatisticsAsync_SendsEnvelopeAndParsesBandStatistics()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            form = await ReadFormAsync(request, cancellationToken);
+            return JsonResponse("""
+            {
+              "statistics": [
+                { "min": 1.0, "max": 9.0, "mean": 5.0, "standardDeviation": 2.0, "count": 100 }
+              ],
+              "histograms": []
+            }
+            """);
+        });
+
+        var response = await client.GetCoverageStatisticsAsync(new RasterCoverageStatisticsRequest
+        {
+            Source = new SpatialDataSource { ServiceId = "Elevation" },
+            Extent = new FeatureBoundingBox { MinX = -158, MinY = 21, MaxX = -157, MaxY = 22, Crs = "4326" },
+            CellSize = 30,
+        });
+
+        Assert.Equal(
+            "http://localhost:5000/rest/services/Elevation/ImageServer/computeStatisticsHistograms",
+            uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("json", form!["f"]);
+        Assert.Equal("esriGeometryEnvelope", form["geometryType"]);
+        Assert.Equal("30,30", form["pixelSize"]);
+        using var geometry = JsonDocument.Parse(form["geometry"]);
+        Assert.Equal(-158, geometry.RootElement.GetProperty("xmin").GetDouble(), precision: 4);
+        Assert.Equal(4326, geometry.RootElement.GetProperty("spatialReference").GetProperty("wkid").GetInt32());
+
+        var band = Assert.Single(response.Bands);
+        Assert.Equal(0, band.BandIndex);
+        Assert.Equal(1.0, band.Minimum);
+        Assert.Equal(9.0, band.Maximum);
+        Assert.Equal(5.0, band.Mean);
+        Assert.Equal(2.0, band.StandardDeviation);
+        Assert.Equal(100, band.Count);
+        Assert.True(response.Succeeded);
+    }
+
+    [Fact]
+    public async Task ReadWindowAsync_BuildsExportRequestAndReturnsWindowStream()
+    {
+        Dictionary<string, string>? form = null;
+        Uri? uri = null;
+        HttpMethod? method = null;
+        var raster = new byte[] { 0x49, 0x49, 0x2A, 0x00 }; // little-endian TIFF magic
+        var client = CreateClient(async (request, cancellationToken) =>
+        {
+            uri = request.RequestUri;
+            method = request.Method;
+            form = await ReadFormAsync(request, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(raster)
+                {
+                    Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/tiff") },
+                },
+            };
+        });
+
+        await using var window = await client.ReadWindowAsync(new RasterWindowReadRequest
+        {
+            Source = new SpatialDataSource { ServiceId = "Elevation" },
+            Extent = new FeatureBoundingBox { MinX = -158, MinY = 21, MaxX = -157, MaxY = 22, Crs = "4326" },
+            OutputSpatialReference = "EPSG:3857",
+            Width = 512,
+            Height = 256,
+            Format = RasterWindowFormat.GeoTiff,
+            BandIndexes = [0, 1, 2],
+            ResamplingMethod = RasterResamplingMethod.Bilinear,
+        });
+
+        Assert.Equal(HttpMethod.Post, method);
+        Assert.Equal("http://localhost:5000/rest/services/Elevation/ImageServer/exportImage", uri?.ToString());
+        Assert.NotNull(form);
+        Assert.Equal("image", form!["f"]);
+        Assert.Equal("-158,21,-157,22", form["bbox"]);
+        Assert.Equal("4326", form["bboxSR"]);
+        Assert.Equal("3857", form["imageSR"]);
+        Assert.Equal("512,256", form["size"]);
+        Assert.Equal("tiff", form["format"]);
+        Assert.Equal("RSP_BilinearInterpolation", form["interpolation"]);
+        Assert.Equal("0,1,2", form["bandIds"]);
+
+        Assert.Equal("image/tiff", window.ContentType);
+        Assert.Equal(512, window.Width);
+        Assert.Equal(256, window.Height);
+        Assert.Equal("Elevation", window.Source.ServiceId);
+        using var memory = new MemoryStream();
+        await window.Content.CopyToAsync(memory);
+        Assert.Equal(raster, memory.ToArray());
+    }
+
+    [Fact]
+    public async Task ReadWindowAsync_NonPositiveSize_Throws()
+    {
+        var client = CreateClient((_, _) => Task.FromResult(JsonResponse("{}")));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.ReadWindowAsync(new RasterWindowReadRequest
+            {
+                Source = new SpatialDataSource { ServiceId = "Elevation" },
+                Extent = new FeatureBoundingBox { MinX = 0, MinY = 0, MaxX = 1, MaxY = 1 },
+                Width = 0,
+                Height = 256,
+            }));
+    }
+
+    private static HonuaImageServerRasterDataClient CreateClient(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+    {
+        var mockHandler = new MockHttpHandler(request => handler(request, CancellationToken.None));
+        var httpClient = new HttpClient(mockHandler)
+        {
+            BaseAddress = new Uri("http://localhost:5000"),
+        };
+
+        return new HonuaImageServerRasterDataClient(new HonuaImageServerClient(httpClient));
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json"),
+    };
+
+    private static async Task<Dictionary<string, string>> ReadFormAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = await request.Content!.ReadAsStringAsync(cancellationToken);
+        return body.Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .ToDictionary(
+                pair => Decode(pair[0]),
+                pair => pair.Length == 2 ? Decode(pair[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private static string Decode(string value) => Uri.UnescapeDataString(value.Replace("+", " ", StringComparison.Ordinal));
+}

--- a/tests/Honua.Sdk.MetaSmoke.Tests/AddHonuaTests.cs
+++ b/tests/Honua.Sdk.MetaSmoke.Tests/AddHonuaTests.cs
@@ -7,8 +7,10 @@ using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.Abstractions.Scenes;
 using Honua.Sdk.Admin;
 using Honua.Sdk.Admin.Catalog;
+using Honua.Sdk.Abstractions.Data;
 using Honua.Sdk.Admin.Geocoding;
 using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.GeoServices.ImageServer;
 using Honua.Sdk.Grpc;
 using Honua.Sdk.OgcFeatures;
 using Honua.Sdk.Processes;
@@ -74,6 +76,7 @@ public sealed class AddHonuaTests
             o.UseWfs = true;
             o.UseGeoServices = true;
             o.UseRouting = true;
+            o.UseImageServer = true;
             o.UseScenes = true;
             o.UseSpec = true;
             o.UseStac = true;
@@ -93,6 +96,8 @@ public sealed class AddHonuaTests
         Assert.NotNull(provider.GetRequiredService<IHonuaWfsClient>());
         Assert.NotNull(provider.GetRequiredService<IHonuaFeatureServerClient>());
         Assert.NotNull(provider.GetRequiredService<IHonuaRoutingClient>());
+        Assert.NotNull(provider.GetRequiredService<HonuaImageServerClient>());
+        Assert.NotNull(provider.GetRequiredService<IHonuaRasterDataClient>());
         Assert.NotNull(provider.GetRequiredService<IHonuaSceneClient>());
         Assert.NotNull(provider.GetRequiredService<IHonuaSpecClient>());
         Assert.NotNull(provider.GetRequiredService<IHonuaStacClient>());
@@ -118,6 +123,7 @@ public sealed class AddHonuaTests
                 o.UseWfs = false;
                 o.UseGeoServices = false;
                 o.UseRouting = false;
+                o.UseImageServer = false;
                 o.UseScenes = false;
                 o.UseSpec = false;
                 o.UseStac = false;
@@ -127,5 +133,42 @@ public sealed class AddHonuaTests
             }));
 
         Assert.Contains("at least one Honua module", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddHonua_WithUseImageServer_RegistersRasterClients()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHonua(o =>
+        {
+            o.BaseAddress = TestBaseAddress;
+            o.EnableRetry = false;
+            o.UseImageServer = true;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<HonuaImageServerClient>());
+        var raster = provider.GetRequiredService<IHonuaRasterDataClient>();
+        Assert.True(raster.RasterCapabilities.SupportsWindowReads);
+    }
+
+    [Fact]
+    public void AddHonua_WithDefaults_DoesNotRegisterImageServer()
+    {
+        var services = new ServiceCollection();
+
+        services.AddHonua(o =>
+        {
+            o.BaseAddress = TestBaseAddress;
+            o.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        // UseImageServer defaults to false, so the raster clients are not registered.
+        Assert.Null(provider.GetService<HonuaImageServerClient>());
+        Assert.Null(provider.GetService<IHonuaRasterDataClient>());
     }
 }


### PR DESCRIPTION
## Summary

Closes the RASTER gap for `arcpy.sa`-style raster geoprocessing parity (per the GP assessment): a raster GP tool could not resolve a raster client from `AddHonua` DI, and `IHonuaRasterDataClient` had **zero implementations**. This PR makes a raster client reachable from the umbrella and provides a real `IHonuaRasterDataClient` implementation with a windowed read.

## Changes

- **DI reachability** — add a `UseImageServer` flag to `HonuaSdkOptions` and register the ImageServer raster client from the umbrella `AddHonua(...)`. Defaults to `false`, matching the other situational `Use*` flags (UseGeoServices/UseRouting/UseScenes/...).
- **`IHonuaRasterDataClient` implementation** — `HonuaImageServerRasterDataClient` over the GeoServices ImageServer surface:
  - `GetRasterMetadataAsync` → ImageServer `?f=json` (name, extent, pixel type, per-band min/max, capabilities).
  - `GetCoverageStatisticsAsync` → ImageServer `computeStatisticsHistograms` (per-band min/max/mean/stddev/count over an envelope + cell size).
  - `ReadWindowAsync` (new on the interface) → maps a bbox extent + target pixel size onto `exportImage`, so a GP tool reads a **clipped window** of a large raster (GeoTIFF by default) instead of the whole dataset — matching arcpy reading a clipped extent. Adds `RasterWindowReadRequest`/`RasterWindowReadResult`/`RasterWindowFormat` and a `SupportsWindowReads` capability.
  - Registered in `AddHonuaImageServer` so both the per-package extension and the umbrella resolve `IHonuaRasterDataClient`.
- **Raster WRITE outcome** — the server already exposes a raster write/upload route (`POST /api/v1/admin/import/raster`, admin multipart GeoTIFF/world-file import into PostGIS). It is **not fabricated** here: it lives on the privileged Admin surface, not the read-only raster-data contract. The read-only stance and the local-GeoTIFF + admin-import output path are documented in the GeoServices README, and a typed Admin-client wrapper follow-up is filed as #219.

## Breaking Changes

`IHonuaRasterDataClient` gains a `ReadWindowAsync` member. The interface had **zero implementations** before this PR (it was unreachable surface area — the gap), so no existing implementer is affected. The abstraction-test fake was updated accordingly.

## Testing

- Umbrella registers the raster clients when `UseImageServer = true` and **not** by default.
- `IHonuaRasterDataClient` resolves from DI; a windowed read builds the correct `exportImage` request (bbox / bboxSR / imageSR / size / format=tiff / interpolation / bandIds) via a faked `HttpMessageHandler`; metadata and coverage-statistics parsing verified.
- Abstraction contract test exercises `ReadWindowAsync` + `SupportsWindowReads`.
- Full solution build green (`Release`, warnings-as-errors); GeoServices (134 passed), MetaSmoke (5), Abstractions (76) test suites green.

Refs: GP raster parity assessment; raster-write follow-up #219.