### PR TITLE
refactor(options): hoist shared options surface, validators & HTTPS guards; docs package map

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -88,7 +88,7 @@ the matching `AddHonua*` extension registers it.
 | `IHonuaFeatureStreamClient` | `Honua.Sdk.Abstractions` | [api/Honua.Sdk.Abstractions.Features.IHonuaFeatureStreamClient.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Abstractions.Features.IHonuaFeatureStreamClient.html) |
 | `IReplicaSyncClient` | `Honua.Sdk.Offline` (interface in `Honua.Sdk.Abstractions.Offline`) | [api/Honua.Sdk.Abstractions.Offline.IReplicaSyncClient.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Abstractions.Offline.IReplicaSyncClient.html) |
 
-## Package map (13 sub-packages + the meta package)
+## Package map (14 sub-packages + the meta package)
 
 Each row links to the package README, the canonical types you reach for
 first, and the DocFX namespace landing page.
@@ -103,6 +103,7 @@ first, and the DocFX namespace landing page.
 | `Honua.Sdk.Processes` | [src/Honua.Sdk.Processes/README.md](../src/Honua.Sdk.Processes/README.md) | `IHonuaProcessesClient`, `HonuaProcessesClientOptions`, `HonuaProcessList`, `HonuaProcessExecuteRequest`, `HonuaProcessExecuteInputs`, `HonuaProcessJobStatus`, `HonuaProcessResults` | [api/Honua.Sdk.Processes.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Processes.html) |
 | `Honua.Sdk.Spec` | [src/Honua.Sdk.Spec/README.md](../src/Honua.Sdk.Spec/README.md) | `IHonuaSpecClient`, `HonuaSpecClientOptions`, `SpecDocumentRequest`, `SpecValidateRequest`, `SpecApplyStream`, `HonuaSpecArtifact` | [api/Honua.Sdk.Spec.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Spec.html) |
 | `Honua.Sdk.Studio` | [src/Honua.Sdk.Studio/README.md](../src/Honua.Sdk.Studio/README.md) | `IHonuaStudioReportsClient`, `HonuaStudioReportsClient`, `HonuaStudioClientOptions`, `HonuaRenderedReport`, `HonuaStudioApiException`, `HonuaStudioContractException` | [api/Honua.Sdk.Studio.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Studio.html) |
+| `Honua.Sdk.ConsoleShare` | [src/Honua.Sdk.ConsoleShare/README.md](../src/Honua.Sdk.ConsoleShare/README.md) | `IHonuaConsoleShareClient`, `IHonuaConsoleShareExportClient`, `IHonuaConsoleShareOpenDataClient`, `HonuaConsoleShareClient`, `HonuaConsoleShareClientOptions` | [api/Honua.Sdk.ConsoleShare.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.ConsoleShare.html) |
 | `Honua.Sdk.Field` | [src/Honua.Sdk.Field/README.md](../src/Honua.Sdk.Field/README.md) | `FormDefinition`, `FormField`, `FieldRecord`, `FormValidator`, `FormValidationResult` | [api/Honua.Sdk.Field.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Field.html) |
 | `Honua.Sdk.Geometry` | [src/Honua.Sdk.Geometry/README.md](../src/Honua.Sdk.Geometry/README.md) | `HonuaSpatialReference`, `HonuaCoordinateTransformer`, `HonuaPlanarGeometryAnalyzer`, `HonuaGeofenceEvaluator`, `GeometryText`, `GeoJsonGeometryConverter` | [api/Honua.Sdk.Geometry.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.Geometry.html) |
 | `Honua.Sdk.GeoServices` | [src/Honua.Sdk.GeoServices/README.md](../src/Honua.Sdk.GeoServices/README.md) | `IHonuaFeatureServerClient`, `IHonuaFeatureServerEditClient`, `IHonuaRoutingClient`, `HonuaGeoServicesClientOptions` | [api/Honua.Sdk.GeoServices.html](https://honua-io.github.io/honua-sdk-dotnet/api/Honua.Sdk.GeoServices.html) |

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
@@ -214,6 +214,48 @@ public static class HonuaAuthenticationSupport
         => string.IsNullOrEmpty(value) ? string.Empty : "[redacted]";
 
     /// <summary>
+    /// Determines whether credentials must only be sent over HTTPS for the given
+    /// request URI. This is the single source of truth for the SDK's plain-HTTP
+    /// credential guard: credentials are permitted over plain HTTP only for local
+    /// development loopback targets (see <see cref="IsLocalDevelopmentHttp(Uri?)"/>),
+    /// and a <c>null</c> URI is treated as requiring HTTPS (fail-closed).
+    /// </summary>
+    /// <param name="uri">The request (or token endpoint) URI.</param>
+    /// <returns><c>true</c> when credentials must not be sent unless the transport is HTTPS.</returns>
+    public static bool RequiresHttpsForAuthentication(Uri? uri)
+    {
+        if (uri is null)
+        {
+            return true;
+        }
+
+        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !IsLocalDevelopmentHttp(uri);
+    }
+
+    /// <summary>
+    /// Determines whether the URI is a local-development plain-HTTP endpoint
+    /// (loopback or <c>localhost</c> over <c>http</c>) for which the SDK permits
+    /// credentials to be sent without HTTPS.
+    /// </summary>
+    /// <param name="uri">The request (or token endpoint) URI.</param>
+    /// <returns><c>true</c> for loopback/localhost HTTP endpoints; otherwise <c>false</c>.</returns>
+    public static bool IsLocalDevelopmentHttp(Uri? uri)
+    {
+        if (uri is null || !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return uri.IsLoopback ||
+               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Normalizes a scope sequence by trimming empty values.
     /// </summary>
     /// <param name="scopes">Scope sequence.</param>

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaOAuthTokenProviders.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaOAuthTokenProviders.cs
@@ -433,7 +433,7 @@ internal static class HonuaOAuthTokenEndpoint
         }
 
         if (!string.Equals(tokenEndpoint.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
-            !IsLocalDevelopmentHttp(tokenEndpoint))
+            !HonuaAuthenticationSupport.IsLocalDevelopmentHttp(tokenEndpoint))
         {
             throw new ArgumentException(
                 "OAuth token endpoint must use HTTPS, except loopback HTTP for local development.",
@@ -471,10 +471,6 @@ internal static class HonuaOAuthTokenEndpoint
         using var document = await JsonDocument.ParseAsync(responseStream, default, cancellationToken).ConfigureAwait(false);
         return HonuaOAuthTokenEndpointResponse.Parse(document.RootElement, DateTimeOffset.UtcNow);
     }
-
-    private static bool IsLocalDevelopmentHttp(Uri uri)
-        => string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-           (uri.IsLoopback || string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
 }
 
 internal sealed class HonuaOAuthTokenEndpointResponse

--- a/src/Honua.Sdk.Abstractions/HonuaClientOptionsBase.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaClientOptionsBase.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions;
+
+/// <summary>
+/// Shared base for Honua SDK client options classes. Centralizes the common
+/// transport configuration surface — <see cref="BaseAddress"/>,
+/// <see cref="Timeout"/>, <see cref="EnableRetry"/>, <see cref="MaxRetryAttempts"/>
+/// and <see cref="PrimaryHttpMessageHandlerFactory"/> — together with its
+/// defaults and the <see cref="MaxRetryAttempts"/> range check, so the protocol
+/// packages no longer re-declare this surface in lockstep. Shared base-address
+/// and timeout validation lives in <see cref="HonuaClientOptionsValidation"/>.
+/// </summary>
+public abstract class HonuaClientOptionsBase : IHonuaClientOptions
+{
+    private int _maxRetryAttempts = 3;
+
+    /// <summary>
+    /// Base address of the Honua server. Required; the SDK does not assume a
+    /// localhost default so that missing configuration surfaces loudly at
+    /// registration time via the owning package's <c>ValidateBaseAddress</c> check.
+    /// </summary>
+    public Uri? BaseAddress { get; set; }
+
+    /// <summary>
+    /// Optional primary HTTP message handler factory for certificate, mTLS, or
+    /// enterprise transport configuration.
+    /// </summary>
+    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
+
+    /// <summary>
+    /// Whether to enable automatic retry on transient failures (default: true).
+    /// </summary>
+    public bool EnableRetry { get; set; } = true;
+
+    /// <summary>
+    /// Overall timeout for each request, including retry attempts (default: 100 seconds).
+    /// Must be greater than 10 milliseconds and less than 24 hours.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+    /// <summary>
+    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
+    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
+    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
+    /// </summary>
+    public int MaxRetryAttempts
+    {
+        get => _maxRetryAttempts;
+        set
+        {
+            if (value is < 2 or > 5)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value), value,
+                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
+            }
+            _maxRetryAttempts = value;
+        }
+    }
+}

--- a/src/Honua.Sdk.Abstractions/HonuaClientOptionsValidation.cs
+++ b/src/Honua.Sdk.Abstractions/HonuaClientOptionsValidation.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions;
+
+/// <summary>
+/// Single source of truth for the base-address and timeout validation shared by
+/// every Honua SDK client options class. Each package routes its own
+/// <c>ValidateBaseAddress</c>/<c>ValidateTimeout</c> check here with a product
+/// label so the rules can never drift between packages.
+/// </summary>
+public static class HonuaClientOptionsValidation
+{
+    private static readonly TimeSpan MinTimeout = TimeSpan.FromMilliseconds(10);
+    private static readonly TimeSpan MaxTimeout = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// Validates that a configured base address is present, absolute, and uses
+    /// HTTP or HTTPS, throwing <see cref="HonuaConfigurationException"/> otherwise.
+    /// </summary>
+    /// <param name="baseAddress">The configured base address.</param>
+    /// <param name="productLabel">Human-readable product prefix used in messages (e.g. <c>"Honua STAC"</c>).</param>
+    public static void ValidateBaseAddress(Uri? baseAddress, string productLabel)
+    {
+        if (baseAddress is null)
+        {
+            throw new HonuaConfigurationException($"{productLabel} base address must be configured.");
+        }
+
+        if (!baseAddress.IsAbsoluteUri)
+        {
+            throw new HonuaConfigurationException($"{productLabel} base address must be an absolute URI.");
+        }
+
+        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new HonuaConfigurationException($"{productLabel} base address must use HTTP or HTTPS.");
+        }
+    }
+
+    /// <summary>
+    /// Validates that a configured timeout is greater than 10 milliseconds and
+    /// less than 24 hours, throwing <see cref="HonuaConfigurationException"/> otherwise.
+    /// </summary>
+    /// <param name="timeout">The configured timeout.</param>
+    /// <param name="productLabel">Human-readable product prefix used in messages (e.g. <c>"Honua STAC"</c>).</param>
+    public static void ValidateTimeout(TimeSpan timeout, string productLabel)
+    {
+        if (timeout <= MinTimeout || timeout >= MaxTimeout)
+        {
+            throw new HonuaConfigurationException($"{productLabel} timeout must be greater than 10 milliseconds and less than 24 hours.");
+        }
+    }
+}

--- a/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.Admin;
 /// <summary>
 /// Configuration options for the Honua Admin client.
 /// </summary>
-public sealed class HonuaAdminClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaAdminClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK does not assume a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via <see cref="HonuaAdminClientOptions.ValidateBaseAddress"/>.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for admin authentication.
     /// </summary>
@@ -63,97 +56,15 @@ public sealed class HonuaAdminClientOptions : IHonuaAuthenticationOptions, Honua
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures (default: true).
-    /// Retries on 429 (Too Many Requests), 502 (Bad Gateway), and 503 (Service Unavailable).
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/>
-    /// is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua admin base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua admin base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua admin base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua admin");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua admin timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua admin");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClientOptions.cs
+++ b/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.Catalogs.Records;
 /// <summary>
 /// Configuration options for the OGC API Records client.
 /// </summary>
-public sealed class HonuaOgcRecordsClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaOgcRecordsClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -57,94 +50,15 @@ public sealed class HonuaOgcRecordsClientOptions : IHonuaAuthenticationOptions, 
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Records base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Records base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Records base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua OGC Records");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Records timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua OGC Records");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Catalogs/Stac/HonuaStacClientOptions.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/HonuaStacClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.Catalogs.Stac;
 /// <summary>
 /// Configuration options for the STAC client.
 /// </summary>
-public sealed class HonuaStacClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaStacClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -57,94 +50,15 @@ public sealed class HonuaStacClientOptions : IHonuaAuthenticationOptions, Honua.
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua STAC base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua STAC base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua STAC base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua STAC");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua STAC timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua STAC");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.ConsoleShare/HonuaConsoleShareClientOptions.cs
+++ b/src/Honua.Sdk.ConsoleShare/HonuaConsoleShareClientOptions.cs
@@ -8,13 +8,8 @@ namespace Honua.Sdk.ConsoleShare;
 /// <summary>
 /// Configuration options for the Honua Console Share client.
 /// </summary>
-public sealed class HonuaConsoleShareClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaConsoleShareClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -55,92 +50,15 @@ public sealed class HonuaConsoleShareClientOptions : IHonuaAuthenticationOptions
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Console Share base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Console Share base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Console Share base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua Console Share");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Console Share timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua Console Share");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.GeoServices;
 /// <summary>
 /// Configuration options shared by the FeatureServer and OGC Features clients.
 /// </summary>
-public sealed class HonuaGeoServicesClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaGeoServicesClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -64,46 +57,6 @@ public sealed class HonuaGeoServicesClientOptions : IHonuaAuthenticationOptions,
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
     /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures (default: true).
-    /// Retries on 429 (Too Many Requests), 502 (Bad Gateway), and 503 (Service Unavailable).
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
-    /// <summary>
     /// Default GeoServices NAServer service id used by routing clients.
     /// </summary>
     public string RoutingServiceId { get; set; } = "Routing";
@@ -129,55 +82,14 @@ public sealed class HonuaGeoServicesClientOptions : IHonuaAuthenticationOptions,
     public string GeometryServiceId { get; set; } = "Geometry";
 
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua GeoServices base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua GeoServices base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua GeoServices base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua GeoServices");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua GeoServices timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua GeoServices");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Grpc/Extensions/ServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers the Honua gRPC client and related services with the DI container.
     /// The supplied <paramref name="configure"/> delegate is invoked exactly once to
-    /// capture options; <see cref="HonuaGrpcClientOptions.BaseAddress"/> and
-    /// <see cref="HonuaGrpcClientOptions.Timeout"/> are validated eagerly so a
+    /// capture options; <see cref="Honua.Sdk.Abstractions.HonuaClientOptionsBase.BaseAddress"/> and
+    /// <see cref="Honua.Sdk.Abstractions.HonuaClientOptionsBase.Timeout"/> are validated eagerly so a
     /// misconfigured client fails at registration time, matching the behavior of every
     /// REST SDK package.
     /// </summary>

--- a/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
+++ b/src/Honua.Sdk.Grpc/HonuaGrpcClientOptions.cs
@@ -8,16 +8,8 @@ namespace Honua.Sdk.Grpc;
 /// <summary>
 /// Configuration options for the Honua gRPC client.
 /// </summary>
-public sealed class HonuaGrpcClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaGrpcClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua gRPC server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static <see cref="ParseAndValidateAddress"/> check.
-    /// Matches the <c>BaseAddress</c> property exposed by every REST SDK options class.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication (sent as grpc-metadata header).
     /// </summary>
@@ -65,12 +57,6 @@ public sealed class HonuaGrpcClientOptions : IHonuaAuthenticationOptions, Honua.
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
     /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
     /// Enables gRPC compression negotiation for responses.
     /// </summary>
     public bool EnableCompressionNegotiation { get; set; } = true;
@@ -79,41 +65,6 @@ public sealed class HonuaGrpcClientOptions : IHonuaAuthenticationOptions, Honua.
     /// Accepted gRPC compression algorithms advertised to the server.
     /// </summary>
     public string AcceptedCompressionEncodings { get; set; } = "gzip,identity";
-
-    /// <summary>
-    /// Enables the default retry policy for transient gRPC failures
-    /// (Unavailable, Internal). Defaults to <c>true</c>.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall deadline applied to each gRPC call, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (including the original call). Only used
-    /// when <see cref="EnableRetry"/> is <c>true</c>. Defaults to 3. Must be in
-    /// the inclusive range [2, 5]; the setter throws
-    /// <see cref="ArgumentOutOfRangeException"/> for values outside that range.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
 
     internal static Uri ParseAndValidateAddress(HonuaGrpcClientOptions options)
     {
@@ -146,36 +97,11 @@ public sealed class HonuaGrpcClientOptions : IHonuaAuthenticationOptions, Honua.
     }
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua gRPC timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua gRPC");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.OgcFeatures;
 /// <summary>
 /// Configuration options for the OGC API Features client.
 /// </summary>
-public sealed class HonuaOgcFeaturesClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaOgcFeaturesClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -63,96 +56,15 @@ public sealed class HonuaOgcFeaturesClientOptions : IHonuaAuthenticationOptions,
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures (default: true).
-    /// Retries on 429 (Too Many Requests), 502 (Bad Gateway), and 503 (Service Unavailable).
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Features base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Features base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Features base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua OGC Features");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua OGC Features timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua OGC Features");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClientOptions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.OgcFeatures.Wfs;
 /// <summary>
 /// Configuration options for the Honua WFS client.
 /// </summary>
-public sealed class HonuaWfsClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaWfsClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -63,96 +56,15 @@ public sealed class HonuaWfsClientOptions : IHonuaAuthenticationOptions, Honua.S
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures (default: true).
-    /// Retries on 429 (Too Many Requests), 502 (Bad Gateway), and 503 (Service Unavailable).
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua WFS base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua WFS base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua WFS base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua WFS");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua WFS timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua WFS");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Processes/HonuaProcessesClientOptions.cs
+++ b/src/Honua.Sdk.Processes/HonuaProcessesClientOptions.cs
@@ -8,13 +8,8 @@ namespace Honua.Sdk.Processes;
 /// <summary>
 /// Configuration options for the Honua OGC API Processes client.
 /// </summary>
-public sealed class HonuaProcessesClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaProcessesClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -55,92 +50,15 @@ public sealed class HonuaProcessesClientOptions : IHonuaAuthenticationOptions, H
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Processes base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Processes base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Processes base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua Processes");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Processes timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua Processes");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Scenes/HonuaSceneClientOptions.cs
+++ b/src/Honua.Sdk.Scenes/HonuaSceneClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.Scenes;
 /// <summary>
 /// Configuration options for the Honua scene metadata client.
 /// </summary>
-public sealed class HonuaSceneClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaSceneClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// Server-relative scene metadata API path.
     /// </summary>
@@ -64,92 +57,15 @@ public sealed class HonuaSceneClientOptions : IHonuaAuthenticationOptions, Honua
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts. Only applies when <see cref="EnableRetry"/> is true.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua scene base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua scene base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua scene base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua scene");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua scene timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua scene");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Spec/HonuaSpecClientOptions.cs
+++ b/src/Honua.Sdk.Spec/HonuaSpecClientOptions.cs
@@ -8,15 +8,8 @@ namespace Honua.Sdk.Spec;
 /// <summary>
 /// Options for the Honua spec client.
 /// </summary>
-public sealed class HonuaSpecClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaSpecClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base Honua Server address. Required; the SDK no longer assumes a
-    /// localhost default so that missing configuration surfaces loudly at
-    /// registration time via the static ValidateBaseAddress check.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -63,96 +56,15 @@ public sealed class HonuaSpecClientOptions : IHonuaAuthenticationOptions, Honua.
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or
-    /// enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures (default: true).
-    /// Retries on 429 (Too Many Requests), 502 (Bad Gateway), and 503 (Service Unavailable).
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts (default: 100 seconds).
-    /// Must be greater than 10 milliseconds and less than 24 hours.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts (default: 3). Must be in the inclusive
-    /// range [2, 5]; the setter throws <see cref="ArgumentOutOfRangeException"/>
-    /// for values outside that range. Only applies when <see cref="EnableRetry"/> is <c>true</c>.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua spec base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua spec base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua spec base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua spec");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua spec timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua spec");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }

--- a/src/Honua.Sdk.Studio/HonuaStudioClientOptions.cs
+++ b/src/Honua.Sdk.Studio/HonuaStudioClientOptions.cs
@@ -8,13 +8,8 @@ namespace Honua.Sdk.Studio;
 /// <summary>
 /// Configuration options for the Honua Console Studio client.
 /// </summary>
-public sealed class HonuaStudioClientOptions : IHonuaAuthenticationOptions, Honua.Sdk.Abstractions.IHonuaClientOptions
+public sealed class HonuaStudioClientOptions : Honua.Sdk.Abstractions.HonuaClientOptionsBase, IHonuaAuthenticationOptions
 {
-    /// <summary>
-    /// Base address of the Honua server.
-    /// </summary>
-    public Uri? BaseAddress { get; set; }
-
     /// <summary>
     /// API key for authentication.
     /// </summary>
@@ -55,92 +50,15 @@ public sealed class HonuaStudioClientOptions : IHonuaAuthenticationOptions, Honu
     /// </summary>
     public HonuaAuthenticationDiagnosticHandler? AuthenticationDiagnostics { get; set; }
 
-    /// <summary>
-    /// Optional primary HTTP message handler factory for certificate, mTLS, or enterprise transport configuration.
-    /// </summary>
-    public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
-
-    /// <summary>
-    /// Whether to enable automatic retry on transient HTTP failures.
-    /// </summary>
-    public bool EnableRetry { get; set; } = true;
-
-    /// <summary>
-    /// Overall timeout for each HTTP request, including retry attempts.
-    /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
-
-    /// <summary>
-    /// Maximum number of retry attempts.
-    /// </summary>
-    public int MaxRetryAttempts
-    {
-        get => _maxRetryAttempts;
-        set
-        {
-            if (value is < 2 or > 5)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(value), value,
-                    "MaxRetryAttempts must be in the inclusive range [2, 5].");
-            }
-
-            _maxRetryAttempts = value;
-        }
-    }
-
-    private int _maxRetryAttempts = 3;
-
     internal static void ValidateBaseAddress(Uri? baseAddress)
-    {
-        if (baseAddress is null)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Studio base address must be configured.");
-        }
-
-        if (!baseAddress.IsAbsoluteUri)
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Studio base address must be an absolute URI.");
-        }
-
-        if (!string.Equals(baseAddress.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !string.Equals(baseAddress.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Studio base address must use HTTP or HTTPS.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateBaseAddress(baseAddress, "Honua Studio");
 
     internal static void ValidateTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.FromMilliseconds(10) || timeout >= TimeSpan.FromHours(24))
-        {
-            throw new Honua.Sdk.Abstractions.HonuaConfigurationException("Honua Studio timeout must be greater than 10 milliseconds and less than 24 hours.");
-        }
-    }
+        => Honua.Sdk.Abstractions.HonuaClientOptionsValidation.ValidateTimeout(timeout, "Honua Studio");
 
     internal static bool RequiresHttpsForAuthentication(Uri? uri)
-    {
-        if (uri is null)
-        {
-            return true;
-        }
-
-        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return !IsLocalDevelopmentHttp(uri);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.RequiresHttpsForAuthentication(uri);
 
     internal static bool IsLocalDevelopmentHttp(Uri uri)
-    {
-        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        return uri.IsLoopback ||
-               string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
-    }
+        => Honua.Sdk.Abstractions.Authentication.HonuaAuthenticationSupport.IsLocalDevelopmentHttp(uri);
 }


### PR DESCRIPTION
Round-1 release-audit fixes (DRY / architecture / docs theme). Net -861 lines.

## Findings addressed

### S2 `src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClientOptions.cs:141` — credential-transport guard copy-pasted into 13 files
`RequiresHttpsForAuthentication` (12x) and `IsLocalDevelopmentHttp` (13x, incl. `HonuaOAuthTokenProviders`) are the boundary deciding whether credentials are sent over plain HTTP. 13 identical copies meant one missed fix could silently downgrade the protection.

**Fix:** added the canonical `RequiresHttpsForAuthentication`/`IsLocalDevelopmentHttp` to `HonuaAuthenticationSupport` (Abstractions). All per-package copies now delegate to it, and `HonuaOAuthTokenProviders` calls it directly (its private copy removed). Single source of truth — the guard can no longer drift between packages.

### S2 `src/Honua.Sdk.Abstractions/IHonuaClientOptions.cs:13` — options surface + validators duplicated across 12 classes; `IHonuaClientOptions` only a marker
Each package re-declared the full transport surface (`BaseAddress`, `Timeout`, `EnableRetry`, `MaxRetryAttempts` + its setter, `PrimaryHttpMessageHandlerFactory`) plus near-identical static `ValidateBaseAddress`/`ValidateTimeout`, differing only by product name — ~12x near-identical code in lockstep.

**Fix:**
- New abstract `HonuaClientOptionsBase` (Abstractions) owns the shared surface, its defaults, and the `MaxRetryAttempts` [2,5] range check. All 12 options classes (11 REST + gRPC) now inherit it and declare only their own members (auth properties, plus e.g. GeoServices routing/geometry ids, Scenes `SceneApiPath`, gRPC compression). `IHonuaClientOptions` is now genuinely implemented by the base rather than acting as a marker.
- New `HonuaClientOptionsValidation` holds the base-address/timeout rules, parameterized by a product label. Each package's `ValidateBaseAddress`/`ValidateTimeout` is now a one-line delegator. **Validation messages are byte-identical to before** (label preserved per package), so the per-package `ClientOptionsValidationTests` pass unchanged.
- gRPC keeps its own `ParseAndValidateAddress` (distinct "address" wording/semantics) and compression options, but routes its timeout validation and HTTPS guards through the shared helpers.

### S2 `docs/api-reference.md:91` — package map omits `Honua.Sdk.ConsoleShare`
Added the `Honua.Sdk.ConsoleShare` row and corrected the heading to "14 sub-packages + the meta package".

## Verification
- `dotnet build Honua.Sdk.sln -c Release -p:TreatWarningsAsErrors=true` — succeeds, 0 warnings.
- All unit test projects pass, including every package's `ClientOptionsValidationTests` (validators, `MaxRetryAttempts` range, and the HTTPS/loopback guards behave identically).