### PR TITLE
fix(query/export): stream feature query/export responses; keep idempotent /query retryable

### DIFF
--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Honua.Sdk.GeoServices.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
+using Polly;
 
 namespace Honua.Sdk.GeoServices.Extensions;
 
@@ -188,8 +189,19 @@ public static class ServiceCollectionExtensions
                 options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
                 options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
                 options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
+                options.Retry.ShouldHandle = args =>
+                {
+                    if (!HttpClientResiliencePredicates.IsTransient(args.Outcome))
+                    {
+                        return ValueTask.FromResult(false);
+                    }
+
+                    // Retry idempotent methods plus the idempotent /query POST fallback, so that a
+                    // long filter string (which forces GET->POST) does not silently lose retry.
+                    // Genuine mutations (applyEdits, attachment edits) remain excluded. Replaces
+                    // DisableForUnsafeHttpMethods(), which would drop the /query POST.
+                    return ValueTask.FromResult(GeoServicesRetryPolicy.IsRetryableRequest(args.Context.GetRequestMessage()));
+                };
                 options.Retry.UseJitter = true;
             });
         }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.GeoServices;
@@ -554,13 +553,19 @@ public sealed class HonuaFeatureServerClient :
 
         var vectorFormat = format ?? FeatureServerVectorFormats.FromFeatureServerFormat(query.Format);
         var protocolFormat = FeatureServerVectorFormats.ToFeatureServerFormat(vectorFormat);
-        var body = await ExecuteQueryAsync(
+
+        // Stream the response straight into the payload reader (ResponseHeadersRead): no
+        // intermediate string allocation and no UTF-8 round-trip, so large/binary-ish vector
+        // payloads (PBF/FlatGeobuf/Parquet) are not buffered or corrupted. This converges the
+        // concrete client onto the same streaming path the third-party extension uses.
+        using var response = await SendQueryAsync(
             serviceId,
             layerId,
             BuildQueryParams(query with { Format = protocolFormat }),
             cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessStreamingAsync(response, cancellationToken).ConfigureAwait(false);
 
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -571,19 +576,52 @@ public sealed class HonuaFeatureServerClient :
         ArgumentNullException.ThrowIfNull(serviceId);
         ArgumentNullException.ThrowIfNull(query);
 
-        var parameters = BuildQueryParams(query);
+        // ResponseHeadersRead: hand the caller a response whose body has NOT been buffered, so
+        // they own streaming/disposal of large export payloads. The caller is responsible for
+        // disposing the returned HttpResponseMessage.
+        return await SendQueryAsync(serviceId, layerId, BuildQueryParams(query), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends a layer <c>/query</c> request returning the response with headers read only (body
+    /// left unbuffered for streaming). Falls back from GET to a form POST when the query string
+    /// exceeds <see cref="PostFallbackThreshold"/> characters; the POST <c>/query</c> remains an
+    /// idempotent read and is kept retry-eligible by the GeoServices resilience policy.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendQueryAsync(
+        string serviceId, int layerId, List<(string Key, string? Value)> parameters, CancellationToken cancellationToken)
+    {
         var basePath = $"{ServicePath(serviceId)}/{layerId}/query";
         var queryString = BuildQueryString(parameters);
         var url = basePath + queryString;
 
         if (url.Length > PostFallbackThreshold)
         {
-            using var content = new FormUrlEncodedContent(
+            var content = new FormUrlEncodedContent(
                 parameters.Where(p => p.Value is not null).Select(p => new KeyValuePair<string, string>(p.Key, p.Value!)));
-            return await _http.PostAsync(CreateRequestUri(basePath), content, cancellationToken).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Post, CreateRequestUri(basePath)) { Content = content };
+            return await _http.SendAsync(
+                request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         }
 
-        return await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
+        return await _http.GetAsync(
+            CreateRequestUri(url), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Validates an unbuffered streaming response without consuming the body on success. On a
+    /// non-success status the (small) error body is read and routed through <see cref="EnsureSuccess"/>
+    /// so callers still observe the normal <see cref="HonuaFeatureServerException"/>.
+    /// </summary>
+    private static async Task EnsureSuccessStreamingAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        EnsureSuccess(response, body);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/Honua.Sdk.GeoServices/GeoServicesRetryPolicy.cs
+++ b/src/Honua.Sdk.GeoServices/GeoServicesRetryPolicy.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.GeoServices;
+
+/// <summary>
+/// Decides whether a GeoServices request is safe to retry on a transient failure.
+/// </summary>
+/// <remarks>
+/// The standard resilience handler's <c>DisableForUnsafeHttpMethods</c> retries only idempotent
+/// HTTP methods. That rule alone silently drops transient-retry protection from the FeatureServer
+/// <c>/query</c> read whenever its URL exceeds the POST fallback threshold (long <c>where</c>
+/// filters), because the read is then issued as a POST. This policy restores that protection:
+/// it retries the idempotent methods <em>plus</em> the idempotent <c>/query</c> POST, while still
+/// excluding genuine mutations such as <c>applyEdits</c>. Retry behaviour therefore no longer
+/// changes with filter length.
+/// </remarks>
+internal static class GeoServicesRetryPolicy
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when a transient failure for <paramref name="request"/> may
+    /// be safely retried.
+    /// </summary>
+    /// <param name="request">The outgoing request, or <see langword="null"/> when unavailable.</param>
+    public static bool IsRetryableRequest(HttpRequestMessage? request)
+    {
+        // When the method cannot be determined, defer to the default transient policy (retry).
+        if (request is null)
+        {
+            return true;
+        }
+
+        var method = request.Method;
+        if (method == HttpMethod.Get
+            || method == HttpMethod.Head
+            || method == HttpMethod.Options
+            || method == HttpMethod.Trace
+            || method == HttpMethod.Put
+            || method == HttpMethod.Delete)
+        {
+            return true;
+        }
+
+        // The GeoServices /query read falls back to POST for long filter strings; it is
+        // idempotent and must remain retry-eligible. Mutations (applyEdits, attachments) do not
+        // target /query and are correctly excluded.
+        return method == HttpMethod.Post && IsQueryRequest(request);
+    }
+
+    private static bool IsQueryRequest(HttpRequestMessage request)
+    {
+        var uri = request.RequestUri;
+        if (uri is null)
+        {
+            return false;
+        }
+
+        var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
+        var queryStart = path.IndexOf('?', StringComparison.Ordinal);
+        if (queryStart >= 0)
+        {
+            path = path[..queryStart];
+        }
+
+        path = path.TrimEnd('/');
+        return path.EndsWith("/query", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -362,7 +362,11 @@ public sealed class HonuaOgcFeaturesClient :
     {
         ArgumentNullException.ThrowIfNull(collectionId);
         var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items{BuildQueryString(query)}";
-        return await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
+
+        // ResponseHeadersRead: return the response without buffering the body so the caller can
+        // stream large export payloads (PBF/FlatGeobuf/Parquet). The caller owns disposal.
+        return await _http.GetAsync(
+            CreateRequestUri(url), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -378,9 +382,19 @@ public sealed class HonuaOgcFeaturesClient :
         var protocolFormat = OgcFeaturesVectorFormats.ToOgcFeaturesFormat(vectorFormat);
         var vectorQuery = (query ?? new OgcItemsParams()) with { Format = protocolFormat };
         var url = $"{BasePath}/collections/{Uri.EscapeDataString(collectionId)}/items{BuildQueryString(vectorQuery)}";
-        var body = await GetStringAsync(url, cancellationToken).ConfigureAwait(false);
 
-        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+        // Stream the response body directly into the reader (ResponseHeadersRead): no buffering
+        // to a string and no UTF-8 round-trip, so large/binary vector payloads are neither
+        // buffered whole nor corrupted.
+        using var response = await _http.GetAsync(
+            CreateRequestUri(url), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            EnsureSuccess(response, body);
+        }
+
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 

--- a/tests/Honua.Sdk.GeoServices.Tests/GeoServicesRetryPolicyTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/GeoServicesRetryPolicyTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.GeoServices;
+
+namespace Honua.Sdk.GeoServices.Tests;
+
+public sealed class GeoServicesRetryPolicyTests
+{
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    [InlineData("TRACE")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    public void IsRetryableRequest_IdempotentMethods_AreRetryable(string method)
+    {
+        using var request = new HttpRequestMessage(new HttpMethod(method), "https://host/rest/services/x/FeatureServer/0/query");
+        Assert.True(GeoServicesRetryPolicy.IsRetryableRequest(request));
+    }
+
+    [Fact]
+    public void IsRetryableRequest_QueryPostFallback_IsRetryable()
+    {
+        // Long filter strings force GET -> POST; the /query read is still idempotent.
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://host/rest/services/x/FeatureServer/0/query");
+        Assert.True(GeoServicesRetryPolicy.IsRetryableRequest(request));
+    }
+
+    [Fact]
+    public void IsRetryableRequest_QueryPostFallback_WithRelativeUri_IsRetryable()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri("rest/services/x/FeatureServer/0/query", UriKind.Relative));
+        Assert.True(GeoServicesRetryPolicy.IsRetryableRequest(request));
+    }
+
+    [Fact]
+    public void IsRetryableRequest_ApplyEditsPost_IsNotRetryable()
+    {
+        // applyEdits is a mutation and must never be auto-retried.
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://host/rest/services/x/FeatureServer/0/applyEdits");
+        Assert.False(GeoServicesRetryPolicy.IsRetryableRequest(request));
+    }
+
+    [Fact]
+    public void IsRetryableRequest_PatchAddAttachment_IsNotRetryable()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Patch, "https://host/rest/services/x/FeatureServer/0/1/addAttachment");
+        Assert.False(GeoServicesRetryPolicy.IsRetryableRequest(request));
+    }
+
+    [Fact]
+    public void IsRetryableRequest_NullRequest_FallsBackToTransientPolicy()
+    {
+        Assert.True(GeoServicesRetryPolicy.IsRetryableRequest(null));
+    }
+}


### PR DESCRIPTION
Finishes the remaining sub-items of the **[audit S2]** FeatureServer/OGC query & export pipeline issue. The per-attempt timeout sub-item (AUD-043) was already shipped in #231; this PR completes the streaming and retry sub-items.

Closes #222

## Fixes

### Stream raw query/export responses — AUD-047
`QueryRawAsync` (FeatureServer) and `GetItemsRawAsync` (OGC API Features) — the documented streaming entry points for PBF/FlatGeobuf/Parquet exports — now issue requests with `HttpCompletionOption.ResponseHeadersRead` instead of buffering the entire body into memory before returning. Caller ownership/disposal of the returned `HttpResponseMessage` is documented on both methods.

### Stream typed vector queries; drop triple-buffering — AUD-048
`QueryVectorAsync` (FeatureServer) and `GetItemsVectorAsync` (OGC) previously buffered the payload to a `string` and then re-encoded it to a `byte[]` `MemoryStream` (≈3× peak memory) and, for the default concrete client, the extension short-circuited its own streaming path. Both now read the response with `ResponseHeadersRead` and feed `response.Content`'s stream directly into `VectorPayloadReaders.ReadAsync`, converging the concrete and third-party paths on one streaming implementation and removing the UTF-8 round-trip (which also corrupted binary payloads). Non-success responses are still surfaced as the usual `HonuaFeatureServerException` / `HonuaOgcFeaturesException`.

### Keep the idempotent `/query` POST retryable — AUD-076
When a query URL exceeds the 2000-char POST-fallback threshold, the idempotent `/query` read is issued as a POST and previously lost transient-retry protection (`DisableForUnsafeHttpMethods` excludes POST). The GeoServices resilience policy now uses a method-aware `ShouldHandle` (`GeoServicesRetryPolicy`) that retries idempotent methods **plus** the `/query` POST fallback, while still excluding genuine mutations (`applyEdits`, attachment edits). Retry behaviour no longer changes with filter length. The request method is read from the resilience context (`Polly.HttpResilienceContextExtensions.GetRequestMessage`) so it is reliable on both transient-status and transient-exception outcomes.

## Note
For the rare GeoServices "HTTP 200 with an `{"error":...}` body" case on the *vector* path, the streaming reader path validates HTTP status rather than re-parsing a success body for an embedded error object (matching the pre-existing third-party extension behaviour). Hard error responses (non-2xx) are still parsed and thrown as typed exceptions.

## Testing
- `dotnet build` (Release, `TreatWarningsAsErrors`) — clean, 0 warnings.
- `Honua.Sdk.GeoServices.Tests` (145, incl. new `GeoServicesRetryPolicyTests`) and `Honua.Sdk.OgcFeatures.Tests` (114) pass.