### PR TITLE
fix: correct GML numeric typing and Esri polygon ring orientation

### DIFF
--- a/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
@@ -465,14 +465,41 @@ public static class GeoServicesGeometryConverter
         writer.WriteStartArray();
         foreach (var polygon in polygonList)
         {
-            WriteCoordinateSequence(writer, polygon.ExteriorRing.CoordinateSequence, hasZ, hasM);
+            // Esri JSON requires clockwise exterior rings and counter-clockwise holes,
+            // and the orientation-aware reader (ReadRings) classifies rings strictly by
+            // orientation. NTS geometry decoded from GeoJSON (RFC 7946) carries a CCW
+            // exterior, so emit each ring in the orientation Esri expects rather than
+            // whatever the source carried; otherwise a strict Esri consumer (or this
+            // SDK's own reader) would mis-demote the exterior ring of a multi-ring
+            // polygon to a hole.
+            WriteRingInEsriOrientation(writer, polygon.ExteriorRing, wantClockwise: true, hasZ, hasM);
             for (var index = 0; index < polygon.NumInteriorRings; index++)
             {
-                WriteCoordinateSequence(writer, polygon.GetInteriorRingN(index).CoordinateSequence, hasZ, hasM);
+                WriteRingInEsriOrientation(writer, polygon.GetInteriorRingN(index), wantClockwise: false, hasZ, hasM);
             }
         }
 
         writer.WriteEndArray();
+    }
+
+    private static void WriteRingInEsriOrientation(
+        Utf8JsonWriter writer,
+        LineString ring,
+        bool wantClockwise,
+        bool hasZ,
+        bool hasM)
+    {
+        var sequence = ring.CoordinateSequence;
+        var isCcw = Orientation.IsCCW(sequence);
+
+        // Reverse only when the current orientation does not match the Esri requirement:
+        // an exterior ring must be clockwise (not CCW); a hole must be counter-clockwise.
+        if (wantClockwise == isCcw)
+        {
+            sequence = ((LineString)ring.Reverse()).CoordinateSequence;
+        }
+
+        WriteCoordinateSequence(writer, sequence, hasZ, hasM);
     }
 
     private static void WriteCoordinateSequence(

--- a/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs
@@ -496,7 +496,7 @@ public static class GeoServicesGeometryConverter
         // an exterior ring must be clockwise (not CCW); a hole must be counter-clockwise.
         if (wantClockwise == isCcw)
         {
-            sequence = ((LineString)ring.Reverse()).CoordinateSequence;
+            sequence = sequence.Reversed();
         }
 
         WriteCoordinateSequence(writer, sequence, hasZ, hasM);

--- a/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
+++ b/src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs
@@ -398,13 +398,20 @@ public sealed class GmlVectorPayloadReader : IVectorPayloadReader
             return boolean ? JsonElementFromLiteral("true") : JsonElementFromLiteral("false");
         }
 
-        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+        // Only re-emit the raw text as a JSON number literal when it is a STRICT JSON
+        // number (RFC 8259). .NET's long/double parsers accept forms JSON forbids —
+        // leading zeros (01234), a leading plus (+5), and bare-fraction values (.5) —
+        // which are pervasive in geospatial attributes (ZIP/FIPS/GEOID codes). Feeding
+        // those to JsonDocument.Parse throws and aborts the whole feature-collection read,
+        // so anything that is not a strict JSON number is preserved verbatim as a string.
+        if (IsStrictJsonNumber(value) &&
+            long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
         {
             return JsonElementFromLiteral(value);
         }
 
-        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _) &&
-            value.Any(char.IsDigit))
+        if (IsStrictJsonNumber(value) &&
+            double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
         {
             return JsonElementFromLiteral(value);
         }
@@ -416,6 +423,88 @@ public sealed class GmlVectorPayloadReader : IVectorPayloadReader
         }
 
         return JsonElementFromBytes(stream.ToArray());
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="value"/> is a strict JSON number
+    /// per RFC 8259 (<c>-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?</c>). Rejects the
+    /// number-like forms .NET parses but JSON forbids: leading zeros, a leading plus, and
+    /// bare-fraction values such as <c>.5</c>.
+    /// </summary>
+    private static bool IsStrictJsonNumber(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        var i = 0;
+        var n = value.Length;
+
+        if (value[i] == '-')
+        {
+            i++;
+        }
+
+        // Integer part: a single 0, or a non-zero digit followed by digits (no leading zeros).
+        if (i >= n)
+        {
+            return false;
+        }
+
+        if (value[i] == '0')
+        {
+            i++;
+        }
+        else if (value[i] is >= '1' and <= '9')
+        {
+            i++;
+            while (i < n && value[i] is >= '0' and <= '9')
+            {
+                i++;
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        // Optional fraction.
+        if (i < n && value[i] == '.')
+        {
+            i++;
+            if (i >= n || value[i] is < '0' or > '9')
+            {
+                return false;
+            }
+
+            while (i < n && value[i] is >= '0' and <= '9')
+            {
+                i++;
+            }
+        }
+
+        // Optional exponent.
+        if (i < n && (value[i] == 'e' || value[i] == 'E'))
+        {
+            i++;
+            if (i < n && (value[i] == '+' || value[i] == '-'))
+            {
+                i++;
+            }
+
+            if (i >= n || value[i] is < '0' or > '9')
+            {
+                return false;
+            }
+
+            while (i < n && value[i] is >= '0' and <= '9')
+            {
+                i++;
+            }
+        }
+
+        return i == n;
     }
 
     private static JsonElement JsonElementFromLiteral(string literal)

--- a/tests/Honua.Sdk.Geometry.Tests/GeoServicesGeometryConverterTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GeoServicesGeometryConverterTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Linq;
 using System.Text.Json;
 using Honua.Sdk.Geometry;
+using NetTopologySuite.Algorithm;
 using NetTopologySuite.Geometries;
 
 namespace Honua.Sdk.Geometry.Tests;
@@ -142,4 +144,53 @@ public class GeoServicesGeometryConverterTests
         Assert.Equal(3, firstCoordinate.GetArrayLength());
         Assert.Equal(1, firstCoordinate[2].GetDouble());
     }
+
+    [Fact]
+    public void WriteGeometry_NormalizesPolygonRingOrientationToEsriConvention()
+    {
+        var factory = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+
+        // Exterior wound CCW and hole wound CW: the GeoJSON (RFC 7946) convention, which
+        // is the OPPOSITE of Esri's clockwise-exterior / counter-clockwise-hole rule. The
+        // writer must normalize so a strict Esri consumer (and this SDK's orientation-aware
+        // reader) does not mis-demote the exterior ring of a multi-ring polygon to a hole.
+        var shell = factory.CreateLinearRing(
+        [
+            new Coordinate(0, 0),
+            new Coordinate(10, 0),
+            new Coordinate(10, 10),
+            new Coordinate(0, 10),
+            new Coordinate(0, 0),
+        ]);
+        var hole = factory.CreateLinearRing(
+        [
+            new Coordinate(2, 2),
+            new Coordinate(2, 8),
+            new Coordinate(8, 8),
+            new Coordinate(8, 2),
+            new Coordinate(2, 2),
+        ]);
+        Assert.True(Orientation.IsCCW(shell.CoordinateSequence));
+        Assert.False(Orientation.IsCCW(hole.CoordinateSequence));
+
+        var polygon = factory.CreatePolygon(shell, [hole]);
+
+        var json = GeoServicesGeometryConverter.WriteGeometry(polygon);
+
+        var rings = json.GetProperty("rings");
+        Assert.Equal(2, rings.GetArrayLength());
+
+        // Esri convention: clockwise exterior (not CCW), counter-clockwise hole.
+        Assert.False(Orientation.IsCCW(ReadRing(rings[0])));
+        Assert.True(Orientation.IsCCW(ReadRing(rings[1])));
+
+        // The normalized geometry round-trips back to a polygon with its hole intact.
+        var roundTripped = Assert.IsType<Polygon>(GeoServicesGeometryConverter.ReadGeometry(json));
+        Assert.Equal(1, roundTripped.NumInteriorRings);
+    }
+
+    private static Coordinate[] ReadRing(JsonElement ring)
+        => ring.EnumerateArray()
+            .Select(coordinate => new Coordinate(coordinate[0].GetDouble(), coordinate[1].GetDouble()))
+            .ToArray();
 }

--- a/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/VectorPayloadReaderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using System.Text;
+using System.Text.Json;
 using Honua.Sdk.Geometry.Vector;
 using NetTopologySuite.Geometries;
 
@@ -119,6 +120,50 @@ public sealed class VectorPayloadReaderTests
         Assert.Equal(4326, point.SRID);
         Assert.Equal(-157.819, point.X, 3);
         Assert.Equal(21.267, point.Y, 3);
+    }
+
+    [Fact]
+    public async Task GmlReader_LeadingZeroAndPlusNumericAttributes_PreservedAsStringsWithoutCrashing()
+    {
+        // ZIP/FIPS/GEOID-style codes parse as .NET numbers but are NOT strict JSON numbers.
+        // Re-emitting them as JSON number literals previously threw JsonReaderException and
+        // aborted the whole feature-collection read. They must round-trip as strings, while
+        // genuine numbers stay numeric.
+        const string gml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <wfs:FeatureCollection
+                xmlns:wfs="http://www.opengis.net/wfs/2.0"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:honua="https://honua.io/schemas/test"
+                numberMatched="1"
+                numberReturned="1">
+              <wfs:member>
+                <honua:place gml:id="places.1">
+                  <honua:zip>01234</honua:zip>
+                  <honua:fips>+5</honua:fips>
+                  <honua:pop>5000</honua:pop>
+                  <honua:area>12.5</honua:area>
+                  <honua:shape>
+                    <gml:Point srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                      <gml:pos>-157.819 21.267</gml:pos>
+                    </gml:Point>
+                  </honua:shape>
+                </honua:place>
+              </wfs:member>
+            </wfs:FeatureCollection>
+            """;
+
+        var result = await VectorPayloadReaders.ReadAsync(ToStream(gml), VectorPayloadFormat.Gml);
+
+        var feature = Assert.Single(result.Features);
+        Assert.Equal(JsonValueKind.String, feature.Attributes["zip"].ValueKind);
+        Assert.Equal("01234", feature.Attributes["zip"].GetString());
+        Assert.Equal(JsonValueKind.String, feature.Attributes["fips"].ValueKind);
+        Assert.Equal("+5", feature.Attributes["fips"].GetString());
+        Assert.Equal(JsonValueKind.Number, feature.Attributes["pop"].ValueKind);
+        Assert.Equal(5000, feature.Attributes["pop"].GetInt32());
+        Assert.Equal(JsonValueKind.Number, feature.Attributes["area"].ValueKind);
+        Assert.Equal(12.5, feature.Attributes["area"].GetDouble(), 3);
     }
 
     [Fact]


### PR DESCRIPTION
Round-2 release-audit fixes for two `Honua.Sdk.Geometry` serialization findings. Minimal, targeted fixes with regression tests.

## 1. GML/WFS reader crashes on leading-zero / leading-plus numeric strings (S1, protocol/format compliance)
`src/Honua.Sdk.Geometry/Vector/GmlVectorPayloadReader.cs:401`

`CreateJsonElement` typed an XML text attribute by validating it with .NET `long.TryParse`/`double.TryParse`, then re-emitted the original string verbatim as a JSON number literal via `JsonDocument.Parse`. .NET number parsers accept forms JSON (RFC 8259) forbids: leading zeros (`01234`), leading plus (`+5`), and bare fractions (`.5`). `JsonDocument.Parse` then throws `JsonReaderException`, which is not caught in the read path, so one such attribute on any feature aborts the entire feature-collection parse. These values are pervasive in geospatial data (ZIP codes, FIPS, census GEOIDs).

Fix: only emit a numeric literal when the value is a strict JSON number (a small RFC 8259 scanner, `IsStrictJsonNumber`); otherwise preserve the value verbatim as a JSON string. Genuine numbers stay numeric; identifier-like values keep their leading zeros.

## 2. Esri-JSON writer does not normalize polygon ring orientation (S2, protocol/format compliance)
`src/Honua.Sdk.Geometry/GeoServicesGeometryConverter.cs:458`

`ReadRings` classifies shells vs holes strictly by orientation (Esri: clockwise outer, CCW hole), but `WriteRings` emitted rings in whatever orientation the NTS geometry carried. NTS geometry decoded from GeoJSON (RFC 7946, CCW exterior) therefore serialized with a CCW exterior, which a strict Esri consumer (or this SDK's own reader) reads as a hole. Reachable via `RequestConverters.ProjectGeometryForFeatureServer` (apply-edits) and `ProtoAdapter.ConvertGeometry`. Multi-ring polygons with holes had the outer ring mis-demoted to a hole.

Fix: `WriteRings` now enforces Esri orientation before emit — exterior clockwise (reverse if CCW), each hole CCW — making the write path symmetric with the orientation-aware reader.

## Verification
`dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true` clean; `Honua.Sdk.Geometry.Tests` passes (incl. new regression tests).