### PR TITLE
fix: harden auto-pagination handling and GeoServices error-code mapping

### DIFF
--- a/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
@@ -311,7 +311,15 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
                         if (errorElement.TryGetProperty("code", out var codeProp) &&
                             codeProp.TryGetInt32(out var errorCode))
                         {
-                            code = (System.Net.HttpStatusCode)errorCode;
+                            // GeoServices error.code is an independent Esri code space (e.g. 400 is a
+                            // real status but 1000/4001 are not). Only adopt it as the HTTP status when
+                            // it is a valid HTTP status (100-599); otherwise keep the transport status,
+                            // mirroring GeoServicesHttp.MapErrorCodeToStatus. Blindly casting an Esri
+                            // code yields a nonsensical HttpStatus that breaks retry/auth branching.
+                            if (errorCode is >= 100 and <= 599)
+                            {
+                                code = (System.Net.HttpStatusCode)errorCode;
+                            }
                         }
 
                         throw new HonuaAdminApiException(code, message, body);

--- a/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
+++ b/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
@@ -618,7 +618,7 @@ public sealed class HonuaRoutingClient : IHonuaRoutingClient
                 codeProp.TryGetInt32(out var errorCode))
             {
                 geoServicesCode = errorCode;
-                httpCode = (HttpStatusCode)errorCode;
+                httpCode = GeoServicesHttp.MapErrorCodeToStatus(errorCode, fallbackStatus);
             }
 
             if (errorElement.TryGetProperty("details", out var detailsProp) &&

--- a/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
+++ b/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
@@ -98,6 +98,15 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
             await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
             throw;
         }
+        catch (Exception ex)
+        {
+            // Any unexpected failure (for example a provider-side auto-pagination
+            // safety-limit InvalidOperationException) must still drive the sync to a
+            // terminal Failed state, otherwise operators are left with state stuck at
+            // an in-progress phase with no record of why the run died.
+            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
     }
 
     /// <summary>
@@ -204,6 +213,21 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                     PackageId = manifest.PackageId,
                     SourceId = source.SourceId,
                     Retryable = true,
+                    Reason = ex.Message,
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // A large layer can trip the provider's auto-pagination safety limit
+                // (QueryPagesAsync throws InvalidOperationException once MaxAutoPages is
+                // exceeded). Record it as a non-retryable failure for this source rather
+                // than letting it escape and abort every remaining source in the pull.
+                await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+                failures.Add(new OfflineSyncFailure
+                {
+                    PackageId = manifest.PackageId,
+                    SourceId = source.SourceId,
+                    Retryable = false,
                     Reason = ex.Message,
                 });
             }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -343,13 +343,19 @@ public sealed class HonuaOgcFeaturesClient :
             page = JsonSerializer.Deserialize(body, OgcFeaturesJsonContext.Default.OgcFeatureCollection)
                 ?? throw new HonuaOgcFeaturesException(HttpStatusCode.OK, "Failed to deserialize paged items.", body);
 
-            if (page.Features is null or { Count: 0 })
-            {
-                yield break;
-            }
-
-            yield return page;
             pageCount++;
+
+            // Do NOT terminate just because this page returned zero features: an OGC API
+            // Features server may emit an empty intermediate page that still advertises a
+            // rel=next link, and stopping here would silently drop the remaining features.
+            // Continuation is governed solely by the next link (its absence ends paging at
+            // the top of the loop), the visited-href set, and the MaxAutoPages guard. This
+            // matches the FeatureServer client, which evaluates the continuation signal
+            // before its empty-page check.
+            if (page.Features is not (null or { Count: 0 }))
+            {
+                yield return page;
+            }
         }
 
         throw new InvalidOperationException(

--- a/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/HonuaGeocodingClientTests.cs
@@ -168,6 +168,32 @@ public sealed class HonuaGeocodingClientTests
     }
 
     [Fact]
+    public async Task ForwardGeocode_EsriErrorCode_DoesNotLeakIntoHttpStatus()
+    {
+        // GeoServices returns HTTP 200 with an Esri error.code (4001) that is NOT a valid
+        // HTTP status. The status must stay at the 200 transport value rather than being
+        // cast to (HttpStatusCode)4001, which would corrupt the HttpStatus contract that
+        // consumers branch on for retry/auth.
+        var responseJson = """
+        {
+            "error": {
+                "code": 4001,
+                "message": "Geocode token expired"
+            }
+        }
+        """;
+
+        var client = CreateGeocodingClient(_ =>
+            Task.FromResult(CreateGeoJsonResponse(responseJson)));
+
+        var ex = await Assert.ThrowsAsync<HonuaAdminApiException>(
+            () => client.ForwardGeocodeAsync("123 Main St"));
+
+        Assert.Equal(HttpStatusCode.OK, ex.StatusCode);
+        Assert.Equal("Geocode token expired", ex.Message);
+    }
+
+    [Fact]
     public async Task ForwardGeocode_NullAddress_ThrowsArgumentNullException()
     {
         var client = CreateGeocodingClient(_ =>

--- a/tests/Honua.Sdk.GeoServices.Tests/Routing/HonuaRoutingClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/Routing/HonuaRoutingClientTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Routing;
 using Honua.Sdk.GeoServices.Extensions;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.GeoServices.Routing;
 using Honua.Sdk.GeoServices.Tests.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
@@ -289,6 +290,27 @@ public sealed class HonuaRoutingClientTests
         Assert.True(routingClient.Capabilities.SupportsRouteOptimization);
         Assert.True(routingClient.Capabilities.SupportsServiceAreas);
         Assert.True(routingClient.Capabilities.SupportsClosestFacility);
+    }
+
+    [Fact]
+    public async Task GetDirectionsAsync_GeoServicesErrorCode_DoesNotLeakIntoHttpStatus()
+    {
+        // GeoServices returns HTTP 200 with an error payload whose code is an Esri code
+        // (1000), NOT an HTTP status. The error must keep the 200 transport status and
+        // expose 1000 via GeoServicesErrorCode rather than casting 1000 into HttpStatus,
+        // which would break consumers branching on status for retry/auth.
+        var client = CreateClient((_, _) =>
+            Task.FromResult(JsonResponse("""
+            { "error": { "code": 1000, "message": "Unable to complete operation." } }
+            """)));
+
+        var ex = await Assert.ThrowsAsync<HonuaFeatureServerException>(() =>
+            client.GetDirectionsAsync(
+                RoutingLocation.FromLongitudeLatitude(-157.8583, 21.3069, "Start"),
+                RoutingLocation.FromLongitudeLatitude(-157.8037, 21.2810, "Finish")));
+
+        Assert.Equal(HttpStatusCode.OK, ex.StatusCode);
+        Assert.Equal(1000, ex.GeoServicesErrorCode);
     }
 
     private static HonuaRoutingClient CreateClient(

--- a/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
@@ -192,6 +192,60 @@ public sealed class OfflineSyncEngineTests
             state => Assert.Equal(OfflineSyncPhase.Completed, state.Phase));
     }
 
+    [Fact]
+    public async Task PullAsync_AutoPaginationCap_RecordsNonRetryableFailureAndFailedState()
+    {
+        // The provider QueryPagesAsync throws InvalidOperationException once its
+        // auto-pagination safety limit is hit. The pull must capture this as a
+        // non-retryable per-source failure (and a terminal Failed state) instead of
+        // letting it escape and abort every remaining source.
+        var queryClient = new FakeQueryClient
+        {
+            PagesError = new InvalidOperationException(
+                "Auto-pagination safety limit reached (100 pages)."),
+        };
+        var store = new FakeOfflineStore();
+        var engine = CreateEngine(
+            queryClient,
+            new FakeEditClient(),
+            store,
+            new FakeChangeJournal(),
+            stateStore: store);
+
+        var result = await engine.PullAsync(CreateManifest());
+
+        var failure = Assert.Single(result.Failures);
+        Assert.Equal("parks", failure.SourceId);
+        Assert.False(failure.Retryable);
+        Assert.Contains("safety limit", failure.Reason, StringComparison.Ordinal);
+        Assert.Contains(store.States, state =>
+            state.SourceId == "parks" && state.Phase == OfflineSyncPhase.Failed);
+    }
+
+    [Fact]
+    public async Task SyncAsync_AutoPaginationCap_EndsInTerminalFailedState()
+    {
+        // A pagination-cap failure during pull must not leave sync stuck at an
+        // in-progress phase: the run completes with failures and a terminal Failed state.
+        var queryClient = new FakeQueryClient
+        {
+            PagesError = new InvalidOperationException(
+                "Auto-pagination safety limit reached (100 pages)."),
+        };
+        var store = new FakeOfflineStore();
+        var engine = CreateEngine(
+            queryClient,
+            new FakeEditClient(),
+            store,
+            new FakeChangeJournal(),
+            stateStore: store);
+
+        var result = await engine.SyncAsync(CreateManifest());
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(OfflineSyncPhase.Failed, store.States[^1].Phase);
+    }
+
     private static OfflineSyncEngine CreateEngine(
         FakeQueryClient queryClient,
         FakeEditClient editClient,
@@ -284,6 +338,12 @@ public sealed class OfflineSyncEngineTests
 
         public List<FeatureQueryRequest> Requests { get; } = [];
 
+        /// <summary>
+        /// When set, thrown after all queued pages are drained, simulating the provider's
+        /// auto-pagination safety-limit <see cref="InvalidOperationException"/>.
+        /// </summary>
+        public Exception? PagesError { get; set; }
+
         public Task<FeatureQueryResult> QueryAsync(FeatureQueryRequest request, CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
@@ -300,6 +360,11 @@ public sealed class OfflineSyncEngineTests
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return Pages.Dequeue();
                 await Task.Yield();
+            }
+
+            if (PagesError is not null)
+            {
+                throw PagesError;
             }
         }
     }

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/HonuaOgcFeaturesClientTests.cs
@@ -854,6 +854,57 @@ public class HonuaOgcFeaturesClientTests
     }
 
     [Fact]
+    public async Task GetItemsPagesAsync_EmptyIntermediatePageWithNextLink_ContinuesPaging()
+    {
+        // A server may return an empty intermediate page that still advertises a rel=next
+        // link. Pagination must follow the link rather than stopping on the empty page,
+        // otherwise the trailing features are silently dropped.
+        var callCount = 0;
+        var client = TestHelpers.CreateOgcFeaturesClient(req =>
+        {
+            callCount++;
+            var json = callCount switch
+            {
+                1 => """
+                {
+                    "type": "FeatureCollection",
+                    "features": [{ "type": "Feature", "id": "1", "properties": {} }],
+                    "links": [{ "href": "http://localhost:5000/ogc/features/collections/test/items?offset=1", "rel": "next" }]
+                }
+                """,
+                2 => """
+                {
+                    "type": "FeatureCollection",
+                    "features": [],
+                    "links": [{ "href": "http://localhost:5000/ogc/features/collections/test/items?offset=2", "rel": "next" }]
+                }
+                """,
+                3 => """
+                {
+                    "type": "FeatureCollection",
+                    "features": [{ "type": "Feature", "id": "3", "properties": {} }],
+                    "links": []
+                }
+                """,
+                _ => """{ "type": "FeatureCollection", "features": [] }"""
+            };
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<OgcFeatureCollection>();
+        await foreach (var page in client.GetItemsPagesAsync("test"))
+        {
+            pages.Add(page);
+        }
+
+        // The empty page is not yielded but its next link is followed to reach page 3.
+        Assert.Equal(3, callCount);
+        Assert.Equal(2, pages.Count);
+        Assert.Equal("1", pages[0].Features![0].Id!.Value.GetString());
+        Assert.Equal("3", pages[1].Features![0].Id!.Value.GetString());
+    }
+
+    [Fact]
     public async Task GetItemsPagesAsync_StopsWhenNoNextLink()
     {
         var json = """


### PR DESCRIPTION
Round-2 release-audit fixes for three reliability/correctness findings in the protocol clients. Each is a minimal, targeted fix with a regression test.

## 1. Offline large-layer pull aborts and gets stuck in `Pulling` (S2, reliability)
`src/Honua.Sdk.Offline/OfflineSyncEngine.cs:148`

When a source has no `MaxFeatureCount`, `PullAsync` iterates every page; the provider `QueryPagesAsync` caps at `MaxAutoPages=100` and throws `InvalidOperationException`. `PullAsync` only caught `HttpRequestException`/`TimeoutException` and `SyncAsync` only caught those plus `OperationCanceledException`, so the exception escaped both — aborting every remaining source and never reaching a terminal `Failed` state.

Fix: catch `InvalidOperationException` per-source in `PullAsync` as a non-retryable `OfflineSyncFailure` (and persist a `Failed` state for that source), and broaden `SyncAsync` so any unexpected exception still transitions state to `Failed` before rethrowing.

## 2. OGC Features auto-pagination stops on an empty intermediate page (S2, correctness)
`src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs:346`

`GetItemsPagesAsync` did `yield break` on an empty page before re-evaluating the `rel=next` link, so a server returning an empty-but-linked page silently dropped subsequent features. The FeatureServer client deliberately evaluates the continuation signal first (`HonuaFeatureServerClient.cs:483-489`).

Fix: only terminate when there is no `rel=next` link, the href repeats (visited-href set), or `MaxAutoPages` is hit. Empty-but-linked pages are skipped (not yielded) but paging continues.

## 3. Geocoding & Routing blind-cast `error.code` to `HttpStatusCode` (S2, coherence/correctness)
`src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs:314`, `src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs:621`

GeoServices/geocode/NAServer responses return HTTP 200 with `{error:{code: ...}}` where `code` is an Esri code space (e.g. 1000, 4001). Casting that to `HttpStatusCode` yields a nonsensical status on the unified `HonuaException.HttpStatus` contract, breaking consumers that branch on status for retry/auth. `GeoServicesHttp.MapErrorCodeToStatus` (and `HonuaFeatureServerClient`) already guard this; these two copies were left unfixed.

Fix: Routing now calls `GeoServicesHttp.MapErrorCodeToStatus`; Geocoding (in `Honua.Sdk.Admin`, which does not reference GeoServices) replicates the 100-599 guard inline.

## Verification
`dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true` clean; Offline/GeoServices/Admin/OgcFeatures test projects all pass (incl. new regression tests).