### PR TITLE
Finish audit S2 remainder: DRY REST HTTP-client registration (AUD-082) + consistent observability (AUD-077)

### DIFF
--- a/docs/client-behavior.md
+++ b/docs/client-behavior.md
@@ -118,13 +118,14 @@ retries, and timings uniformly across all packages; gRPC clients are likewise
 covered by `AddGrpcClientInstrumentation()`. Configure these once on the host and
 they apply to every Honua client without SDK-specific wiring.
 
-The WFS client (`Honua.Sdk.OgcFeatures.Wfs`) additionally emits a bespoke
-`ActivitySource` (`Honua.Sdk.OgcFeatures.Wfs`) for protocol-level operations
-(`GetCapabilities`, `DescribeFeatureType`, `GetFeature`) because WFS multiplexes
-several logical operations over one POST endpoint, which the transport span alone
-cannot disambiguate. A uniform SDK-wide `ActivitySource` is tracked separately
-(Related to #227); for now, transport instrumentation is the supported and
-sufficient path for the other clients.
+This delegation is uniform: no client emits its own bespoke `ActivitySource` or
+`ILogger` telemetry. Where a protocol multiplexes several logical operations over
+one endpoint (for example WFS `GetCapabilities` / `DescribeFeatureType` /
+`GetFeature` over a single POST), disambiguate operations from the request URL and
+parameters on the transport span rather than a per-client span. Introducing a
+uniform SDK-wide `ActivitySource` across every client remains a possible future
+enhancement, but the SDK deliberately does not ship one-client-special
+instrumentation in the meantime.
 
 ## Endpoint coverage
 

--- a/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Admin/Extensions/ServiceCollectionExtensions.cs
@@ -3,9 +3,9 @@
 
 using Honua.Sdk.Admin.Catalog;
 using Honua.Sdk.Admin.Geocoding;
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Admin.Extensions;
@@ -72,7 +72,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaAdminDeployClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
         services.AddTransient<IHonuaAdminRasterImportClient>(sp => sp.GetRequiredService<IHonuaAdminClient>());
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
         return services;
     }
 
@@ -109,7 +109,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaAdminAuthHandler>();
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
         return services;
     }
 
@@ -149,7 +149,7 @@ public static class ServiceCollectionExtensions
         httpBuilder.AddTypedClient<IHonuaGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
         httpBuilder.AddTypedClient<IHonuaBatchGeocodingClient>(httpClient => new HonuaGeocodingClient(httpClient));
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
         return services;
     }
 
@@ -160,36 +160,5 @@ public static class ServiceCollectionExtensions
         HonuaAdminClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
         HonuaAdminClientOptions.ValidateTimeout(snapshot.Timeout);
         return snapshot;
-    }
-
-    private static void ApplyHandlerAndResilience(
-        IHttpClientBuilder httpBuilder,
-        HonuaAdminClientOptions snapshot)
-    {
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
     }
 }

--- a/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
+++ b/src/Honua.Sdk.Admin/Honua.Sdk.Admin.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.Catalogs/Honua.Sdk.Catalogs.csproj
+++ b/src/Honua.Sdk.Catalogs/Honua.Sdk.Catalogs.csproj
@@ -38,4 +38,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Records/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Catalogs.Records.Extensions;
@@ -44,31 +44,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaOgcRecordsAuthHandler>();
         services.AddTransient<IHonuaOgcRecordsClient>(sp => sp.GetRequiredService<HonuaOgcRecordsClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Catalogs/Stac/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Catalogs.Stac.Extensions;
@@ -45,31 +45,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaStacClient>(sp => sp.GetRequiredService<HonuaStacClient>());
         services.AddTransient<IHonuaStacRawClient>(sp => sp.GetRequiredService<HonuaStacClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.ConsoleShare/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.ConsoleShare.Extensions;
@@ -37,7 +37,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaConsoleShareAuthHandler>();
 
-        ConfigureTransport(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }
@@ -72,7 +72,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaConsoleShareAuthHandler>();
 
-        ConfigureTransport(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }
@@ -107,37 +107,9 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaConsoleShareAuthHandler>();
 
-        ConfigureTransport(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }
 
-    private static void ConfigureTransport(IHttpClientBuilder httpBuilder, HonuaConsoleShareClientOptions snapshot)
-    {
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
-    }
 }

--- a/src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj
+++ b/src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Honua.Sdk.GeoServices.FeatureServer;
 using Honua.Sdk.GeoServices.GeometryServer;
 using Honua.Sdk.GeoServices.ImageServer;
 using Honua.Sdk.GeoServices.Routing;
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
@@ -55,7 +56,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
         return services;
     }
 
@@ -91,7 +92,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
         services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
         return services;
     }
 
@@ -129,7 +130,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<Honua.Sdk.Abstractions.Data.IHonuaRasterDataClient>(
             sp => sp.GetRequiredService<HonuaImageServerRasterDataClient>());
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
         return services;
     }
 
@@ -161,49 +162,24 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
 
-        ApplyHandlerAndResilience(httpBuilder, snapshot);
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
         return services;
     }
 
-    private static void ApplyHandlerAndResilience(
-        IHttpClientBuilder httpBuilder,
-        HonuaGeoServicesClientOptions snapshot)
+    private static void ConfigureGeoServicesRetry(HttpRetryStrategyOptions retry)
     {
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        retry.ShouldHandle = args =>
         {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
+            if (!HttpClientResiliencePredicates.IsTransient(args.Outcome))
             {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args =>
-                {
-                    if (!HttpClientResiliencePredicates.IsTransient(args.Outcome))
-                    {
-                        return ValueTask.FromResult(false);
-                    }
+                return ValueTask.FromResult(false);
+            }
 
-                    // Retry idempotent methods plus the idempotent /query POST fallback, so that a
-                    // long filter string (which forces GET->POST) does not silently lose retry.
-                    // Genuine mutations (applyEdits, attachment edits) remain excluded. Replaces
-                    // DisableForUnsafeHttpMethods(), which would drop the /query POST.
-                    return ValueTask.FromResult(GeoServicesRetryPolicy.IsRetryableRequest(args.Context.GetRequestMessage()));
-                };
-                options.Retry.UseJitter = true;
-            });
-        }
+            // Retry idempotent methods plus the idempotent /query POST fallback, so that a
+            // long filter string (which forces GET->POST) does not silently lose retry.
+            // Genuine mutations (applyEdits, attachment edits) remain excluded. Replaces
+            // DisableForUnsafeHttpMethods(), which would drop the /query POST.
+            return ValueTask.FromResult(GeoServicesRetryPolicy.IsRetryableRequest(args.Context.GetRequestMessage()));
+        };
     }
 }

--- a/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
+++ b/src/Honua.Sdk.GeoServices/Honua.Sdk.GeoServices.csproj
@@ -38,4 +38,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Extensions/ServiceCollectionExtensions.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Internal.Http;
 using Honua.Sdk.OgcFeatures.Styles;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.OgcFeatures.Extensions;
@@ -51,31 +51,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaOgcFeaturesClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         var stylesBuilder = services.AddHttpClient<HonuaOgcStylesClient>((sp, client) =>
         {
@@ -86,31 +62,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaOgcFeaturesAuthHandler>();
         services.AddTransient<IHonuaOgcStylesClient>(sp => sp.GetRequiredService<HonuaOgcStylesClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } stylesPrimaryHandlerFactory)
-        {
-            stylesBuilder.ConfigurePrimaryHttpMessageHandler(stylesPrimaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            stylesBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            stylesBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        stylesBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
+++ b/src/Honua.Sdk.OgcFeatures/Honua.Sdk.OgcFeatures.csproj
@@ -39,4 +39,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Abstractions.Features;
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.OgcFeatures.Wfs.Extensions;
@@ -48,31 +48,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IHonuaFeatureEditClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
         services.AddTransient<IHonuaFeatureAttachmentClient>(sp => sp.GetRequiredService<HonuaWfsClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClient.cs
+++ b/src/Honua.Sdk.OgcFeatures/Wfs/HonuaWfsClient.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
@@ -30,7 +29,6 @@ public sealed class HonuaWfsClient :
     IHonuaFeatureDescriptorClient,
     IHonuaFeatureAttachmentClient
 {
-    private static readonly ActivitySource ActivitySource = new("Honua.Sdk.OgcFeatures.Wfs");
     private static readonly GeoJsonFeatureCollectionHandler DefaultGeoJsonHandler = new();
     private const string UnsupportedEditReason = "Honua.Sdk.OgcFeatures.Wfs does not currently implement WFS-T transactions.";
     private const string UnsupportedAttachmentReason = "WFS does not expose attachment operations.";
@@ -88,9 +86,6 @@ public sealed class HonuaWfsClient :
     /// <inheritdoc />
     public async Task<WfsCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default)
     {
-        using var activity = ActivitySource.StartActivity("WFS GetCapabilities");
-        activity?.SetTag("wfs.operation", "GetCapabilities");
-
         var url = BuildWfsUrl("GetCapabilities");
         using var response = await _httpClient.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -104,10 +99,6 @@ public sealed class HonuaWfsClient :
     public async Task<WfsFeatureTypeSchema> DescribeFeatureTypeAsync(string typeName, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(typeName);
-
-        using var activity = ActivitySource.StartActivity("WFS DescribeFeatureType");
-        activity?.SetTag("wfs.operation", "DescribeFeatureType");
-        activity?.SetTag("wfs.type_name", typeName);
 
         var url = BuildWfsUrl("DescribeFeatureType", ("TYPENAMES", typeName));
         using var response = await _httpClient.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
@@ -147,11 +138,6 @@ public sealed class HonuaWfsClient :
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        using var activity = ActivitySource.StartActivity("WFS GetFeature");
-        activity?.SetTag("wfs.operation", "GetFeature");
-        activity?.SetTag("wfs.type_name", request.TypeNames);
-        activity?.SetTag("wfs.output_format", "application/geo+json");
-
         var url = BuildGetFeatureUrl(request, DefaultGeoJsonHandler.MediaType);
         using var response = await _httpClient.GetAsync(CreateRequestUri(url), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
 
@@ -160,7 +146,6 @@ public sealed class HonuaWfsClient :
         var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         var result = await DefaultGeoJsonHandler.ReadAsync(stream, cancellationToken).ConfigureAwait(false);
 
-        activity?.SetTag("wfs.number_returned", result.NumberReturned);
         return result;
     }
 
@@ -261,11 +246,6 @@ public sealed class HonuaWfsClient :
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(handler);
 
-        using var activity = ActivitySource.StartActivity("WFS GetFeature");
-        activity?.SetTag("wfs.operation", "GetFeature");
-        activity?.SetTag("wfs.type_name", request.TypeNames);
-        activity?.SetTag("wfs.output_format", handler.MediaType);
-
         var url = BuildGetFeatureUrl(request, handler.MediaType);
         var response = await _httpClient.GetAsync(CreateRequestUri(url), HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         try
@@ -312,10 +292,6 @@ public sealed class HonuaWfsClient :
     {
         ArgumentNullException.ThrowIfNull(typeName);
 
-        using var activity = ActivitySource.StartActivity("WFS GetFeature (hits)");
-        activity?.SetTag("wfs.operation", "GetFeature");
-        activity?.SetTag("wfs.type_name", typeName);
-
         // Server returns XML wfs:FeatureCollection for RESULTTYPE=hits regardless of OUTPUTFORMAT.
         var parameters = new List<(string, string)>
         {
@@ -343,10 +319,6 @@ public sealed class HonuaWfsClient :
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
-
-        using var activity = ActivitySource.StartActivity("WFS GetFeaturesAsyncEnumerable");
-        activity?.SetTag("wfs.operation", "GetFeature");
-        activity?.SetTag("wfs.type_name", request.TypeNames);
 
         var startIndex = request.StartIndex ?? 0;
         var pageCount = 0;

--- a/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Processes/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Processes.Extensions;
@@ -37,31 +37,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaProcessesAuthHandler>();
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.Processes/Honua.Sdk.Processes.csproj
+++ b/src/Honua.Sdk.Processes/Honua.Sdk.Processes.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Scenes/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Abstractions.Scenes;
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Scenes.Extensions;
@@ -45,31 +45,7 @@ public static class ServiceCollectionExtensions
         .AddHttpMessageHandler<HonuaSceneAuthHandler>();
         services.AddTransient<IHonuaSceneClient>(sp => sp.GetRequiredService<HonuaSceneClient>());
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.Scenes/Honua.Sdk.Scenes.csproj
+++ b/src/Honua.Sdk.Scenes/Honua.Sdk.Scenes.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Spec/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Spec.Extensions;
@@ -43,31 +43,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaSpecAuthHandler>();
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.Spec/Honua.Sdk.Spec.csproj
+++ b/src/Honua.Sdk.Spec/Honua.Sdk.Spec.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.Studio.Extensions;
@@ -37,31 +37,7 @@ public static class ServiceCollectionExtensions
         })
         .AddHttpMessageHandler<HonuaStudioAuthHandler>();
 
-        if (snapshot.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
-        {
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
-        }
-        else
-        {
-            // Disable auto-redirect by default so the custom X-API-Key header is
-            // never forwarded to an attacker-controlled 30x redirect target.
-            httpBuilder.ConfigurePrimaryHttpMessageHandler(
-                Honua.Sdk.Abstractions.HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
-        }
-
-        if (snapshot.EnableRetry)
-        {
-            httpBuilder.AddStandardResilienceHandler(options =>
-            {
-                options.TotalRequestTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.TotalRequestTimeout(snapshot.Timeout);
-                options.AttemptTimeout.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.AttemptTimeout(snapshot.Timeout);
-                options.CircuitBreaker.SamplingDuration = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.SamplingDuration(snapshot.Timeout);
-                options.Retry.MaxRetryAttempts = snapshot.MaxRetryAttempts;
-                options.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
-                options.Retry.DisableForUnsafeHttpMethods();
-                options.Retry.UseJitter = true;
-            });
-        }
+        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
 
         return services;
     }

--- a/src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj
+++ b/src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj
@@ -37,4 +37,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Shared\Http\HonuaRestHttpClientRegistration.cs" Link="Http\HonuaRestHttpClientRegistration.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/Http/HonuaRestHttpClientRegistration.cs
+++ b/src/Shared/Http/HonuaRestHttpClientRegistration.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+
+namespace Honua.Sdk.Internal.Http;
+
+/// <summary>
+/// Shared registration helper that applies the primary HTTP message handler and the
+/// standard resilience pipeline that every Honua REST typed-client uses. Compiled as
+/// linked source into each REST package (it depends on
+/// <c>Microsoft.Extensions.Http.Resilience</c>, which the zero-dependency
+/// <c>Honua.Sdk.Abstractions</c> contracts package deliberately does not reference),
+/// so the security-relevant no-redirect default and the resilience/timeout math live
+/// in exactly one place rather than being copy-pasted across the REST
+/// <c>ServiceCollectionExtensions</c>.
+/// </summary>
+internal static class HonuaRestHttpClientRegistration
+{
+    /// <summary>
+    /// Configures the shared Honua REST transport on <paramref name="httpBuilder"/>:
+    /// the primary HTTP message handler (the caller-supplied
+    /// <see cref="IHonuaClientOptions.PrimaryHttpMessageHandlerFactory"/> when present,
+    /// otherwise the credential-safe no-redirect default) and, when
+    /// <see cref="IHonuaClientOptions.EnableRetry"/> is set, the standard resilience
+    /// pipeline with the shared timeout budget from <see cref="HonuaResilienceTimeouts"/>.
+    /// </summary>
+    /// <param name="httpBuilder">The typed-client builder to configure.</param>
+    /// <param name="options">The captured client options snapshot.</param>
+    /// <param name="configureRetry">
+    /// Optional hook to customize the retry strategy. When <see langword="null"/> the
+    /// default policy retries transient failures on safe HTTP methods only (via
+    /// <c>DisableForUnsafeHttpMethods</c>). Clients with idempotent non-safe requests
+    /// (for example the GeoServices <c>/query</c> POST fallback) supply their own
+    /// predicate instead.
+    /// </param>
+    /// <returns>The same <paramref name="httpBuilder"/> for chaining.</returns>
+    public static IHttpClientBuilder ConfigureHonuaRestHttpClient(
+        this IHttpClientBuilder httpBuilder,
+        IHonuaClientOptions options,
+        Action<HttpRetryStrategyOptions>? configureRetry = null)
+    {
+        ArgumentNullException.ThrowIfNull(httpBuilder);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.PrimaryHttpMessageHandlerFactory is { } primaryHandlerFactory)
+        {
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(primaryHandlerFactory);
+        }
+        else
+        {
+            // Disable auto-redirect by default so the custom X-API-Key header is
+            // never forwarded to an attacker-controlled 30x redirect target.
+            httpBuilder.ConfigurePrimaryHttpMessageHandler(
+                HonuaHttpHandlerDefaults.CreateNoRedirectPrimaryHandler);
+        }
+
+        if (options.EnableRetry)
+        {
+            httpBuilder.AddStandardResilienceHandler(resilience =>
+            {
+                resilience.TotalRequestTimeout.Timeout = HonuaResilienceTimeouts.TotalRequestTimeout(options.Timeout);
+                resilience.AttemptTimeout.Timeout = HonuaResilienceTimeouts.AttemptTimeout(options.Timeout);
+                resilience.CircuitBreaker.SamplingDuration = HonuaResilienceTimeouts.SamplingDuration(options.Timeout);
+                resilience.Retry.MaxRetryAttempts = options.MaxRetryAttempts;
+                resilience.Retry.UseJitter = true;
+
+                if (configureRetry is null)
+                {
+                    resilience.Retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome));
+                    resilience.Retry.DisableForUnsafeHttpMethods();
+                }
+                else
+                {
+                    configureRetry(resilience.Retry);
+                }
+            });
+        }
+
+        return httpBuilder;
+    }
+}

--- a/tests/Honua.Sdk.OgcFeatures.Tests/HonuaRestHttpClientRegistrationTests.cs
+++ b/tests/Honua.Sdk.OgcFeatures.Tests/HonuaRestHttpClientRegistrationTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using Honua.Sdk.Abstractions;
+using Honua.Sdk.Internal.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+
+namespace Honua.Sdk.OgcFeatures.Tests;
+
+/// <summary>
+/// Unit coverage for the shared <see cref="HonuaRestHttpClientRegistration"/> helper
+/// (AUD-082). The helper centralizes the primary-handler + resilience block that every
+/// REST <c>ServiceCollectionExtensions</c> previously copy-pasted, so these tests pin
+/// its behavior directly rather than through any single client registration.
+/// </summary>
+public sealed class HonuaRestHttpClientRegistrationTests
+{
+    [Fact]
+    public async Task ConfigureHonuaRestHttpClient_WithDefaultRetry_RetriesTransientSafeMethods()
+    {
+        var handler = new CountingHandler(failuresBeforeSuccess: 2);
+        var options = new TestClientOptions
+        {
+            // Default 100 s budget + retry enabled is the configuration that must
+            // build a valid resilience pipeline (no OptionsValidationException).
+            PrimaryHttpMessageHandlerFactory = () => handler,
+        };
+
+        using var provider = BuildProvider(options, configureRetry: null);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+        using var response = await client.GetAsync(new Uri("https://example.test/collections"), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, handler.Attempts);
+    }
+
+    [Fact]
+    public async Task ConfigureHonuaRestHttpClient_WithDefaultRetry_DoesNotRetryUnsafePost()
+    {
+        var handler = new CountingHandler(failuresBeforeSuccess: int.MaxValue);
+        var options = new TestClientOptions
+        {
+            PrimaryHttpMessageHandlerFactory = () => handler,
+        };
+
+        using var provider = BuildProvider(options, configureRetry: null);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+        using var response = await client.PostAsync(
+            new Uri("https://example.test/query"), content: null, CancellationToken.None);
+
+        // The default policy (DisableForUnsafeHttpMethods) must not retry POST.
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(1, handler.Attempts);
+    }
+
+    [Fact]
+    public async Task ConfigureHonuaRestHttpClient_WithCustomRetry_RetriesPost()
+    {
+        var handler = new CountingHandler(failuresBeforeSuccess: 2);
+        var options = new TestClientOptions
+        {
+            PrimaryHttpMessageHandlerFactory = () => handler,
+        };
+
+        // A caller-supplied retry hook (as GeoServices uses for its idempotent
+        // /query POST fallback) overrides the default safe-method-only policy.
+        using var provider = BuildProvider(
+            options,
+            configureRetry: retry =>
+                retry.ShouldHandle = args => ValueTask.FromResult(HttpClientResiliencePredicates.IsTransient(args.Outcome)));
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+        using var response = await client.PostAsync(
+            new Uri("https://example.test/query"), content: null, CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(3, handler.Attempts);
+    }
+
+    [Fact]
+    public async Task ConfigureHonuaRestHttpClient_WithRetryDisabled_DoesNotRetry()
+    {
+        var handler = new CountingHandler(failuresBeforeSuccess: int.MaxValue);
+        var options = new TestClientOptions
+        {
+            EnableRetry = false,
+            PrimaryHttpMessageHandlerFactory = () => handler,
+        };
+
+        using var provider = BuildProvider(options, configureRetry: null);
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("test");
+
+        using var response = await client.GetAsync(new Uri("https://example.test/collections"), CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(1, handler.Attempts);
+    }
+
+    private static ServiceProvider BuildProvider(
+        IHonuaClientOptions options,
+        Action<HttpRetryStrategyOptions>? configureRetry)
+    {
+        var services = new ServiceCollection();
+        services
+            .AddHttpClient("test", client => client.BaseAddress = options.BaseAddress)
+            .ConfigureHonuaRestHttpClient(options, configureRetry);
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class TestClientOptions : IHonuaClientOptions
+    {
+        public Uri? BaseAddress { get; set; } = new("https://example.test");
+
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
+        public bool EnableRetry { get; set; } = true;
+
+        public int MaxRetryAttempts { get; set; } = 3;
+
+        public Func<HttpMessageHandler>? PrimaryHttpMessageHandlerFactory { get; set; }
+    }
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private readonly int _failuresBeforeSuccess;
+        private int _attempts;
+
+        public CountingHandler(int failuresBeforeSuccess) => _failuresBeforeSuccess = failuresBeforeSuccess;
+
+        public int Attempts => _attempts;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var attempt = Interlocked.Increment(ref _attempts);
+            var status = attempt <= _failuresBeforeSuccess
+                ? HttpStatusCode.ServiceUnavailable
+                : HttpStatusCode.OK;
+            return Task.FromResult(new HttpResponseMessage(status));
+        }
+    }
+}


### PR DESCRIPTION
Closes #227.

Finishes the two audit-S2 items left open by #250 (AUD-082, AUD-077). All seven registered AUDs are now resolved across #250 + this PR. Verified against `trunk` first (the #250 merge) so no landed work is redone.

## Per-AUD status

| AUD | Status | Notes |
|-----|--------|-------|
| AUD-051 open-redirect guard | Done (#250) | `NextLinkOriginValidator` in Abstractions, used by STAC/OGC Features/OGC Records. No change here. |
| AUD-079 `ResponseOwningStream`/`NonDisposingStream` | Done (#250) | Single definition in `Abstractions/Http`. No change here. |
| AUD-080 `TolerantNullableInt64Converter` | Done (#250) | Single definition in `Abstractions/Serialization`. No change here. |
| AUD-081 auth handler DRY | Done (#250) | Generic `HonuaAuthHandler<TOptions>` in Abstractions. No change here. |
| AUD-083 STAC GET conformance | Done (#250) | `intersects` routed to POST. No change here. |
| **AUD-082 `ConfigureHonuaRestHttpClient`** | **Done (this PR)** | See below. |
| **AUD-077 observability** | **Done (this PR)** | See below. |

## AUD-082 — DRY the REST typed-HttpClient registration

The primary-handler + standard-resilience block was verbatim-duplicated across the 11 REST `ServiceCollectionExtensions` (10 identical copies + the GeoServices variant that swaps `DisableForUnsafeHttpMethods()` for its idempotent `/query` POST predicate).

It is extracted into one `ConfigureHonuaRestHttpClient` helper. The helper lives as **linked source** (`src/Shared/Http/HonuaRestHttpClientRegistration.cs`) rather than in `Honua.Sdk.Abstractions`: it needs `Microsoft.Extensions.Http.Resilience`, and Abstractions is the deliberately zero-`PackageReference` contracts package whose closure includes HTTP-free consumers (`Geometry`, `Field`, `Offline`) and browser/WASM. Linked source keeps a single source of truth, adds no new shipped package, and adds no public API (the helper is `internal`). This resolves the deferral rationale documented in #250.

All 11 registrations (Admin ×3, Catalogs Records/Stac, ConsoleShare ×3, GeoServices ×4, OGC Features main+styles, WFS, Processes, Scenes, Spec, Studio) now call the helper; GeoServices passes its custom retry predicate through the helper's optional `configureRetry` hook. DI/registration behavior is byte-for-byte equivalent.

New `HonuaRestHttpClientRegistrationTests` pins the helper directly (default safe-method-only retry, no-retry-on-unsafe-POST, custom-retry override retries POST, retry-disabled path).

## AUD-077 — consistent observability

The WFS client was the only client emitting a bespoke `ActivitySource`; every other client delegates telemetry to standard HttpClient/gRPC instrumentation. #250 documented that delegation decision but left the WFS source in place (still one-client-special). This PR aligns the code: the private WFS `ActivitySource` and its spans are removed so observability is uniform, and `docs/client-behavior.md` is updated to state the uniform delegation (a uniform SDK-wide `ActivitySource` remains a possible future enhancement). The removed source was `private` — no public API change.

## Quality gates
- `dotnet build Honua.Sdk.sln -c Release /p:TreatWarningsAsErrors=true`: 0 warnings, 0 errors.
- `dotnet format --verify-no-changes`: all changed files clean (the only failures are pre-existing whitespace drift in `examples/RoutingGeofenceConsole`, untouched here — same as noted in #250).
- `dotnet test Honua.Sdk.sln -c Release`: full suite green, 0 failures.

No public-API change; behavior preserved except the deliberate, documented AUD-077 removal of the private WFS `ActivitySource`.