### PR TITLE
fix(catalogs): keep following next-links across empty intermediate pages

### DIFF
--- a/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClient.cs
+++ b/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClient.cs
@@ -143,13 +143,19 @@ public sealed class HonuaOgcRecordsClient : IHonuaOgcRecordsClient
             page = JsonSerializer.Deserialize(body, OgcRecordsJsonContext.Default.OgcRecordCollection)
                 ?? throw new HonuaOgcRecordsException(HttpStatusCode.OK, "Failed to deserialize paged Records response.", body);
 
-            if (page.Records is null or { Count: 0 })
-            {
-                yield break;
-            }
-
-            yield return page;
             pageCount++;
+
+            // Do NOT terminate just because this page returned zero records: an OGC API
+            // Records server may emit an empty intermediate page that still advertises a
+            // rel=next link, and stopping here would silently drop the remaining records.
+            // Continuation is governed solely by the next link (its absence ends paging at the
+            // top of the loop), the visited-href set, and the MaxAutoPages guard. This matches
+            // the OGC Features client, which evaluates the continuation signal before its
+            // empty-page check.
+            if (page.Records is not (null or { Count: 0 }))
+            {
+                yield return page;
+            }
         }
 
         throw new InvalidOperationException(

--- a/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
@@ -185,13 +185,19 @@ public sealed class HonuaStacClient : IHonuaStacClient
             var body = await GetNextPageStringAsync(nextLink, cancellationToken).ConfigureAwait(false);
             page = DeserializeItemCollection(body, "Failed to deserialize paged STAC items response.");
 
-            if (page.Features is null or { Count: 0 })
-            {
-                yield break;
-            }
-
-            yield return page;
             pageCount++;
+
+            // Do NOT terminate just because this page returned zero features: a STAC API
+            // server may emit an empty intermediate page that still advertises a rel=next
+            // link, and stopping here would silently drop the remaining items. Continuation
+            // is governed solely by the next link (its absence ends paging at the top of the
+            // loop), the visited-href set, and the MaxAutoPages guard. This matches the OGC
+            // Features client, which evaluates the continuation signal before its empty-page
+            // check.
+            if (page.Features is not (null or { Count: 0 }))
+            {
+                yield return page;
+            }
         }
 
         throw new InvalidOperationException(
@@ -225,13 +231,19 @@ public sealed class HonuaStacClient : IHonuaStacClient
             var body = await GetNextPageStringAsync(nextLink, cancellationToken).ConfigureAwait(false);
             page = DeserializeItemCollection(body, "Failed to deserialize paged STAC search response.");
 
-            if (page.Features is null or { Count: 0 })
-            {
-                yield break;
-            }
-
-            yield return page;
             pageCount++;
+
+            // Do NOT terminate just because this page returned zero features: a STAC API
+            // server may emit an empty intermediate page that still advertises a rel=next
+            // link, and stopping here would silently drop the remaining items. Continuation
+            // is governed solely by the next link (its absence ends paging at the top of the
+            // loop), the visited-href set, and the MaxAutoPages guard. This matches the OGC
+            // Features client, which evaluates the continuation signal before its empty-page
+            // check.
+            if (page.Features is not (null or { Count: 0 }))
+            {
+                yield return page;
+            }
         }
 
         throw new InvalidOperationException(
@@ -271,13 +283,19 @@ public sealed class HonuaStacClient : IHonuaStacClient
             var body = await FollowNextLinkAsync(nextLink, requestBody, cancellationToken).ConfigureAwait(false);
             page = DeserializeItemCollection(body, "Failed to deserialize paged STAC search response.");
 
-            if (page.Features is null or { Count: 0 })
-            {
-                yield break;
-            }
-
-            yield return page;
             pageCount++;
+
+            // Do NOT terminate just because this page returned zero features: a STAC API
+            // server may emit an empty intermediate page that still advertises a rel=next
+            // link, and stopping here would silently drop the remaining items. Continuation
+            // is governed solely by the next link (its absence ends paging at the top of the
+            // loop), the visited-href set, and the MaxAutoPages guard. This matches the OGC
+            // Features client, which evaluates the continuation signal before its empty-page
+            // check.
+            if (page.Features is not (null or { Count: 0 }))
+            {
+                yield return page;
+            }
         }
 
         throw new InvalidOperationException(

--- a/tests/Honua.Sdk.Catalogs.RecordsTests/HonuaOgcRecordsClientTests.cs
+++ b/tests/Honua.Sdk.Catalogs.RecordsTests/HonuaOgcRecordsClientTests.cs
@@ -270,6 +270,60 @@ public sealed class HonuaOgcRecordsClientTests
     }
 
     [Fact]
+    public async Task GetRecordsPagesAsync_EmptyIntermediatePageWithNextLink_KeepsFollowing()
+    {
+        // An OGC API Records server can legitimately emit an empty intermediate items page that
+        // still advertises a rel=next link to a populated page. The pager must follow the empty
+        // page's own next link rather than terminating, otherwise the remaining records are
+        // silently dropped.
+        var calls = 0;
+        var client = TestHelpers.CreateOgcRecordsClient(req =>
+        {
+            calls++;
+            var json = calls switch
+            {
+                1 => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [{ "type": "Feature", "id": "first", "properties": { "title": "First" } }],
+                         "links": [
+                             { "href": "https://honua.example.test/ogc/records/collections/default/items?offset=1&f=json", "rel": "next" }
+                         ]
+                     }
+                     """,
+                2 => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [],
+                         "links": [
+                             { "href": "https://honua.example.test/ogc/records/collections/default/items?offset=2&f=json", "rel": "next" }
+                         ]
+                     }
+                     """,
+                _ => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [{ "type": "Feature", "id": "third", "properties": { "title": "Third" } }]
+                     }
+                     """
+            };
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<OgcRecordCollection>();
+        await foreach (var page in client.GetRecordsPagesAsync("default", new OgcRecordsQuery { Limit = 1 }))
+        {
+            pages.Add(page);
+        }
+
+        // The empty page is not yielded, but its next link is followed to the populated page.
+        Assert.Equal(2, pages.Count);
+        Assert.Equal("first", pages[0].Records?[0].Id?.GetString());
+        Assert.Equal("third", pages[1].Records?[0].Id?.GetString());
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
     public async Task GetRecordsPagesAsync_RejectsCrossOriginNextLink()
     {
         var json = """

--- a/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
+++ b/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
@@ -402,6 +402,60 @@ public sealed class HonuaStacClientTests
     }
 
     [Fact]
+    public async Task GetItemsPagesAsync_EmptyIntermediatePageWithNextLink_KeepsFollowing()
+    {
+        // A STAC API can legitimately emit an empty intermediate page that still advertises a
+        // rel=next link to a populated page (sparse/filtered result sets). The pager must follow
+        // the empty page's own next link rather than terminating, otherwise the remaining items
+        // are silently dropped.
+        var calls = 0;
+        var client = TestHelpers.CreateStacClient(req =>
+        {
+            calls++;
+            var json = calls switch
+            {
+                1 => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [{ "type": "Feature", "id": "scene-001", "properties": {} }],
+                         "links": [
+                             { "href": "https://honua.example.test/stac/collections/imagery/items?offset=1&limit=1", "rel": "next" }
+                         ]
+                     }
+                     """,
+                2 => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [],
+                         "links": [
+                             { "href": "https://honua.example.test/stac/collections/imagery/items?offset=2&limit=1", "rel": "next" }
+                         ]
+                     }
+                     """,
+                _ => """
+                     {
+                         "type": "FeatureCollection",
+                         "features": [{ "type": "Feature", "id": "scene-003", "properties": {} }]
+                     }
+                     """
+            };
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        var pages = new List<StacItemCollection>();
+        await foreach (var page in client.GetItemsPagesAsync("imagery", new StacItemsQuery { Limit = 1 }))
+        {
+            pages.Add(page);
+        }
+
+        // The empty page is not yielded, but its next link is followed to the populated page.
+        Assert.Equal(2, pages.Count);
+        Assert.Equal("scene-001", pages[0].Features?[0].Id);
+        Assert.Equal("scene-003", pages[1].Features?[0].Id);
+        Assert.Equal(3, calls);
+    }
+
+    [Fact]
     public async Task SearchPagesAsync_PostThenFollowsNextLinkWithGet()
     {
         var calls = 0;


### PR DESCRIPTION
## Problem

Round-3 audit findings (S2, protocol-compliance):

- `src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs:188` — `GetItemsPagesAsync`, `SearchPagesAsync`, and `PostSearchPagesAsync` terminate auto-pagination with `yield break` the moment a fetched page returns zero features, **before** that page's own `rel=next` link is consulted.
- `src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsClient.cs:146` — `GetRecordsPagesAsync` has the same pattern for zero records.

STAC API and OGC API Records servers can legitimately emit an empty *intermediate* page that still advertises a continuation link over sparse or filtered result sets. The old behavior silently dropped every remaining item past the first empty page — data loss.

## Fix

Mirror the OGC Features client (`HonuaOgcFeaturesClient.GetItemsPagesAsync`, which already documents this exact case): govern continuation solely by the presence of a `rel=next` link, plus the existing visited-href and `MaxAutoPages` guards. On an empty page, skip the `yield return` but continue the loop so the empty page's own next-link is followed.

Applied identically to all three STAC pagers and the OGC Records pager.

## Tests

- `GetItemsPagesAsync_EmptyIntermediatePageWithNextLink_KeepsFollowing` (STAC)
- `GetRecordsPagesAsync_EmptyIntermediatePageWithNextLink_KeepsFollowing` (Records)

Each serves a populated page → an empty page that carries a next-link → a populated page, and asserts the trailing items are still returned.

## Verification

- `dotnet build src/Honua.Sdk.Catalogs/Honua.Sdk.Catalogs.csproj -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- STAC tests: 51 passed; Records tests: 46 passed

Findings referenced by file:line; no GitHub issue numbers exist for these.