### PR TITLE
fix: correct vendored proto license header to Apache-2.0

### DIFF
--- a/third_party/geospatial-grpc/proto/honua/v1/feature_service.proto
+++ b/third_party/geospatial-grpc/proto/honua/v1/feature_service.proto
@@ -1,5 +1,5 @@
 // Copyright (c) Honua. All rights reserved.
-// Licensed under the Elastic License 2.0. See LICENSE in the project root.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 syntax = "proto3";
 


### PR DESCRIPTION
Round-2 release-audit fix for a licensing finding (S2).

`third_party/geospatial-grpc/proto/honua/v1/feature_service.proto:2`

The vendored proto header read:
```
// Licensed under the Elastic License 2.0. See LICENSE in the project root.
```
This contradicts the entire repository: the root `LICENSE` is Apache-2.0, every `src/` file is Apache-2.0, and all 15 csproj declare `<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>`. It was the only Elastic-License reference anywhere in the tree, and the "See LICENSE in the project root" pointer was factually wrong.

Verified the upstream `geospatial-grpc` proto this snapshot mirrors is itself Apache-2.0 (`geospatial/v1/feature_service.proto` header), confirming the Elastic line was a stale copy-paste rather than a genuine license. Corrected the header to Apache-2.0 to match the actual license; the Honua copyright line is kept consistent with the rest of the repo.

Note: the canonical source of truth lives in the upstream `geospatial-grpc` repo. This PR fixes only the in-repo vendored snapshot; no upstream change is required since upstream already declares Apache-2.0.