### PR TITLE
feat(admin,geoservices): raster import client + vector error-envelope guard; backlog sweep

### DIFF
--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaAdminFeatureEventsClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
         services.AddTransient<IHonuaAdminStreamingOperationsClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
         services.AddTransient<IHonuaAdminDeployClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
+        services.AddTransient<IHonuaAdminRasterImportClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
 
         ApplyHandlerAndResilience(httpBuilder, snapshot);
         return services;

--- a/src/Honua.Sdk.Admin/HonuaAdminClient.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Json;
@@ -815,6 +816,86 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseLicenseStatusResponse);
         return envelope?.Data ?? throw new HonuaAdminOperationException("Server returned null license status.", "UploadLicense");
+    }
+
+    // ── Raster import (write/output) ──────────────────────────────────────
+
+    /// <inheritdoc />
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "MultipartFormDataContent owns and disposes child HttpContent instances.")]
+    public async Task<RasterImportResult> ImportRasterAsync(RasterImportRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(request.Content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.FileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.Name);
+
+        using var form = new MultipartFormDataContent();
+
+        // The caller retains ownership of the content stream; wrap it so disposing the multipart
+        // form (and its StreamContent child) does not dispose the caller's stream.
+        var rasterContent = new StreamContent(new Honua.Sdk.Abstractions.Http.NonDisposingStream(request.Content));
+        rasterContent.Headers.ContentType = new MediaTypeHeaderValue(
+            string.IsNullOrWhiteSpace(request.ContentType) ? "application/octet-stream" : request.ContentType);
+        form.Add(rasterContent, "file", request.FileName);
+
+        form.Add(new StringContent(request.LayerId.ToString(CultureInfo.InvariantCulture)), "layerId");
+        form.Add(new StringContent(request.Name), "name");
+
+        if (!string.IsNullOrWhiteSpace(request.Description))
+        {
+            form.Add(new StringContent(request.Description), "description");
+        }
+
+        if (request.Srid is { } srid)
+        {
+            form.Add(new StringContent(srid.ToString(CultureInfo.InvariantCulture)), "srid");
+        }
+
+        if (request.AcquisitionDate is { } acquisitionDate)
+        {
+            form.Add(new StringContent(acquisitionDate.ToString("O", CultureInfo.InvariantCulture)), "acquisitionDate");
+        }
+
+        if (request.TileZoomLevels is { Count: > 0 } zoomLevels)
+        {
+            form.Add(
+                new StringContent(string.Join(",", zoomLevels.Select(z => z.ToString(CultureInfo.InvariantCulture)))),
+                "tileZoomLevels");
+        }
+
+        // World-file and projection sidecars are uploaded as file parts; the server routes them by
+        // extension (.wld/.pgw/.jgw/.tfw for world files, .prj for projections).
+        var stem = Path.GetFileNameWithoutExtension(request.FileName);
+        if (!string.IsNullOrEmpty(request.WorldFileContent))
+        {
+            form.Add(new StringContent(request.WorldFileContent), "worldFile", $"{stem}.wld");
+        }
+
+        if (!string.IsNullOrEmpty(request.ProjectionContent))
+        {
+            form.Add(new StringContent(request.ProjectionContent), "projection", $"{stem}.prj");
+        }
+
+        using var response = await _http.PostAsync(
+            CreateRequestUri($"{ApiPrefix}/import/raster/"), form, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+
+        return JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.RasterImportResult)
+            ?? throw new HonuaAdminOperationException("Server returned null raster import result.", "ImportRaster");
+    }
+
+    /// <inheritdoc />
+    public async Task<RasterFormatsResponse> GetSupportedRasterFormatsAsync(CancellationToken cancellationToken = default)
+    {
+        var data = await GetRawAsync<RasterFormatsResponse>(
+            $"{ApiPrefix}/import/raster/formats",
+            HonuaAdminJsonContext.Default.RasterFormatsResponse,
+            cancellationToken).ConfigureAwait(false);
+        return data ?? throw new HonuaAdminOperationException("Server returned null raster formats response.", "GetSupportedRasterFormats");
     }
 
     // ── Observability ────────────────────────────────────────────────────

--- a/src/Honua.Sdk.Admin/HonuaAdminJsonContext.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminJsonContext.cs
@@ -128,6 +128,8 @@ namespace Honua.Sdk.Admin;
 [JsonSerializable(typeof(LicenseStatusResponse))]
 [JsonSerializable(typeof(LicenseEntitlement))]
 [JsonSerializable(typeof(LicenseEntitlement[]))]
+[JsonSerializable(typeof(RasterImportResult))]
+[JsonSerializable(typeof(RasterFormatsResponse))]
 [JsonSerializable(typeof(JsonElement))]
 internal sealed partial class HonuaAdminJsonContext : JsonSerializerContext
 {

--- a/src/Honua.Sdk.Admin/IHonuaAdminClient.cs
+++ b/src/Honua.Sdk.Admin/IHonuaAdminClient.cs
@@ -37,6 +37,7 @@ public interface IHonuaAdminClient :
     IHonuaAdminAlertsClient,
     IHonuaAdminFeatureEventsClient,
     IHonuaAdminStreamingOperationsClient,
-    IHonuaAdminDeployClient
+    IHonuaAdminDeployClient,
+    IHonuaAdminRasterImportClient
 {
 }

--- a/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminRasterImportClient.cs
+++ b/src/Honua.Sdk.Admin/Interfaces/IHonuaAdminRasterImportClient.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Admin.Models;
+
+namespace Honua.Sdk.Admin;
+
+/// <summary>
+/// Admin raster import (raster write/output) operations over
+/// <c>/api/v1/admin/import/raster</c>. This is the write half of the raster geoprocessing
+/// round-trip; the read half lives on the read-only <c>IHonuaRasterDataClient</c>.
+/// </summary>
+public interface IHonuaAdminRasterImportClient
+{
+    /// <summary>
+    /// Imports (uploads) a raster file into PostGIS via multipart upload
+    /// (<c>POST /api/v1/admin/import/raster</c>).
+    /// </summary>
+    /// <param name="request">The raster import request (content stream, target layer, sidecars, options).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The parsed raster import result.</returns>
+    Task<RasterImportResult> ImportRasterAsync(RasterImportRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the raster file formats supported by the server
+    /// (<c>GET /api/v1/admin/import/raster/formats</c>).
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The supported raster formats and descriptions.</returns>
+    Task<RasterFormatsResponse> GetSupportedRasterFormatsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Sdk.Admin/Models/RasterImport.cs
+++ b/src/Honua.Sdk.Admin/Models/RasterImport.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Admin.Models;
+
+/// <summary>
+/// Request to import (upload) a raster file into PostGIS via the admin raster import endpoint
+/// (<c>POST /api/v1/admin/import/raster</c>). The raster bytes are sent as a multipart file part;
+/// optional world-file and projection sidecars are sent as additional file parts.
+/// </summary>
+/// <remarks>
+/// This is the write/output half of the raster geoprocessing round-trip. The read half lives on the
+/// read-only <c>IHonuaRasterDataClient</c> (ImageServer-backed metadata, statistics, and windowed reads).
+/// </remarks>
+public sealed class RasterImportRequest
+{
+    /// <summary>
+    /// The raster content stream (GeoTIFF / PNG / JPEG bytes). The caller retains ownership of the
+    /// stream; the client reads but does not dispose it.
+    /// </summary>
+    public required Stream Content { get; init; }
+
+    /// <summary>
+    /// The raster file name including extension (for example <c>elevation.tif</c>). The server detects
+    /// the format from the extension (<c>.tif</c>, <c>.tiff</c>, <c>.png</c>, <c>.jpg</c>, <c>.jpeg</c>).
+    /// </summary>
+    public required string FileName { get; init; }
+
+    /// <summary>
+    /// The target layer identifier to associate the imported raster with.
+    /// </summary>
+    public required int LayerId { get; init; }
+
+    /// <summary>
+    /// A human-readable name for the imported raster.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional description of the imported raster.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Optional spatial reference (EPSG SRID). Required when the source raster lacks embedded
+    /// georeferencing and no projection sidecar is supplied.
+    /// </summary>
+    public int? Srid { get; init; }
+
+    /// <summary>
+    /// Optional acquisition timestamp for the raster.
+    /// </summary>
+    public DateTimeOffset? AcquisitionDate { get; init; }
+
+    /// <summary>
+    /// Optional world-file sidecar content (for PNG/JPEG sources that carry georeferencing in a
+    /// <c>.pgw</c>/<c>.jgw</c>/<c>.wld</c> sidecar rather than embedded in the raster).
+    /// </summary>
+    public string? WorldFileContent { get; init; }
+
+    /// <summary>
+    /// Optional projection (<c>.prj</c>) sidecar content describing the coordinate reference system.
+    /// </summary>
+    public string? ProjectionContent { get; init; }
+
+    /// <summary>
+    /// Optional tile pyramid zoom levels to generate (0-24). Defaults to the server's pyramid policy
+    /// when omitted.
+    /// </summary>
+    public IReadOnlyList<int>? TileZoomLevels { get; init; }
+
+    /// <summary>
+    /// Optional MIME content type for the raster part. Defaults to <c>application/octet-stream</c>.
+    /// </summary>
+    public string? ContentType { get; init; }
+}
+
+/// <summary>
+/// Result of an admin raster import operation.
+/// </summary>
+public sealed record RasterImportResult
+{
+    /// <summary>
+    /// Whether the import succeeded.
+    /// </summary>
+    public bool Success { get; init; }
+
+    /// <summary>
+    /// The identifier of the imported raster, when available.
+    /// </summary>
+    public long? RasterId { get; init; }
+
+    /// <summary>
+    /// The target layer identifier.
+    /// </summary>
+    public int LayerId { get; init; }
+
+    /// <summary>
+    /// The name of the imported raster.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// The detected source format (for example <c>GeoTiff</c>, <c>PngWorldFile</c>, <c>JpegWorldFile</c>).
+    /// </summary>
+    public string? Format { get; init; }
+
+    /// <summary>
+    /// The spatial reference (EPSG SRID) of the imported raster, when resolved.
+    /// </summary>
+    public int? Srid { get; init; }
+
+    /// <summary>
+    /// Raster width in pixels.
+    /// </summary>
+    public int Width { get; init; }
+
+    /// <summary>
+    /// Raster height in pixels.
+    /// </summary>
+    public int Height { get; init; }
+
+    /// <summary>
+    /// Number of bands in the imported raster.
+    /// </summary>
+    public int BandCount { get; init; }
+
+    /// <summary>
+    /// Number of bands for which statistics were computed.
+    /// </summary>
+    public int StatisticsBands { get; init; }
+
+    /// <summary>
+    /// Number of tiles generated during import.
+    /// </summary>
+    public int TilesGenerated { get; init; }
+
+    /// <summary>
+    /// Error message when <see cref="Success"/> is <c>false</c>.
+    /// </summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>
+    /// Non-fatal warnings emitted during import.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>
+    /// Total import duration.
+    /// </summary>
+    public TimeSpan Duration { get; init; }
+}
+
+/// <summary>
+/// Supported raster import formats and their human-readable descriptions.
+/// </summary>
+public sealed record RasterFormatsResponse
+{
+    /// <summary>
+    /// Supported file extensions (for example <c>.tif</c>, <c>.png</c>, <c>.jpg</c>).
+    /// </summary>
+    public IReadOnlyList<string> SupportedExtensions { get; init; } = [];
+
+    /// <summary>
+    /// Format descriptions keyed by file extension.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> FormatDescriptions { get; init; }
+        = new Dictionary<string, string>();
+}

--- a/src/Honua.Sdk.Admin/README.md
+++ b/src/Honua.Sdk.Admin/README.md
@@ -109,6 +109,29 @@ var candidates = await geocoder.ForwardGeocodeAsync(
     cancellationToken);
 ```
 
+### Raster import (write/output)
+
+`IHonuaAdminRasterImportClient` (part of `IHonuaAdminClient`) uploads a raster into
+PostGIS via the admin import endpoint. This is the write half of the raster
+geoprocessing round-trip; the read half is the read-only `IHonuaRasterDataClient`
+(`ReadWindowAsync`) in `Honua.Sdk.GeoServices`.
+
+```csharp
+var admin = provider.GetRequiredService<IHonuaAdminClient>();
+
+await using var tiff = File.OpenRead("output.tif");
+var result = await admin.ImportRasterAsync(new RasterImportRequest
+{
+    Content = tiff,
+    FileName = "output.tif",
+    LayerId = 7,
+    Name = "GP result",
+    Srid = 4326,
+}, cancellationToken);
+
+var formats = await admin.GetSupportedRasterFormatsAsync(cancellationToken);
+```
+
 ## Server compatibility
 
 `IHonuaAdminClient.CheckCompatibilityAsync` reports whether the connected Honua

--- a/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorClientExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/FeatureServerVectorClientExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Text;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Honua.Sdk.Geometry.Vector;
 
@@ -46,8 +47,27 @@ public static class FeatureServerVectorClientExtensions
             query with { Format = protocolFormat },
             cancellationToken).ConfigureAwait(false);
 
-        response.EnsureSuccessStatusCode();
+        // GeoServices reports failures in-band as HTTP 200 with a JSON `{"error":{...}}` envelope
+        // even when a binary (PBF) format was requested. A non-success transport status, or a JSON
+        // content type on a binary request, signals the server fell back to an error envelope (or a
+        // GeoJSON body). Route those through the shared envelope-aware error check so the vector path
+        // surfaces a HonuaFeatureServerException with parity to the JSON query path, instead of
+        // handing an error body to the binary reader and throwing an unhelpful decode error.
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        if (!response.IsSuccessStatusCode || IsJsonMediaType(mediaType))
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            GeoServicesHttp.EnsureSuccess(response, body);
+
+            // Success + JSON with no error envelope: a genuine GeoJSON payload. Parse it from the body.
+            using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            return await VectorPayloadReaders.ReadAsync(jsonStream, vectorFormat, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         return await VectorPayloadReaders.ReadAsync(stream, vectorFormat, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
+
+    private static bool IsJsonMediaType(string? mediaType)
+        => mediaType is not null && mediaType.Contains("json", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Honua.Sdk.GeoServices/README.md
+++ b/src/Honua.Sdk.GeoServices/README.md
@@ -111,9 +111,26 @@ coverage statistics, and windowed reads. The Honua server does expose a raster
 but it lives on the privileged Admin surface and is not part of the raster-data
 read contract. A geoprocessing tool that produces a raster should write a GeoTIFF
 locally (for example from a `ReadWindowAsync` window or a computed result) and
-register it through that admin raster import endpoint. A typed SDK wrapper for the
-admin raster import endpoint on the Admin client surface is tracked as a
-follow-up.
+register it through that admin raster import endpoint.
+
+The write half is exposed by `Honua.Sdk.Admin` via `IHonuaAdminRasterImportClient`
+(included in `IHonuaAdminClient`), completing the raster geoprocessing round-trip:
+
+```csharp
+// Read half  (Honua.Sdk.GeoServices): IHonuaRasterDataClient.ReadWindowAsync(...)
+// Write half (Honua.Sdk.Admin):
+await using var tiff = File.OpenRead("output.tif");
+var result = await adminClient.ImportRasterAsync(new RasterImportRequest
+{
+    Content = tiff,
+    FileName = "output.tif",
+    LayerId = 7,
+    Name = "GP result",
+    Srid = 4326,
+});
+
+var formats = await adminClient.GetSupportedRasterFormatsAsync();
+```
 
 ## Documentation
 

--- a/tests/Honua.Sdk.Admin.Tests/RasterImportTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/RasterImportTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using Honua.Sdk.Admin.Exceptions;
+using Honua.Sdk.Admin.Extensions;
+using Honua.Sdk.Admin.Models;
+using Honua.Sdk.Admin.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.Admin.Tests;
+
+public sealed class RasterImportTests
+{
+    [Fact]
+    public async Task ImportRasterAsync_PostsMultipartToImportEndpoint()
+    {
+        string? capturedPath = null;
+        HttpMethod? capturedMethod = null;
+        string? capturedBody = null;
+
+        var client = TestHelpers.CreateClient(async req =>
+        {
+            capturedPath = req.RequestUri!.AbsolutePath;
+            capturedMethod = req.Method;
+            capturedBody = await req.Content!.ReadAsStringAsync();
+
+            return TestHelpers.CreateRawJsonResponse(new
+            {
+                success = true,
+                rasterId = 42L,
+                layerId = 7,
+                name = "elevation",
+                format = "GeoTiff",
+                srid = 4326,
+                width = 256,
+                height = 256,
+                bandCount = 1,
+                tilesGenerated = 9,
+                duration = "00:00:01.5",
+            });
+        });
+
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("fake-geotiff-bytes"));
+        var result = await client.ImportRasterAsync(
+            new RasterImportRequest
+            {
+                Content = content,
+                FileName = "elevation.tif",
+                LayerId = 7,
+                Name = "elevation",
+                Srid = 4326,
+                TileZoomLevels = [0, 1, 2],
+            });
+
+        Assert.Equal(HttpMethod.Post, capturedMethod);
+        Assert.Equal("/api/v1/admin/import/raster/", capturedPath);
+        Assert.NotNull(capturedBody);
+        Assert.Contains("name=file; filename=elevation.tif", capturedBody);
+        Assert.Contains("name=layerId", capturedBody);
+        Assert.Contains("name=name", capturedBody);
+        Assert.Contains("name=srid", capturedBody);
+        Assert.Contains("name=tileZoomLevels", capturedBody);
+        Assert.Contains("0,1,2", capturedBody);
+
+        Assert.True(result.Success);
+        Assert.Equal(42L, result.RasterId);
+        Assert.Equal(7, result.LayerId);
+        Assert.Equal("GeoTiff", result.Format);
+        Assert.Equal(TimeSpan.FromSeconds(1.5), result.Duration);
+    }
+
+    [Fact]
+    public async Task ImportRasterAsync_IncludesSidecarsAsFileParts()
+    {
+        string? capturedBody = null;
+        var client = TestHelpers.CreateClient(async req =>
+        {
+            capturedBody = await req.Content!.ReadAsStringAsync();
+            return TestHelpers.CreateRawJsonResponse(new { success = true, layerId = 3, name = "ortho", format = "PngWorldFile" });
+        });
+
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("fake-png-bytes"));
+        await client.ImportRasterAsync(
+            new RasterImportRequest
+            {
+                Content = content,
+                FileName = "ortho.png",
+                LayerId = 3,
+                Name = "ortho",
+                WorldFileContent = "1.0\n0.0\n0.0\n-1.0\n0.0\n0.0\n",
+                ProjectionContent = "GEOGCS[\"WGS 84\"]",
+            });
+
+        Assert.NotNull(capturedBody);
+        Assert.Contains("filename=ortho.wld", capturedBody);
+        Assert.Contains("filename=ortho.prj", capturedBody);
+    }
+
+    [Fact]
+    public async Task ImportRasterAsync_ErrorResponse_ThrowsApiException()
+    {
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateErrorResponse(HttpStatusCode.BadRequest, "Unsupported raster format: .bmp")));
+
+        using var content = new MemoryStream(Encoding.UTF8.GetBytes("nope"));
+        var exception = await Assert.ThrowsAsync<HonuaAdminApiException>(
+            () => client.ImportRasterAsync(
+                new RasterImportRequest
+                {
+                    Content = content,
+                    FileName = "image.bmp",
+                    LayerId = 1,
+                    Name = "image",
+                }));
+
+        Assert.Equal(HttpStatusCode.BadRequest, exception.StatusCode);
+        Assert.Contains("Unsupported raster format", exception.Message);
+    }
+
+    [Fact]
+    public async Task ImportRasterAsync_NullRequest_Throws()
+    {
+        var client = TestHelpers.CreateClient(_ =>
+            Task.FromResult(TestHelpers.CreateRawJsonResponse(new { success = true })));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => client.ImportRasterAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetSupportedRasterFormatsAsync_ParsesRawResponse()
+    {
+        var client = TestHelpers.CreateClient(req =>
+        {
+            Assert.Equal("/api/v1/admin/import/raster/formats", req.RequestUri!.AbsolutePath);
+            Assert.Equal(HttpMethod.Get, req.Method);
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+            {
+                supportedExtensions = new[] { ".tif", ".tiff", ".png" },
+                formatDescriptions = new Dictionary<string, string>
+                {
+                    [".tif"] = "GeoTIFF",
+                    [".png"] = "PNG with world file",
+                },
+            }));
+        });
+
+        var formats = await client.GetSupportedRasterFormatsAsync();
+
+        Assert.Equal(3, formats.SupportedExtensions.Count);
+        Assert.Contains(".tif", formats.SupportedExtensions);
+        Assert.Equal("GeoTIFF", formats.FormatDescriptions[".tif"]);
+    }
+
+    [Fact]
+    public void AddHonuaAdmin_ResolvesRasterImportClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaAdmin(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var rasterClient = provider.GetRequiredService<IHonuaAdminRasterImportClient>();
+        Assert.NotNull(rasterClient);
+        Assert.IsType<HonuaAdminClient>(rasterClient);
+    }
+}

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/FeatureServerVectorPayloadTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/FeatureServerVectorPayloadTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Honua.Sdk.GeoServices.FeatureServer.Models;
 using Honua.Sdk.GeoServices.Tests.Fixtures;
 using Honua.Sdk.Geometry.Vector;
@@ -74,5 +76,99 @@ public sealed class FeatureServerVectorPayloadTests
         Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
         var point = Assert.IsType<Point>(Assert.Single(result.Features).Geometry);
         Assert.Equal(-157.84, point.X, 2);
+    }
+
+    [Fact]
+    public async Task QueryVectorAsync_GenericClient_200ErrorEnvelope_ThrowsHonuaFeatureServerException()
+    {
+        // The extension fallback path (non-HonuaFeatureServerClient implementations) goes through
+        // QueryRawAsync. GeoServices reports failures in-band as HTTP 200 with a JSON {error} body;
+        // the vector path must surface that as a HonuaFeatureServerException rather than feeding the
+        // error body to the binary payload reader.
+        var client = new FakeRawFeatureServerClient(
+            () => TestHelpers.CreateGeoServicesErrorResponse(400, "Invalid where clause.", ["WHERE parse error"]));
+
+        var exception = await Assert.ThrowsAsync<HonuaFeatureServerException>(
+            () => client.QueryVectorAsync("parks", 0, new FeatureServerQueryParams()));
+
+        Assert.Equal("Invalid where clause.", exception.Message);
+        Assert.Equal(400, exception.GeoServicesErrorCode);
+    }
+
+    [Fact]
+    public async Task QueryVectorAsync_GenericClient_GeoJsonBody_ParsesSuccessfully()
+    {
+        // A genuine JSON (GeoJSON) payload on the fallback path must still parse — the envelope
+        // check is a no-op when there is no {error} object.
+        const string geoJson = """
+            {
+              "type": "FeatureCollection",
+              "features": [
+                {
+                  "type": "Feature",
+                  "id": "parks.1",
+                  "properties": { "name": "Lagoon" },
+                  "geometry": { "type": "Point", "coordinates": [-157.84, 21.29] }
+                }
+              ]
+            }
+            """;
+        var client = new FakeRawFeatureServerClient(() => TestHelpers.CreateRawJsonResponse(geoJson));
+
+        var result = await client.QueryVectorAsync(
+            "parks",
+            0,
+            new FeatureServerQueryParams(),
+            VectorPayloadFormat.GeoJson);
+
+        Assert.Equal(VectorPayloadFormat.GeoJson, result.Format);
+        Assert.Single(result.Features);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IHonuaFeatureServerClient"/> stub that is NOT a
+    /// <see cref="HonuaFeatureServerClient"/>, so the vector extension exercises its
+    /// generic-client fallback path. Only <see cref="QueryRawAsync"/> is implemented.
+    /// </summary>
+    private sealed class FakeRawFeatureServerClient : IHonuaFeatureServerClient
+    {
+        private readonly Func<HttpResponseMessage> _rawResponseFactory;
+
+        public FakeRawFeatureServerClient(Func<HttpResponseMessage> rawResponseFactory)
+            => _rawResponseFactory = rawResponseFactory;
+
+        public Task<HttpResponseMessage> QueryRawAsync(
+            string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => Task.FromResult(_rawResponseFactory());
+
+        public Task<FeatureServerServiceInfo> GetServiceInfoAsync(string serviceId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerLayerInfo> GetLayerInfoAsync(string serviceId, int layerId, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerQueryResponse> QueryAsync(string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerFeature?> GetFeatureAsync(string serviceId, int layerId, long objectId, FeatureServerQueryParams? query = null, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<long> QueryCountAsync(string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<long>> QueryIdsAsync(string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerExtent> QueryExtentAsync(string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<FeatureServerQueryResponse> QueryPagesAsync(string serviceId, int layerId, FeatureServerQueryParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerQueryResponse> QueryStatisticsAsync(string serviceId, int layerId, FeatureServerStatisticsParams query, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<FeatureServerValidateSqlResponse> ValidateSqlAsync(string serviceId, int layerId, string where, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary

Tractable backlog sweep for `honua-sdk-dotnet`. Two issues needed real code on the current `trunk` (`#233`, `#219`); the other three were verified already-landed and are closed/cross-referenced here to clear the backlog.

## Per-issue status

- **`#233` (bug) — DONE.** The GeoServices vector/PBF read path only had the bare `EnsureSuccessStatusCode()` in the *generic-client fallback* branch of `FeatureServerVectorClientExtensions.QueryVectorAsync` (the `HonuaFeatureServerClient` branch was already covered). GeoServices reports failures in-band as HTTP 200 + `{"error":{code,message,details}}`, even for binary requests. The fallback now branches on content type: a non-success status or a JSON body is routed through the existing shared `GeoServicesHttp.EnsureSuccess` (which surfaces a `HonuaFeatureServerException` with the envelope code/message/details), and a genuine GeoJSON body still parses; binary (PBF) bodies stream straight to the reader as before. Reuses the existing shared helper — no new duplicate envelope parser.
- **`#219` (feature) — DONE.** New `IHonuaAdminRasterImportClient` (part of `IHonuaAdminClient`): `ImportRasterAsync` (multipart `POST /api/v1/admin/import/raster`) and `GetSupportedRasterFormatsAsync` (`GET .../formats`). Adds `RasterImportRequest` / `RasterImportResult` / `RasterFormatsResponse`, source-generated JSON, DI alias via `AddHonuaAdmin` (and the umbrella), world-file/projection sidecars, caller-owned stream (not disposed), and README notes linking the raster read (`IHonuaRasterDataClient.ReadWindowAsync`) and write halves. Request shape matches the server's `RasterImportEndpoints` contract.
- **`#171` (P1) — ALREADY ON TRUNK.** `Honua.Sdk.ConsoleShare` already ships all three surfaces: Share access/public-link/embed (`IHonuaConsoleShareClient`), open-data/DCAT/Schema.org/STAC publication + public projections (`IHonuaConsoleShareOpenDataClient`), and scheduled export definitions/runs + traffic summaries/series (`IHonuaConsoleShareExportClient`), with DTOs, DI, AOT JSON context, and tests. Landed via #180/#216. Closing to clear the backlog.
- **`#159` (feature) — ALREADY ON TRUNK + RELEASED.** The edit-projection fix (`#156` / `b9e2d1e`) is an ancestor of `trunk` and shipped in published releases since `dotnet-sdk-v1.1.0` (current `v1.4.3`). The SDK-side acceptance (a release/tag exists including `#156`) is satisfied; re-enabling the skipped tests is `honua-mobile`'s job (honua-mobile#199), out of scope here.
- **`#227` (maintainability, S2) — SAFE SCOPE ALREADY ON TRUNK; remainder deferred.** The concrete safe items are done on trunk: open-redirect guard centralized in `Honua.Sdk.Abstractions.Http.NextLinkOriginValidator`; `ResponseOwningStream`/`NonDisposingStream` and `TolerantNullableInt64Converter` consolidated into Abstractions; STAC GET item-search now routes `Intersects` to POST. The remaining items (generic `HonuaAuthHandler<TOptions>`, shared `ConfigureHonuaRestHttpClient`, uniform `ActivitySource`) are the broader refactors explicitly scoped out; left as `Related to`.

## Changes Made

- `geoservices`: vector extension fallback now surfaces the 200-OK GeoServices error envelope via the shared `GeoServicesHttp.EnsureSuccess`.
- `admin`: new `IHonuaAdminRasterImportClient` + models + source-gen JSON + DI registration.
- `docs`: GeoServices and Admin READMEs link the raster read/write round-trip.
- `tests`: vector error-envelope regression (generic-client path) + raster import client tests (multipart shape, sidecars, parse, error mapping, DI resolution).

## Breaking Changes

Additive only: a new sub-interface is composed into `IHonuaAdminClient` (consistent with the established Admin composition pattern) and new public types are added. No existing signatures changed. CI api-compat runs with `ALLOW_BREAKING=true`.

## Testing

- `dotnet build` (Release, `TreatWarningsAsErrors=true`) clean for `Honua.Sdk.Admin`, `Honua.Sdk.GeoServices`, the umbrella `Honua.Sdk`, and both test projects.
- `dotnet test` (Release): `Honua.Sdk.Admin.Tests` 185/185, `Honua.Sdk.GeoServices.Tests` 149/149.
- `dotnet format --verify-no-changes` clean on all changed projects.

Closes #233
Closes #219
Closes #171
Closes #159
Related to #227