### PR TITLE
fix(reliability): scale resilience timeouts to budget; offline pull full-refresh honesty

### DIFF
--- a/src/Honua.Sdk.Abstractions/HonuaResilienceTimeouts.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaResilienceTimeouts.cs
@@ -11,52 +11,73 @@ namespace Honua.Sdk.Abstractions;
 /// <remarks>
 /// <para>
 /// <c>AddStandardResilienceHandler</c> validates that the circuit-breaker
-/// <c>SamplingDuration</c> (default 30 s) is at least <em>double</em> the
-/// per-attempt timeout. With the default option <see cref="IHonuaClientOptions.Timeout"/>
-/// of 100 s, naively setting <c>AttemptTimeout = Timeout</c> fails that check and
-/// throws <c>OptionsValidationException</c> the first time any client is resolved.
+/// <c>SamplingDuration</c> is at least <em>double</em> the per-attempt timeout,
+/// and that the total request timeout is greater than both. With the default
+/// option <see cref="IHonuaClientOptions.Timeout"/> of 100 s, naively setting
+/// <c>AttemptTimeout = Timeout</c> fails those checks and throws
+/// <c>OptionsValidationException</c> the first time any client is resolved.
 /// </para>
 /// <para>
 /// This helper treats <see cref="IHonuaClientOptions.Timeout"/> as the
 /// <em>overall</em> request budget (matching its documented meaning, "including
-/// retry attempts") and derives a per-attempt timeout that (a) stays strictly
-/// below half the circuit-breaker sampling window and (b) leaves room for retries
-/// when the overall budget allows it.
+/// retry attempts") and derives <em>both</em> the per-attempt timeout
+/// (<see cref="AttemptTimeout(TimeSpan)"/>) and the circuit-breaker sampling
+/// window (<see cref="SamplingDuration(TimeSpan)"/>) <em>from that budget</em>.
+/// Deriving the sampling window from the budget — instead of pinning the
+/// per-attempt timeout under a fixed 30 s window — means a configured 100 s budget
+/// genuinely permits a single attempt of up to ~45 s (and a 24 h budget scales up
+/// accordingly), rather than aborting every attempt at a hard-coded 14 s ceiling.
 /// </para>
 /// </remarks>
 public static class HonuaResilienceTimeouts
 {
+    // Per-attempt timeout as a fraction of the overall budget. At 0.45 the
+    // budget always covers at least two attempts, and the derived sampling
+    // window (2 x attempt + slack) stays strictly below the total budget, so
+    // the standard resilience handler's validator is satisfied for any budget:
+    //   total > sampling (0.95) >= 2 x attempt (0.90)  and  total > attempt (0.45).
+    private const double AttemptFraction = 0.45;
+    private const double SamplingFraction = 0.95;
+
     /// <summary>
     /// The standard resilience handler's default circuit-breaker sampling
-    /// duration. The handler requires <c>SamplingDuration &gt;= 2 * AttemptTimeout</c>.
+    /// duration. Retained for backwards compatibility; the effective sampling
+    /// window is now derived from the configured budget via
+    /// <see cref="SamplingDuration(TimeSpan)"/> so that the per-attempt timeout is
+    /// not pinned under a fixed 30 s window.
     /// </summary>
     public static readonly TimeSpan CircuitBreakerSamplingDuration = TimeSpan.FromSeconds(30);
 
-    // A small margin below SamplingDuration/2 (15 s) keeps the validator happy
-    // even accounting for any internal rounding, and is a sane per-attempt ceiling.
-    private static readonly TimeSpan MaxAttemptTimeout = TimeSpan.FromSeconds(14);
-
     /// <summary>
     /// Computes the per-attempt timeout for the standard resilience handler from
-    /// the caller's overall <paramref name="totalTimeout"/> budget. The result is
-    /// always strictly less than half of <see cref="CircuitBreakerSamplingDuration"/>
-    /// (so handler validation passes) and never exceeds the overall budget. When
-    /// the overall budget is large, the per-attempt timeout is capped so multiple
-    /// attempts fit inside the budget.
+    /// the caller's overall <paramref name="totalTimeout"/> budget. The result
+    /// scales with the budget (≈45% of it) so a long single call is allowed to
+    /// run for a meaningful fraction of the configured budget instead of being
+    /// aborted at a fixed ceiling, while still leaving room for a retry. Pair this
+    /// with <see cref="SamplingDuration(TimeSpan)"/> when configuring the handler
+    /// so that <c>SamplingDuration &gt;= 2 * AttemptTimeout</c> always holds.
     /// </summary>
     /// <param name="totalTimeout">The overall request budget (the option <c>Timeout</c>).</param>
     /// <returns>A per-attempt timeout suitable for <c>AttemptTimeout.Timeout</c>.</returns>
     public static TimeSpan AttemptTimeout(TimeSpan totalTimeout)
-    {
-        if (totalTimeout <= MaxAttemptTimeout)
-        {
-            // Budget already fits within a single valid attempt; leave a little
-            // headroom for at least a second attempt when the budget is not tiny.
-            return totalTimeout;
-        }
+        => totalTimeout <= TimeSpan.Zero
+            ? totalTimeout
+            : TimeSpan.FromTicks((long)(totalTimeout.Ticks * AttemptFraction));
 
-        return MaxAttemptTimeout;
-    }
+    /// <summary>
+    /// Computes the circuit-breaker sampling window for the standard resilience
+    /// handler from the caller's overall <paramref name="totalTimeout"/> budget.
+    /// The result (≈95% of the budget) is guaranteed to be at least double the
+    /// per-attempt timeout returned by <see cref="AttemptTimeout(TimeSpan)"/> for
+    /// the same budget, and strictly less than the total budget, so the handler's
+    /// validation passes for any configured <c>Timeout</c>.
+    /// </summary>
+    /// <param name="totalTimeout">The overall request budget (the option <c>Timeout</c>).</param>
+    /// <returns>A sampling duration suitable for <c>CircuitBreaker.SamplingDuration</c>.</returns>
+    public static TimeSpan SamplingDuration(TimeSpan totalTimeout)
+        => totalTimeout <= TimeSpan.Zero
+            ? totalTimeout
+            : TimeSpan.FromTicks((long)(totalTimeout.Ticks * SamplingFraction));
 
     /// <summary>
     /// Computes the overall request timeout for the standard resilience handler's

--- a/src/Honua.Sdk.Abstractions/Offline/OfflineSyncState.cs
+++ b/src/Honua.Sdk.Abstractions/Offline/OfflineSyncState.cs
@@ -68,7 +68,12 @@ public sealed record OfflineSyncCheckpoint
     /// <summary>Source identifier inside the package.</summary>
     public required string SourceId { get; init; }
 
-    /// <summary>Provider sync token associated with the checkpoint.</summary>
+    /// <summary>
+    /// Provider sync token associated with the checkpoint. Reserved for providers
+    /// that supply a server high-water mark; <c>OfflineSyncEngine</c>
+    /// performs a full-refresh pull and leaves this <c>null</c> (it does not record
+    /// an advancing token).
+    /// </summary>
     public string? SyncToken { get; init; }
 
     /// <summary>Time when the checkpoint was recorded.</summary>

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -183,6 +183,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
@@ -62,6 +62,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
@@ -132,6 +132,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -180,6 +180,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
+++ b/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
@@ -103,6 +103,23 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
     /// <summary>
     /// Pulls remote feature pages into the local feature store.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is a <strong>full refresh</strong>: every call re-queries each source
+    /// from the beginning and re-stores all matching features. It is
+    /// <em>not</em> an incremental/delta pull. The provider-neutral feature query
+    /// API (<see cref="Honua.Sdk.Abstractions.Features.FeatureQueryResult"/>)
+    /// exposes no server high-water-mark / sync token, so there is nothing to
+    /// advance between runs; the persisted checkpoint therefore tracks only the
+    /// number of features pulled and does not record an advancing
+    /// <see cref="OfflineSyncCheckpoint.SyncToken"/>.
+    /// </para>
+    /// <para>
+    /// Callers that need server-driven delta sync (a <c>serverGen</c> high-water
+    /// mark) should use <see cref="ReplicaSyncClient"/> instead, which threads the
+    /// server generation through extract-changes requests.
+    /// </para>
+    /// </remarks>
     /// <param name="manifest">Offline package manifest.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Pull result.</returns>
@@ -162,7 +179,11 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 {
                     PackageId = manifest.PackageId,
                     SourceId = source.SourceId,
-                    SyncToken = request.LastSyncToken,
+                    // Full-refresh pull: the query API surfaces no server-advanced
+                    // sync token, so there is no high-water mark to persist. Leave
+                    // SyncToken null rather than re-storing the (unchanged) request
+                    // token, which would falsely imply incremental progress.
+                    SyncToken = null,
                     PulledFeatureCount = sourceFeatureCount,
                 }, cancellationToken).ConfigureAwait(false);
             }

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -69,6 +69,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();
@@ -103,6 +104,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtensions
             {
                 options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
+                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
                 options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
                 options.Retry.DisableForUnsafeHttpMethods();

--- a/tests/Honua.Sdk.Abstractions.Tests/HonuaResilienceTimeoutsTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/HonuaResilienceTimeoutsTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Tests;
+
+public sealed class HonuaResilienceTimeoutsTests
+{
+    public static IEnumerable<object[]> BudgetCases()
+    {
+        yield return [TimeSpan.FromSeconds(1)];
+        yield return [TimeSpan.FromSeconds(15)];
+        yield return [TimeSpan.FromSeconds(30)];
+        yield return [TimeSpan.FromSeconds(100)];
+        yield return [TimeSpan.FromMinutes(10)];
+        yield return [TimeSpan.FromHours(1)];
+        yield return [TimeSpan.FromHours(23)];
+    }
+
+    [Theory]
+    [MemberData(nameof(BudgetCases))]
+    public void DerivedTimeouts_SatisfyStandardResilienceValidatorConstraints(TimeSpan budget)
+    {
+        var attempt = HonuaResilienceTimeouts.AttemptTimeout(budget);
+        var sampling = HonuaResilienceTimeouts.SamplingDuration(budget);
+        var total = HonuaResilienceTimeouts.TotalRequestTimeout(budget);
+
+        // The standard resilience handler validates:
+        //   1. TotalRequestTimeout > AttemptTimeout
+        //   2. CircuitBreaker.SamplingDuration >= 2 * AttemptTimeout
+        //   3. TotalRequestTimeout > CircuitBreaker.SamplingDuration
+        Assert.True(attempt > TimeSpan.Zero);
+        Assert.True(total > attempt, $"total {total} must exceed attempt {attempt}");
+        Assert.True(sampling >= attempt + attempt, $"sampling {sampling} must be >= 2x attempt {attempt}");
+        Assert.True(total > sampling, $"total {total} must exceed sampling {sampling}");
+    }
+
+    [Fact]
+    public void AttemptTimeout_ScalesWithBudget_NotPinnedAtFixedCeiling()
+    {
+        // Regression: a configured 100 s budget must permit a single attempt well
+        // beyond the old hard-coded 14 s per-attempt ceiling, and the per-attempt
+        // timeout must grow with the budget rather than saturating at a constant.
+        var attempt100 = HonuaResilienceTimeouts.AttemptTimeout(TimeSpan.FromSeconds(100));
+        var attempt30 = HonuaResilienceTimeouts.AttemptTimeout(TimeSpan.FromSeconds(30));
+
+        Assert.True(attempt100 > TimeSpan.FromSeconds(14), $"attempt for 100 s budget was {attempt100}");
+        Assert.True(attempt100 > attempt30, "per-attempt timeout must scale with the overall budget");
+
+        var attemptDay = HonuaResilienceTimeouts.AttemptTimeout(TimeSpan.FromHours(12));
+        Assert.True(attemptDay > attempt100, "per-attempt timeout must keep scaling for large budgets");
+    }
+
+    [Fact]
+    public void TotalRequestTimeout_EqualsConfiguredBudget()
+    {
+        var budget = TimeSpan.FromSeconds(73);
+        Assert.Equal(budget, HonuaResilienceTimeouts.TotalRequestTimeout(budget));
+    }
+}

--- a/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
@@ -47,7 +47,9 @@ public sealed class OfflineSyncEngineTests
         Assert.Equal("token-1", storedPage.SyncToken);
 
         var checkpoint = Assert.Single(store.Checkpoints.Values);
-        Assert.Equal("token-1", checkpoint.SyncToken);
+        // Full-refresh pull: no server high-water mark exists to advance, so the
+        // checkpoint must not persist a (misleading) static sync token.
+        Assert.Null(checkpoint.SyncToken);
         Assert.Equal(2, checkpoint.PulledFeatureCount);
     }
 


### PR DESCRIPTION
Round-1 release-audit fixes (reliability/performance theme).

## Findings addressed

### S2 `src/Honua.Sdk.Abstractions/HonuaResilienceTimeouts.cs:49` — per-attempt HTTP timeout hard-capped at 14s
`AttemptTimeout` returned `min(totalTimeout, 14s)` so that the default 30s circuit-breaker `SamplingDuration` (validator requires `SamplingDuration >= 2*AttemptTimeout`) would validate. Result: every single HTTP attempt was aborted at 14s with `TimeoutRejectedException` regardless of the configured `Timeout` (default 100s, configurable to 24h). Any call legitimately needing >14s (large FeatureServer query/QueryStatistics, ImageServer ExportImage, GeometryServer buffer/union, batch geocode, STAC search) could never complete, making the advertised `Timeout` budget meaningless for long single calls.

**Fix:** derive *both* the per-attempt timeout (~45% of budget) and the circuit-breaker sampling window (~95% of budget) from the configured `Timeout`, instead of pinning the attempt under a fixed 30s window. This keeps all standard-resilience validator constraints satisfied for any budget (`total > sampling >= 2*attempt`, `total > attempt`) while letting a 100s budget permit ~45s attempts and larger budgets scale up. Each package's `AddStandardResilienceHandler` registration now also sets `CircuitBreaker.SamplingDuration`. Added `HonuaResilienceTimeoutsTests` asserting the constraints hold across a range of budgets and that the per-attempt timeout scales (no longer pinned at 14s).

### S2 `src/Honua.Sdk.Offline/OfflineSyncEngine.cs:161` — non-incremental pull persists a static, misleading sync token
`PullAsync` saved the checkpoint with `SyncToken = request.LastSyncToken` — the same token it started with — and the provider-neutral `FeatureQueryResult` exposes no server high-water mark to advance (`OfflinePackageManifest.ToQueryRequest` even discards the token). The checkpoint therefore never moved forward: every sync re-pulled the whole source while *looking* like delta progress.

**Fix (per recommendation's documented fallback, since the query API cannot return a server token without a cross-repo server change):** document `PullAsync` clearly as a full-refresh (non-incremental) operation and stop persisting the misleading static `SyncToken` (now left `null`), so callers are not led to expect incremental behavior. Callers needing delta sync are pointed at `ReplicaSyncClient` (serverGen-based). Updated the checkpoint doc and the offline test expectation.

## Verification
- `dotnet build Honua.Sdk.sln -c Release -p:TreatWarningsAsErrors=true` — succeeds, 0 warnings.
- `Honua.Sdk.Abstractions.Tests` (86) and `Honua.Sdk.Offline.Tests` (38) pass, including the new resilience tests.