### PR TITLE
fix(sdk): close pagination open-redirect bypass and tighten error-model fidelity

### DIFF
--- a/src/Honua.Sdk.Abstractions/Http/NextLinkOriginValidator.cs
+++ b/src/Honua.Sdk.Abstractions/Http/NextLinkOriginValidator.cs
@@ -12,38 +12,52 @@ namespace Honua.Sdk.Abstractions.Http;
 public static class NextLinkOriginValidator
 {
     /// <summary>
-    /// Determines whether a <c>next</c> link is safe to follow: relative links (which resolve
-    /// against the same base) are always safe, and absolute links must share the base address'
-    /// scheme and authority.
+    /// Determines whether a <c>next</c> link is safe to follow: path-relative links (which resolve
+    /// against the same authority) are always safe, and any link that resolves to a different
+    /// scheme or authority than the base address is rejected.
     /// </summary>
     /// <param name="nextLink">The server-supplied next-page link.</param>
     /// <param name="baseAddress">The client's configured base address, or <see langword="null"/>.</param>
     /// <returns><see langword="true"/> when the link is same-origin (or cannot be cross-origin).</returns>
     public static bool IsSameOrigin(string? nextLink, Uri? baseAddress)
     {
-        if (string.IsNullOrEmpty(nextLink) || !Uri.TryCreate(nextLink, UriKind.Absolute, out var nextUri))
-        {
-            // Relative URLs are safe — they resolve against the same base.
-            return true;
-        }
-
-        // A next link can only point cross-origin when it carries its own HTTP(S) authority.
-        // On Unix a path-absolute reference such as "/collections/items" parses as an absolute
-        // file: URI (a leading slash is a rooted filesystem path), so restrict the cross-origin
-        // check to http/https links and treat any other scheme as same-origin/relative.
-        if (!string.Equals(nextUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(nextUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(nextLink))
         {
             return true;
         }
 
+        // Network-path (protocol-relative) references such as "//evil.example/steal" do NOT parse
+        // as UriKind.Absolute, yet per RFC 3986 they resolve against the base by inheriting only
+        // the scheme and REPLACING the authority — i.e. they are cross-origin-capable. Resolving
+        // the link against the base address (the same resolution HttpClient performs) is the only
+        // reliable way to classify it; a bare scheme/authority string-compare on the raw link
+        // misclassifies "//host" as relative and a path-absolute "/items" as a Unix file: URI.
         if (baseAddress is null)
         {
+            // Without a base we cannot compare origins; only a self-describing absolute HTTP(S)
+            // authority could be cross-origin, and there is nothing to compare it against.
             return true;
         }
 
-        return string.Equals(nextUri.Scheme, baseAddress.Scheme, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(nextUri.Authority, baseAddress.Authority, StringComparison.OrdinalIgnoreCase);
+        if (!Uri.TryCreate(nextLink, UriKind.RelativeOrAbsolute, out var candidate)
+            || !Uri.TryCreate(baseAddress, candidate, out var resolved))
+        {
+            // Unparseable links are conservatively rejected so paging stops rather than
+            // following an ambiguous reference.
+            return false;
+        }
+
+        // Only HTTP(S) origins are meaningful for this guard; a resolved non-HTTP(S) scheme
+        // (e.g. a path-relative reference resolved against an http base stays http) cannot widen
+        // the authority. If resolution somehow produced a non-HTTP(S) scheme, treat it as unsafe.
+        if (!string.Equals(resolved.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(resolved.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return string.Equals(resolved.Scheme, baseAddress.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(resolved.Authority, baseAddress.Authority, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/Honua.Sdk.Spec/HonuaSpecException.cs
+++ b/src/Honua.Sdk.Spec/HonuaSpecException.cs
@@ -56,11 +56,20 @@ public sealed class HonuaSpecException : Honua.Sdk.Abstractions.HonuaException
 
     /// <inheritdoc />
     public override Honua.Sdk.Abstractions.HonuaProblemDetails? ProblemDetails =>
-        new Honua.Sdk.Abstractions.HonuaProblemDetails
-        {
-            Status = (int)StatusCode,
-            Detail = Message,
-        };
+        Problem is { } problem
+            ? new Honua.Sdk.Abstractions.HonuaProblemDetails
+            {
+                Type = problem.Type,
+                Title = problem.Title,
+                Status = problem.Status,
+                Detail = problem.Detail,
+                Instance = problem.NodeId,
+            }
+            : new Honua.Sdk.Abstractions.HonuaProblemDetails
+            {
+                Status = (int)StatusCode,
+                Detail = Message,
+            };
 
     /// <summary>Raw response body when available.</summary>
     public string? ResponseBody { get; }

--- a/tests/Honua.Sdk.Abstractions.Tests/NextLinkOriginValidatorTests.cs
+++ b/tests/Honua.Sdk.Abstractions.Tests/NextLinkOriginValidatorTests.cs
@@ -39,9 +39,19 @@ public sealed class NextLinkOriginValidatorTests
     [InlineData("https://evil.example/steal")]            // different host
     [InlineData("http://api.honua.example/items")]        // different scheme
     [InlineData("https://api.honua.example:8443/items")]  // different port
+    [InlineData("//evil.example/steal")]                  // protocol-relative cross-origin
+    [InlineData("//evil.example:9000/steal")]             // protocol-relative cross-origin with port
     public void IsSameOrigin_CrossOriginLink_IsRejected(string link)
     {
         Assert.False(NextLinkOriginValidator.IsSameOrigin(link, Base));
+    }
+
+    [Theory]
+    [InlineData("//api.honua.example/items?page=2")]      // protocol-relative same authority
+    [InlineData("collections/x/items?page=2")]            // path-relative (no leading slash)
+    public void IsSameOrigin_SameAuthorityRelativeLink_IsAllowed(string link)
+    {
+        Assert.True(NextLinkOriginValidator.IsSameOrigin(link, Base));
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Conformance.Tests/LiveConformanceTests.cs
+++ b/tests/Honua.Sdk.Conformance.Tests/LiveConformanceTests.cs
@@ -95,7 +95,16 @@ public sealed class LiveConformanceTests(LiveConformanceFixture fixture)
         var features = await _fixture.WfsClient.GetFeaturesAsync(
             new GetFeaturesRequest { TypeNames = typeName, Count = 1 },
             timeout.Token).ConfigureAwait(false);
-        Assert.InRange(features.Features.Count, 0, 1);
+
+        // The conformance contract is the FeatureCollection shape surviving the WFS GeoJSON
+        // wire + SDK conversion round-trip. An empty result must fail the drift gate (a
+        // no-features regression would otherwise pass silently), so require exactly one
+        // feature and assert its content survived — mirroring the gRPC and OGC cases above.
+        var feature = Assert.Single(features.Features);
+        Assert.NotNull(feature.Geometry);
+        Assert.False(string.IsNullOrWhiteSpace(feature.Geometry!.Type),
+            "WFS feature geometry dropped its GeoJSON type.");
+        Assert.NotEmpty(feature.Properties);
     }
 
     // honua-server#1238: a server-side JSONB attribute-projection change alters

--- a/tests/Honua.Sdk.Spec.Tests/HonuaSpecExceptionTests.cs
+++ b/tests/Honua.Sdk.Spec.Tests/HonuaSpecExceptionTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Honua.Sdk.Abstractions;
+using Honua.Sdk.Spec.Models;
 
 namespace Honua.Sdk.Spec.Tests;
 
@@ -39,5 +40,39 @@ public sealed class HonuaSpecExceptionTests
         Assert.Equal("raw", ex.ResponseBody);
         Assert.Null(ex.Problem);
         Assert.Equal("missing", ex.Message);
+    }
+
+    [Fact]
+    public void ProblemDetails_WithoutProblem_FallsBackToStatusAndMessage()
+    {
+        var ex = new HonuaSpecException(HttpStatusCode.BadGateway, "upstream down", "raw");
+
+        var problem = ex.ProblemDetails;
+        Assert.NotNull(problem);
+        Assert.Equal((int)HttpStatusCode.BadGateway, problem!.Status);
+        Assert.Equal("upstream down", problem.Detail);
+    }
+
+    [Fact]
+    public void ProblemDetails_WithProblem_SurfacesStructuredFields()
+    {
+        var specProblem = new SpecProblem
+        {
+            Type = "https://honua.io/problems/spec-invalid",
+            Title = "Spec invalid",
+            Status = (int)HttpStatusCode.UnprocessableEntity,
+            Detail = "node 'foo' is malformed",
+            Code = "SPEC_INVALID",
+            NodeId = "foo",
+        };
+        var ex = new HonuaSpecException(HttpStatusCode.UnprocessableEntity, "Spec invalid", "raw", specProblem);
+
+        var problem = ex.ProblemDetails;
+        Assert.NotNull(problem);
+        Assert.Equal("https://honua.io/problems/spec-invalid", problem!.Type);
+        Assert.Equal("Spec invalid", problem.Title);
+        Assert.Equal((int)HttpStatusCode.UnprocessableEntity, problem.Status);
+        Assert.Equal("node 'foo' is malformed", problem.Detail);
+        Assert.Equal("foo", problem.Instance);
     }
 }


### PR DESCRIPTION
## Summary

Round-4 release-audit fix wave. Addresses three confirmed S2 findings spanning the SDK's security, error-model, and conformance-test-integrity surfaces. No public API signatures change; full `Release` build (`/p:TreatWarningsAsErrors=true`, analyzers `AllEnabledByDefault`) is clean.

## Findings addressed

### 1. Protocol-relative next-link bypasses the open-redirect guard (security)
`src/Honua.Sdk.Abstractions/Http/NextLinkOriginValidator.cs:24`

A network-path (protocol-relative) `next` link such as `//evil.example/steal` does not parse as `UriKind.Absolute`, so the prior http/https scheme gate classified it as same-origin/relative and allowed it. Per RFC 3986 such a reference resolves against the base by inheriting only the scheme and **replacing** the authority, so the paging clients (STAC / OGC API Features / OGC Records, all sharing this single guard) would follow it cross-origin via `HttpClient` and leak the `Authorization` header attached by the auth handler — the exact threat the class exists to prevent.

Fix per recommendation: `IsSameOrigin` now resolves the candidate against `baseAddress` (the same base-relative resolution `HttpClient` performs) and compares resolved scheme + authority, conservatively rejecting unparseable links and non-HTTP(S) resolved schemes. Path-relative links (`/items`, `items?page=2`) still resolve same-authority and remain allowed. Added `InlineData("//evil.example/steal")` (+ port variant) regression cases and same-authority protocol-relative/path-relative allow cases.

### 2. `HonuaSpecException.ProblemDetails` discards the structured `SpecProblem` (error-model / data loss)
`src/Honua.Sdk.Spec/HonuaSpecException.cs:58`

The override emitted only `{ Status, Detail }` and never consulted the parsed `Problem` it already holds, dropping the server-supplied `type`/`title`/`instance` from the normalized RFC 7807 surface — the opposite of the Admin client. Fix maps `Problem` → `HonuaProblemDetails` when present (`Type`, `Title`, `Status`, `Detail`, `Instance` ← `NodeId`), falling back to the `Status`+`Message` stub only when `Problem` is null. Added unit tests for both branches.

### 3. WFS conformance round-trip accepts an empty result (test integrity)
`tests/Honua.Sdk.Conformance.Tests/LiveConformanceTests.cs:98`

`Wfs_GetFeatures_RoundTripsCanonicalFeatureCollection` asserted only `Assert.InRange(count, 0, 1)`, so a no-features regression passed silently — this is a required (non-`knownGap`) drift gate. Now requires `Assert.Single` and asserts the feature's geometry type and properties survived the round-trip, matching the gRPC (L55) and OGC (L154) cases.

## Testing
- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true` → succeeded, 0 warnings.
- `Honua.Sdk.Abstractions.Tests` `NextLinkOriginValidator*` → 13 passed.
- `Honua.Sdk.Spec.Tests` `HonuaSpecExceptionTests` → 6 passed (incl. 2 new).
- Conformance test is `[LiveConformanceFact]` (server-gated); compiles in the solution build.

## Not addressed (out of scope for this coarse PR)
- **Uniform error-model base refactor** (S2, `HonuaException.cs:27`): introducing an intermediate `HonuaApiException` base and re-parenting ~10 exception types is a public-API-shaped refactor (apicompat-gated) better done as its own change. The Spec data-loss slice here is the safe in-repo portion.
- **DRY HTTP-client/resilience pipeline extraction** (S2, `ServiceCollectionExtensions.cs`): factoring the ~50-line typed-client + no-redirect + resilience block out of ~15 call sites into a shared Abstractions helper is a large cross-package refactor; deferred to avoid coupling it with the security fix.
