### PR TITLE
fix(example): drain pending sync ops into a snapshot to honor retry backoff

### DIFF
--- a/examples/FieldDataCollection/Services/OfflineSyncManager.cs
+++ b/examples/FieldDataCollection/Services/OfflineSyncManager.cs
@@ -298,7 +298,19 @@ public class OfflineSyncManager : IOfflineSyncManager, IDisposable
     {
         var processedOps = 0;
 
-        while (_pendingOperations.TryDequeue(out var operation))
+        // Snapshot the operations queued at the start of this pass before processing any of them.
+        // Draining the queue inline and re-enqueuing failures back into the same loop would cause a
+        // just-failed operation to be dequeued and retried immediately within this same sync pass —
+        // burning through MaxRetries back-to-back with no delay and flooding result.Errors. By taking
+        // a fixed snapshot, a re-queued operation waits for the next ProcessPendingOperationsAsync
+        // invocation (i.e. the next sync interval) before it is retried, honoring the intended backoff.
+        var batch = new List<SyncOperation>();
+        while (_pendingOperations.TryDequeue(out var queued))
+        {
+            batch.Add(queued);
+        }
+
+        foreach (var operation in batch)
         {
             try
             {
@@ -311,7 +323,8 @@ public class OfflineSyncManager : IOfflineSyncManager, IDisposable
                 _logger.LogWarning(ex, "Failed to process operation {OperationId}", operation.Id);
                 result.Errors.Add($"Operation {operation.Id} failed: {ex.Message}");
 
-                // Re-queue operation for retry if within retry limit
+                // Re-queue operation for retry if within retry limit. Because it is enqueued onto the
+                // shared queue (not this pass's snapshot), it is not retried again until the next sync.
                 if (operation.RetryCount < _options.MaxRetries)
                 {
                     operation.RetryCount++;


### PR DESCRIPTION
## Problem

Round-3 audit finding (S2, correctness) — `examples/FieldDataCollection/Services/OfflineSyncManager.cs:301`.

`ProcessPendingOperationsAsync` runs `while (_pendingOperations.TryDequeue(out var operation))`. On a retryable failure the operation is re-enqueued (`_pendingOperations.Enqueue(operation)`) **inside the same loop**. Since the loop keeps dequeuing until the queue is empty, the just-re-enqueued op is dequeued and retried again immediately in the same sync pass — burning through `MaxRetries` back-to-back with zero delay and flooding `result.Errors`. `operation.LastRetryAt` is set but never consulted before re-processing, so the intended backoff is not applied.

## Fix

Snapshot the operations queued at the start of the pass into a local `List<SyncOperation>` before processing any of them, then iterate the snapshot. A re-queued operation now lands on the shared queue and is not retried until the next `ProcessPendingOperationsAsync` invocation (next sync interval), honoring the intended backoff. Retry-count bookkeeping and persistence are unchanged.

## Verification

- `dotnet build examples/FieldDataCollection -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors

This is example code with no dedicated test project; verification is via the strict build. Finding referenced by file:line; no GitHub issue number exists.