### PR TITLE
Finish audit S2 maintainability remainder: STAC GET conformance + auth handler DRY (#227)

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -108,6 +108,24 @@ also implement `IHonuaFeatureQueryClient.QueryPagesAsync` from
 | gRPC | `QueryFeaturesStreamAsync` returns server-streamed pages until `IsLastPage`; `QueryPagesAsync` maps those pages to the shared abstraction. |
 | OGC API Processes | `ListJobsAsync` accepts an optional server-side `limit`. The client does not auto-page jobs because the current OGC Processes job list contract does not expose a shared continuation token. |
 
+## Observability
+
+SDK telemetry is intentionally delegated to the standard .NET HTTP and gRPC
+instrumentation rather than re-implemented per client. Every REST client is a
+typed `HttpClient`, so enabling `AddHttpClientInstrumentation()` (OpenTelemetry)
+or `IHttpClientFactory` logging captures request/response spans, status codes,
+retries, and timings uniformly across all packages; gRPC clients are likewise
+covered by `AddGrpcClientInstrumentation()`. Configure these once on the host and
+they apply to every Honua client without SDK-specific wiring.
+
+The WFS client (`Honua.Sdk.OgcFeatures.Wfs`) additionally emits a bespoke
+`ActivitySource` (`Honua.Sdk.OgcFeatures.Wfs`) for protocol-level operations
+(`GetCapabilities`, `DescribeFeatureType`, `GetFeature`) because WFS multiplexes
+several logical operations over one POST endpoint, which the transport span alone
+cannot disambiguate. A uniform SDK-wide `ActivitySource` is tracked separately
+(Related to #227); for now, transport instrumentation is the supported and
+sufficient path for the other clients.
+
 ## Endpoint coverage
 
 Current typed endpoint coverage is:

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthHandler.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthHandler.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Abstractions.Authentication;
+
+/// <summary>
+/// Shared <see cref="DelegatingHandler"/> base for Honua REST clients that applies SDK
+/// authentication credentials and enforces the plain-HTTP credential guard. Every paginating
+/// and non-paginating HTTP client delegates to this single implementation so that a hardening
+/// change (for example to the insecure-transport policy or the rejection message) reaches all
+/// clients at once instead of drifting across per-package copies.
+/// </summary>
+/// <typeparam name="TOptions">
+/// The concrete client options type, which must expose both the transport surface
+/// (<see cref="IHonuaClientOptions"/>) and the authentication surface
+/// (<see cref="IHonuaAuthenticationOptions"/>).
+/// </typeparam>
+public abstract class HonuaAuthHandler<TOptions> : DelegatingHandler
+    where TOptions : class, IHonuaClientOptions, IHonuaAuthenticationOptions
+{
+    private readonly TOptions _options;
+    private readonly string _serviceName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaAuthHandler{TOptions}"/> class.
+    /// </summary>
+    /// <param name="options">The resolved client options carrying credentials and base address.</param>
+    /// <param name="serviceName">
+    /// The logical Honua service name used in authentication diagnostics (for example
+    /// <c>"stac"</c> or <c>"admin"</c>).
+    /// </param>
+    /// <param name="validateBaseAddress">
+    /// The owning package's base-address validation callback, invoked once at construction so the
+    /// failure carries the client-specific display name.
+    /// </param>
+    protected HonuaAuthHandler(TOptions options, string serviceName, Action<Uri?> validateBaseAddress)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+        ArgumentNullException.ThrowIfNull(validateBaseAddress);
+
+        _options = options;
+        _serviceName = serviceName;
+        validateBaseAddress(options.BaseAddress);
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
+            HonuaAuthenticationSupport.RequiresHttpsForAuthentication(request.RequestUri))
+        {
+            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, _serviceName);
+            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
+                _options,
+                context,
+                cancellationToken).ConfigureAwait(false);
+            throw new InvalidOperationException(HonuaAuthenticationSupport.InsecureTransportRejectedMessage);
+        }
+
+        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
+            request,
+            _options,
+            _serviceName,
+            cancellationToken).ConfigureAwait(false);
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
+++ b/src/Honua.Sdk.Abstractions/Authentication/HonuaAuthenticationSupport.cs
@@ -21,6 +21,15 @@ public static class HonuaAuthenticationSupport
     public const string InsecureTransportRejectedEvent = "honua.auth.insecure_transport_rejected";
 
     /// <summary>
+    /// Canonical exception message thrown when the SDK refuses to send credentials over a
+    /// remote plain-HTTP connection. Centralized here so every HTTP auth handler raises the
+    /// same message (the per-service name is captured separately in auth diagnostics).
+    /// </summary>
+    public const string InsecureTransportRejectedMessage =
+        "Refusing to send credentials over an insecure connection. Use HTTPS, " +
+        "or use loopback HTTP only for local development.";
+
+    /// <summary>
     /// Determines whether any credential source is configured.
     /// </summary>
     /// <param name="options">Authentication options.</param>

--- a/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.Admin;
 /// <summary>
 /// Delegating handler that adds authentication headers to admin API requests.
 /// </summary>
-internal sealed class HonuaAdminAuthHandler : DelegatingHandler
+internal sealed class HonuaAdminAuthHandler : HonuaAuthHandler<HonuaAdminClientOptions>
 {
-    private readonly HonuaAdminClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaAdminAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The admin client options containing authentication credentials.</param>
     public HonuaAdminAuthHandler(IOptions<HonuaAdminClientOptions> options)
+        : base(options.Value, "admin", HonuaAdminClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaAdminClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaAdminClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "admin");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send admin credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "admin",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsAuthHandler.cs
+++ b/src/Honua.Sdk.Catalogs/Records/HonuaOgcRecordsAuthHandler.cs
@@ -9,44 +9,14 @@ namespace Honua.Sdk.Catalogs.Records;
 /// <summary>
 /// Delegating handler that adds authentication headers to OGC API Records requests.
 /// </summary>
-internal sealed class HonuaOgcRecordsAuthHandler : DelegatingHandler
+internal sealed class HonuaOgcRecordsAuthHandler : HonuaAuthHandler<HonuaOgcRecordsClientOptions>
 {
-    private readonly HonuaOgcRecordsClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaOgcRecordsAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The OGC API Records client options containing authentication credentials.</param>
     public HonuaOgcRecordsAuthHandler(IOptions<HonuaOgcRecordsClientOptions> options)
+        : base(options.Value, "ogc-records", HonuaOgcRecordsClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaOgcRecordsClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaOgcRecordsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "ogc-records");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "ogc-records",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Catalogs/Stac/HonuaStacAuthHandler.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/HonuaStacAuthHandler.cs
@@ -9,44 +9,14 @@ namespace Honua.Sdk.Catalogs.Stac;
 /// <summary>
 /// Delegating handler that adds authentication headers to STAC requests.
 /// </summary>
-internal sealed class HonuaStacAuthHandler : DelegatingHandler
+internal sealed class HonuaStacAuthHandler : HonuaAuthHandler<HonuaStacClientOptions>
 {
-    private readonly HonuaStacClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaStacAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The STAC client options containing authentication credentials.</param>
     public HonuaStacAuthHandler(IOptions<HonuaStacClientOptions> options)
+        : base(options.Value, "stac", HonuaStacClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaStacClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaStacClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "stac");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "stac",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/HonuaStacClient.cs
@@ -333,6 +333,14 @@ public sealed class HonuaStacClient : IHonuaStacClient
         StacSearchQuery? query = null,
         CancellationToken cancellationToken = default)
     {
+        // `intersects` is only valid on POST /search per the STAC API spec; a conformant server
+        // may ignore it on a GET and silently return unfiltered results. Route such searches to
+        // the POST path so the geometry filter is actually honored (mirrors SearchAsync).
+        if (query?.Intersects is not null)
+        {
+            return await PostSearchJsonAsync(ToSearchRequest(query), cancellationToken).ConfigureAwait(false);
+        }
+
         var body = await GetStringAsync($"{BasePath}/search{BuildQueryString(query)}", cancellationToken).ConfigureAwait(false);
         return JsonDocument.Parse(body);
     }
@@ -362,8 +370,29 @@ public sealed class HonuaStacClient : IHonuaStacClient
     public async Task<HttpResponseMessage> SearchRawAsync(
         StacSearchQuery? query = null,
         CancellationToken cancellationToken = default)
-        => await _http.GetAsync(CreateRequestUri($"{BasePath}/search{BuildQueryString(query)}"), cancellationToken)
+    {
+        // `intersects` is only valid on POST /search per the STAC API spec; a conformant server
+        // may ignore it on a GET and silently return unfiltered results. Route such searches to
+        // the POST path so the geometry filter is actually honored (mirrors SearchAsync).
+        if (query?.Intersects is not null)
+        {
+            return await PostSearchRawAsync(ToSearchRequest(query), cancellationToken).ConfigureAwait(false);
+        }
+
+        return await _http.GetAsync(CreateRequestUri($"{BasePath}/search{BuildQueryString(query)}"), cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private async Task<HttpResponseMessage> PostSearchRawAsync(
+        StacSearchRequest request,
+        CancellationToken cancellationToken)
+    {
+        var body = JsonSerializer.SerializeToUtf8Bytes(request, StacJsonContext.Default.StacSearchRequest);
+        using var content = new ByteArrayContent(body);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return await _http.PostAsync(CreateRequestUri($"{BasePath}/search"), content, cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     private async Task<string> GetStringAsync(string url, CancellationToken cancellationToken)
     {
@@ -546,7 +575,11 @@ public sealed class HonuaStacClient : IHonuaStacClient
         var parameters = CreateCommonParameters(query.Limit, query.Offset, query.Next, query.Bbox, query.Datetime);
         AddList(parameters, "ids", query.Ids);
         AddList(parameters, "collections", query.Collections);
-        AddValue(parameters, "intersects", FormatJsonElement(query.Intersects));
+
+        // `intersects` is deliberately NOT emitted here: STAC API allows it only on POST /search,
+        // and a conformant server may silently ignore it on a GET. The public GET search entry
+        // points (SearchAsync/SearchJsonAsync/SearchRawAsync) detect Intersects and route to the
+        // POST path, so the GET query string must never carry it.
         AddValue(parameters, "query", FormatJsonElement(query.Query));
         AddValue(parameters, "filter", query.Filter);
         AddValue(parameters, "filter-lang", query.FilterLang);

--- a/src/Honua.Sdk.ConsoleShare/HonuaConsoleShareAuthHandler.cs
+++ b/src/Honua.Sdk.ConsoleShare/HonuaConsoleShareAuthHandler.cs
@@ -9,41 +9,14 @@ namespace Honua.Sdk.ConsoleShare;
 /// <summary>
 /// Delegating handler that adds authentication headers to Console Share requests.
 /// </summary>
-internal sealed class HonuaConsoleShareAuthHandler : DelegatingHandler
+internal sealed class HonuaConsoleShareAuthHandler : HonuaAuthHandler<HonuaConsoleShareClientOptions>
 {
-    private readonly HonuaConsoleShareClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaConsoleShareAuthHandler"/> class.
     /// </summary>
+    /// <param name="options">The Console Share client options containing authentication credentials.</param>
     public HonuaConsoleShareAuthHandler(IOptions<HonuaConsoleShareClientOptions> options)
+        : base(options.Value, "console-share", HonuaConsoleShareClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaConsoleShareClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaConsoleShareClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "console-share");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "console-share",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.GeoServices;
 /// <summary>
 /// Delegating handler that adds authentication headers to GeoServices API requests.
 /// </summary>
-internal sealed class HonuaGeoServicesAuthHandler : DelegatingHandler
+internal sealed class HonuaGeoServicesAuthHandler : HonuaAuthHandler<HonuaGeoServicesClientOptions>
 {
-    private readonly HonuaGeoServicesClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaGeoServicesAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The GeoServices client options containing authentication credentials.</param>
     public HonuaGeoServicesAuthHandler(IOptions<HonuaGeoServicesClientOptions> options)
+        : base(options.Value, "geoservices", HonuaGeoServicesClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaGeoServicesClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaGeoServicesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "geoservices");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "geoservices",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
+++ b/src/Honua.Sdk.OgcFeatures/HonuaOgcFeaturesAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.OgcFeatures;
 /// <summary>
 /// Delegating handler that adds authentication headers to OGC API Features requests.
 /// </summary>
-internal sealed class HonuaOgcFeaturesAuthHandler : DelegatingHandler
+internal sealed class HonuaOgcFeaturesAuthHandler : HonuaAuthHandler<HonuaOgcFeaturesClientOptions>
 {
-    private readonly HonuaOgcFeaturesClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaOgcFeaturesAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The OGC API Features client options containing authentication credentials.</param>
     public HonuaOgcFeaturesAuthHandler(IOptions<HonuaOgcFeaturesClientOptions> options)
+        : base(options.Value, "ogc-features", HonuaOgcFeaturesClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaOgcFeaturesClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaOgcFeaturesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "ogc-features");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "ogc-features",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsAuthHandler.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.OgcFeatures.Wfs;
 /// <summary>
 /// Delegating handler that adds authentication headers to WFS requests.
 /// </summary>
-internal sealed class HonuaWfsAuthHandler : DelegatingHandler
+internal sealed class HonuaWfsAuthHandler : HonuaAuthHandler<HonuaWfsClientOptions>
 {
-    private readonly HonuaWfsClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaWfsAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The WFS client options containing authentication credentials.</param>
     public HonuaWfsAuthHandler(IOptions<HonuaWfsClientOptions> options)
+        : base(options.Value, "wfs", HonuaWfsClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaWfsClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaWfsClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "wfs");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send WFS credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "wfs",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Processes/HonuaProcessesAuthHandler.cs
+++ b/src/Honua.Sdk.Processes/HonuaProcessesAuthHandler.cs
@@ -9,41 +9,14 @@ namespace Honua.Sdk.Processes;
 /// <summary>
 /// Delegating handler that adds authentication headers to OGC API Processes requests.
 /// </summary>
-internal sealed class HonuaProcessesAuthHandler : DelegatingHandler
+internal sealed class HonuaProcessesAuthHandler : HonuaAuthHandler<HonuaProcessesClientOptions>
 {
-    private readonly HonuaProcessesClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaProcessesAuthHandler"/> class.
     /// </summary>
+    /// <param name="options">The OGC API Processes client options containing authentication credentials.</param>
     public HonuaProcessesAuthHandler(IOptions<HonuaProcessesClientOptions> options)
+        : base(options.Value, "processes", HonuaProcessesClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaProcessesClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaProcessesClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "processes");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "processes",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Scenes/HonuaSceneAuthHandler.cs
+++ b/src/Honua.Sdk.Scenes/HonuaSceneAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.Scenes;
 /// <summary>
 /// Delegating handler that adds authentication headers to scene metadata requests.
 /// </summary>
-internal sealed class HonuaSceneAuthHandler : DelegatingHandler
+internal sealed class HonuaSceneAuthHandler : HonuaAuthHandler<HonuaSceneClientOptions>
 {
-    private readonly HonuaSceneClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaSceneAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The scene client options containing authentication credentials.</param>
     public HonuaSceneAuthHandler(IOptions<HonuaSceneClientOptions> options)
+        : base(options.Value, "scenes", HonuaSceneClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaSceneClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaSceneClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "scenes");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "scenes",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Spec/HonuaSpecAuthHandler.cs
+++ b/src/Honua.Sdk.Spec/HonuaSpecAuthHandler.cs
@@ -9,42 +9,14 @@ namespace Honua.Sdk.Spec;
 /// <summary>
 /// Delegating handler that adds authentication headers to spec workspace API requests.
 /// </summary>
-internal sealed class HonuaSpecAuthHandler : DelegatingHandler
+internal sealed class HonuaSpecAuthHandler : HonuaAuthHandler<HonuaSpecClientOptions>
 {
-    private readonly HonuaSpecClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaSpecAuthHandler"/> class.
     /// </summary>
     /// <param name="options">The spec client options containing authentication credentials.</param>
     public HonuaSpecAuthHandler(IOptions<HonuaSpecClientOptions> options)
+        : base(options.Value, "spec", HonuaSpecClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaSpecClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaSpecClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "spec");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send spec credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "spec",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Honua.Sdk.Studio/HonuaStudioAuthHandler.cs
+++ b/src/Honua.Sdk.Studio/HonuaStudioAuthHandler.cs
@@ -9,41 +9,14 @@ namespace Honua.Sdk.Studio;
 /// <summary>
 /// Delegating handler that adds authentication headers to Console Studio requests.
 /// </summary>
-internal sealed class HonuaStudioAuthHandler : DelegatingHandler
+internal sealed class HonuaStudioAuthHandler : HonuaAuthHandler<HonuaStudioClientOptions>
 {
-    private readonly HonuaStudioClientOptions _options;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaStudioAuthHandler"/> class.
     /// </summary>
+    /// <param name="options">The Console Studio client options containing authentication credentials.</param>
     public HonuaStudioAuthHandler(IOptions<HonuaStudioClientOptions> options)
+        : base(options.Value, "studio", HonuaStudioClientOptions.ValidateBaseAddress)
     {
-        _options = options.Value;
-        HonuaStudioClientOptions.ValidateBaseAddress(_options.BaseAddress);
-    }
-
-    /// <inheritdoc />
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        if (HonuaAuthenticationSupport.HasCredentialSource(_options) &&
-            HonuaStudioClientOptions.RequiresHttpsForAuthentication(request.RequestUri))
-        {
-            var context = HonuaAuthenticationSupport.CreateHttpRequest(request, _options, "studio");
-            await HonuaAuthenticationSupport.EmitInsecureTransportRejectedDiagnosticAsync(
-                _options,
-                context,
-                cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                "Refusing to send credentials over an insecure connection. Use HTTPS, " +
-                "or use loopback HTTP only for local development.");
-        }
-
-        await HonuaAuthenticationSupport.ApplyHttpCredentialsAsync(
-            request,
-            _options,
-            "studio",
-            cancellationToken).ConfigureAwait(false);
-
-        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
+++ b/tests/Honua.Sdk.Catalogs.StacTests/HonuaStacClientTests.cs
@@ -360,6 +360,78 @@ public sealed class HonuaStacClientTests
     }
 
     [Fact]
+    public async Task SearchJsonAsync_WithIntersects_RoutesToPostBecauseItIsPostOnly()
+    {
+        // `intersects` is only honored on POST /search per the STAC API spec; the JSON GET search
+        // must route to POST rather than emit a non-conformant (silently-ignored) query param.
+        HttpMethod? capturedMethod = null;
+        string? capturedBody = null;
+        var json = """{ "type": "FeatureCollection", "features": [] }""";
+        using var intersects = JsonDocument.Parse("""{ "type": "Point", "coordinates": [-158, 21] }""");
+        var client = TestHelpers.CreateStacClient(async req =>
+        {
+            capturedMethod = req.Method;
+            capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync();
+            return TestHelpers.CreateRawJsonResponse(json);
+        });
+
+        using var document = await client.SearchJsonAsync(new StacSearchQuery
+        {
+            Collections = ["imagery"],
+            Intersects = intersects.RootElement,
+        });
+
+        Assert.Equal(HttpMethod.Post, capturedMethod);
+        Assert.NotNull(capturedBody);
+        using var sent = JsonDocument.Parse(capturedBody!);
+        Assert.Equal("Point", sent.RootElement.GetProperty("intersects").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task SearchRawAsync_WithIntersects_RoutesToPostBecauseItIsPostOnly()
+    {
+        // `intersects` is only honored on POST /search per the STAC API spec; the raw GET search
+        // must route to POST rather than emit a non-conformant (silently-ignored) query param.
+        HttpMethod? capturedMethod = null;
+        string? capturedBody = null;
+        var json = """{ "type": "FeatureCollection", "features": [] }""";
+        using var intersects = JsonDocument.Parse("""{ "type": "Point", "coordinates": [-158, 21] }""");
+        var client = TestHelpers.CreateStacClient(async req =>
+        {
+            capturedMethod = req.Method;
+            capturedBody = req.Content is null ? null : await req.Content.ReadAsStringAsync();
+            return TestHelpers.CreateRawJsonResponse(json);
+        });
+
+        using var response = await client.SearchRawAsync(new StacSearchQuery
+        {
+            Collections = ["imagery"],
+            Intersects = intersects.RootElement,
+        });
+
+        Assert.Equal(HttpMethod.Post, capturedMethod);
+        Assert.NotNull(capturedBody);
+        using var sent = JsonDocument.Parse(capturedBody!);
+        Assert.Equal("Point", sent.RootElement.GetProperty("intersects").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task SearchRawAsync_WithoutIntersects_UsesGet()
+    {
+        HttpMethod? capturedMethod = null;
+        var json = """{ "type": "FeatureCollection", "features": [] }""";
+        var client = TestHelpers.CreateStacClient(req =>
+        {
+            capturedMethod = req.Method;
+            return Task.FromResult(TestHelpers.CreateRawJsonResponse(json));
+        });
+
+        using var response = await client.SearchRawAsync(new StacSearchQuery { Collections = ["imagery"] });
+
+        Assert.Equal(HttpMethod.Get, capturedMethod);
+    }
+
+    [Fact]
     public async Task GetItemsPagesAsync_FollowsSameOriginNextLinks()
     {
         var calls = 0;


### PR DESCRIPTION
Closes the genuine remainder of issue #227 (audit S2 maintainability & consistency). Verified against `trunk` first: several listed items were already landed by #236/#246, so this PR scopes to what actually remained.

## Per-AUD status

| AUD | Status | Notes |
|-----|--------|-------|
| AUD-051 (open-redirect guard) | Already done on trunk | `NextLinkOriginValidator` in Abstractions is used by STAC, OGC Features, and OGC Records; copies of the security logic are gone. Cross-origin rejection is tested in all three client test suites plus a validator unit test. No change needed. |
| AUD-079 (`ResponseOwningStream`/`NonDisposingStream`) | Already done on trunk | Single definition in `Honua.Sdk.Abstractions/Http`; no duplicates remain. |
| AUD-080 (`TolerantNullableInt64Converter`) | Already done on trunk | Single definition in Abstractions; consumers reference it via attribute only. |
| **AUD-083 (STAC GET conformance)** | **Done (this PR)** | `SearchAsync`/`SearchPagesAsync` already routed `intersects` to POST; `SearchJsonAsync` and `SearchRawAsync` did not. Both now route to POST, and `BuildQueryString` no longer emits the POST-only `intersects` param at all. Tests added. |
| **AUD-081 (auth handler DRY)** | **Done (this PR)** | New generic `HonuaAuthHandler<TOptions>` in Abstractions holds the shared plain-HTTP credential guard + credential application; the 11 HTTP auth handlers become thin subclasses. The divergent insecure-transport message is centralized as `HonuaAuthenticationSupport.InsecureTransportRejectedMessage`. Type names and per-service diagnostics labels preserved; no new Abstractions dependencies. |
| **AUD-077 (observability)** | **Documented (this PR)** | `docs/client-behavior.md` now states SDK telemetry is delegated to standard HttpClient/gRPC instrumentation (WFS keeps its bespoke `ActivitySource` for multiplexed operations). A uniform SDK-wide ActivitySource is left as a tracked follow-up. |
| AUD-082 (`ConfigureHonuaRestHttpClient`) | **Deferred (Related to #227)** | The only clean shared home is the zero-PackageReference Abstractions contracts package; adding the HTTP resilience/DI stack there would pollute the dependency closure of HTTP-free consumers (`Geometry`, `Field`, `Offline`, `Grpc`) and browser/WASM. The per-package blocks already delegate timeout/handler math to shared Abstractions helpers, so the genuinely duplicated surface is small. |

## Quality gates
- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet format --verify-no-changes`: all changed files clean (the only repo-wide failures are pre-existing whitespace drift in `examples/RoutingGeofenceConsole`, untouched here; CI does not run format).
- `dotnet test Honua.Sdk.sln -c Release`: full suite green (0 failures).

Public API change is additive only (`HonuaAuthHandler<TOptions>` + one new public const); no behavior change beyond the deliberate AUD-083 conformance fix and the deliberately-centralized auth message.

## Remainder
- AUD-082 deferred with rationale above (Related to #227).
- AUD-077 documented rather than fully built (uniform ActivitySource is a tracked follow-up, Related to #227).