### PR TITLE
fix(ogcfeatures): map vector extension fallback failures to HonuaException

### DIFF
--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesClient.cs
@@ -479,7 +479,11 @@ public sealed class HonuaOgcFeaturesClient :
         return new StringContent(json, Encoding.UTF8, "application/merge-patch+json");
     }
 
-    private static void EnsureSuccess(HttpResponseMessage response, string body)
+    // Internal so package extension methods (e.g. OgcFeaturesVectorClientExtensions) can map a
+    // failed response through the same RFC 7807 Problem Details path and throw the package's
+    // HonuaOgcFeaturesException, rather than a generic HttpRequestException that escapes
+    // catch(HonuaException).
+    internal static void EnsureSuccess(HttpResponseMessage response, string body)
     {
         if (response.IsSuccessStatusCode)
         {

--- a/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorClientExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorClientExtensions.cs
@@ -42,7 +42,15 @@ public static class OgcFeaturesVectorClientExtensions
             (query ?? new OgcItemsParams()) with { Format = protocolFormat },
             cancellationToken).ConfigureAwait(false);
 
-        response.EnsureSuccessStatusCode();
+        // Route failures through the package error mapper so a non-Honua client surfaces the same
+        // HonuaOgcFeaturesException (with RFC 7807 Problem Details) as the concrete client, instead
+        // of a generic HttpRequestException that would escape a catch(HonuaException) handler.
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            HonuaOgcFeaturesClient.EnsureSuccess(response, errorBody);
+        }
+
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, cancellationToken: cancellationToken).ConfigureAwait(false);
     }

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
@@ -102,7 +102,7 @@ public sealed class OgcFeaturesVectorPayloadTests
               "status": 404
             }
             """;
-        var client = new FakeOgcFeaturesClient(new HttpResponseMessage(HttpStatusCode.NotFound)
+        using var client = new FakeOgcFeaturesClient(new HttpResponseMessage(HttpStatusCode.NotFound)
         {
             Content = new StringContent(problem, System.Text.Encoding.UTF8, "application/problem+json")
         });
@@ -120,8 +120,10 @@ public sealed class OgcFeaturesVectorPayloadTests
     /// Minimal non-<see cref="HonuaOgcFeaturesClient"/> implementation that exercises the
     /// extension method's fallback branch. Only <see cref="GetItemsRawAsync"/> is meaningful.
     /// </summary>
-    private sealed class FakeOgcFeaturesClient(HttpResponseMessage rawResponse) : IHonuaOgcFeaturesClient
+    private sealed class FakeOgcFeaturesClient(HttpResponseMessage rawResponse) : IHonuaOgcFeaturesClient, IDisposable
     {
+        public void Dispose() => rawResponse.Dispose();
+
         public Task<HttpResponseMessage> GetItemsRawAsync(
             string collectionId, OgcItemsParams? query = null, CancellationToken cancellationToken = default)
             => Task.FromResult(rawResponse);

--- a/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/OgcFeatures/OgcFeaturesVectorPayloadTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Honua.Sdk.Geometry.Vector;
+using Honua.Sdk.OgcFeatures.Exceptions;
 using Honua.Sdk.OgcFeatures.Models;
 using Honua.Sdk.OgcFeatures.Tests.Fixtures;
 using NetTopologySuite.Geometries;
@@ -85,5 +86,68 @@ public sealed class OgcFeaturesVectorPayloadTests
         Assert.Equal("parks.2", feature.Id);
         Assert.Equal("Magic Island", feature.Attributes["name"].GetString());
         Assert.Equal(4326, Assert.IsType<Point>(feature.Geometry).SRID);
+    }
+
+    [Fact]
+    public async Task GetItemsVectorAsync_NonHonuaClientFailure_ThrowsHonuaException()
+    {
+        // A non-Honua IHonuaOgcFeaturesClient takes the extension's fallback branch. A failed
+        // response must surface as a HonuaOgcFeaturesException (mapped from RFC 7807 Problem
+        // Details) so callers can catch(HonuaException) uniformly — not a raw HttpRequestException.
+        const string problem = """
+            {
+              "type": "https://honua.io/errors/not-found",
+              "title": "Collection not found",
+              "detail": "No collection named 'parks'.",
+              "status": 404
+            }
+            """;
+        var client = new FakeOgcFeaturesClient(new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(problem, System.Text.Encoding.UTF8, "application/problem+json")
+        });
+
+        var ex = await Assert.ThrowsAsync<HonuaOgcFeaturesException>(
+            () => client.GetItemsVectorAsync("parks"));
+
+        // Catchable as the shared base type, with Problem Details preserved.
+        Assert.IsAssignableFrom<Honua.Sdk.Abstractions.HonuaException>(ex);
+        Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
+        Assert.Equal("No collection named 'parks'.", ex.ProblemDetail);
+    }
+
+    /// <summary>
+    /// Minimal non-<see cref="HonuaOgcFeaturesClient"/> implementation that exercises the
+    /// extension method's fallback branch. Only <see cref="GetItemsRawAsync"/> is meaningful.
+    /// </summary>
+    private sealed class FakeOgcFeaturesClient(HttpResponseMessage rawResponse) : IHonuaOgcFeaturesClient
+    {
+        public Task<HttpResponseMessage> GetItemsRawAsync(
+            string collectionId, OgcItemsParams? query = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(rawResponse);
+
+        public Task<OgcLandingPage> GetLandingPageAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<OgcConformance> GetConformanceAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<OgcCollection>> ListCollectionsAsync(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<OgcCollection> GetCollectionAsync(string collectionId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<OgcQueryables> GetQueryablesAsync(string collectionId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<OgcFeatureCollection> GetItemsAsync(string collectionId, OgcItemsParams? query = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<OgcFeature> GetItemAsync(string collectionId, string featureId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<OgcFeatureCollection> GetItemsPagesAsync(string collectionId, OgcItemsParams? query = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Problem

Round-3 audit finding (S2, coherence) — `src/Honua.Sdk.OgcFeatures/OgcFeaturesVectorClientExtensions.cs:45`.

`GetItemsVectorAsync` has two branches:
- concrete `HonuaOgcFeaturesClient` → throws `HonuaOgcFeaturesException` (derives from `HonuaException`)
- any other `IHonuaOgcFeaturesClient` → fallback calls `response.EnsureSuccessStatusCode()`, which throws a plain `HttpRequestException`.

A caller using `catch (HonuaException)` (or `catch (HonuaOgcFeaturesException)`) handles failures from the concrete client but silently misses failures from the fallback path — inconsistent exception contract.

## Fix

Route the fallback through the package error mapper. The existing RFC 7807 Problem Details mapping (`HonuaOgcFeaturesClient.EnsureSuccess`) is promoted from `private` to `internal` and called on a failed response, so both branches surface the same `HonuaOgcFeaturesException` with `StatusCode` and Problem Details populated.

## Tests

`GetItemsVectorAsync_NonHonuaClientFailure_ThrowsHonuaException` — a minimal non-Honua `IHonuaOgcFeaturesClient` returns a `problem+json` 404; the test asserts a `HonuaOgcFeaturesException` (assignable to `HonuaException`) with the mapped `StatusCode` and `ProblemDetail`.

## Verification

- `dotnet build src/Honua.Sdk.OgcFeatures -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- `Honua.Sdk.OgcFeatures.Tests` — 116 passed

Finding referenced by file:line; no GitHub issue number exists.