### PR TITLE
feat(studio): capability-manifest + Studio package-family clients (C1 remainder)

### DIFF
--- a/src/Honua.Sdk.Studio/Capabilities/CapabilityManifest.cs
+++ b/src/Honua.Sdk.Studio/Capabilities/CapabilityManifest.cs
@@ -1,0 +1,570 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Studio.Capabilities;
+
+/// <summary>
+/// Client projection of the server capability manifest returned by
+/// <c>GET /api/v1/capabilities/manifest</c> (schema
+/// <c>honua.capability_manifest.v1</c>). Lets a Console/MCP/QGIS client gate UI
+/// and tool exposure on what the connected server actually supports for the
+/// current tenant, workspace, environment, and caller policy scope.
+/// </summary>
+/// <remarks>
+/// This shape mirrors the frozen server wire contract and is the .NET analogue
+/// of the honua-sdk-js <c>StudioCapabilityManifest</c> projection. The JS
+/// projection is a looser subset; the query helpers (<see cref="GetCapability"/>,
+/// <see cref="IsAvailable"/>, <see cref="IsSupported"/>, <see cref="GetReasonCode"/>)
+/// provide the same semantics as the JS <c>getCapability</c>/<c>hasCapability</c>
+/// helpers.
+/// </remarks>
+public sealed record CapabilityManifest
+{
+    /// <summary>Manifest schema version, for example <c>honua.capability_manifest.v1</c>.</summary>
+    public string SchemaVersion { get; init; } = "honua.capability_manifest.v1";
+
+    /// <summary>Timestamp when the manifest was generated.</summary>
+    public DateTimeOffset IssuedAt { get; init; }
+
+    /// <summary>Tenant, workspace, environment, and authentication scope the manifest was generated for.</summary>
+    public CapabilityManifestScope? Scope { get; init; }
+
+    /// <summary>Server and API version information.</summary>
+    public CapabilityManifestServerInfo? Server { get; init; }
+
+    /// <summary>Environment (metadata snapshot) availability state.</summary>
+    public CapabilityManifestEnvironment? Environment { get; init; }
+
+    /// <summary>Package schema versions and family support state.</summary>
+    public CapabilityManifestPackages? Packages { get; init; }
+
+    /// <summary>Advertised capability entries.</summary>
+    public IReadOnlyList<CapabilityEntry> Capabilities { get; init; } = Array.Empty<CapabilityEntry>();
+
+    /// <summary>Transport availability (HTTP, gRPC, gRPC-Web) and mTLS state.</summary>
+    public CapabilityManifestTransports? Transports { get; init; }
+
+    /// <summary>Operational limits advertised by the server.</summary>
+    public CapabilityManifestLimits? Limits { get; init; }
+
+    /// <summary>Edition, license, and entitlement policy state.</summary>
+    public CapabilityManifestPolicies? Policies { get; init; }
+
+    /// <summary>Related resource links.</summary>
+    public IReadOnlyList<CapabilityManifestLink> Links { get; init; } = Array.Empty<CapabilityManifestLink>();
+
+    /// <summary>
+    /// Returns the capability entry with the given id, or <see langword="null"/>
+    /// when the manifest does not advertise it (regardless of support/availability).
+    /// Mirrors the JS <c>getCapability</c> helper.
+    /// </summary>
+    /// <param name="id">Capability identifier.</param>
+    public CapabilityEntry? GetCapability(string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        for (var i = 0; i < Capabilities.Count; i++)
+        {
+            if (string.Equals(Capabilities[i].Id, id, StringComparison.Ordinal))
+            {
+                return Capabilities[i];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the manifest advertises the capability
+    /// as available in the current scope. Mirrors the JS <c>hasCapability</c>
+    /// helper (JS <c>enabled</c> maps to the server <c>available</c> flag).
+    /// </summary>
+    /// <param name="id">Capability identifier.</param>
+    public bool IsAvailable(string id) => GetCapability(id)?.Available == true;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the server implements the capability at
+    /// all, even if it is not currently available (for example gated by edition or
+    /// entitlement). Inspect <see cref="GetReasonCode"/> to explain an unavailable
+    /// but supported capability.
+    /// </summary>
+    /// <param name="id">Capability identifier.</param>
+    public bool IsSupported(string id) => GetCapability(id)?.Supported == true;
+
+    /// <summary>
+    /// Returns the machine-friendly reason code explaining a capability's
+    /// availability state, or <see langword="null"/> when unknown or the
+    /// capability is unrecognized.
+    /// </summary>
+    /// <param name="id">Capability identifier.</param>
+    public string? GetReasonCode(string id) => GetCapability(id)?.ReasonCode;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the server advertises a supported
+    /// package family with the given identifier (for example <c>map</c>).
+    /// </summary>
+    /// <param name="familyId">Package family identifier.</param>
+    public bool HasPackageFamily(string familyId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(familyId);
+        var families = Packages?.Families;
+        if (families is null)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < families.Count; i++)
+        {
+            if (families[i].Supported &&
+                string.Equals(families[i].Id, familyId, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>Tenant, workspace, environment, and authentication scope of a capability manifest.</summary>
+public sealed record CapabilityManifestScope
+{
+    /// <summary>Resolved tenant identifier, when known.</summary>
+    public string? TenantId { get; init; }
+
+    /// <summary>How the tenant was resolved.</summary>
+    public string? TenantSource { get; init; }
+
+    /// <summary>Requested environment identifier, when supplied.</summary>
+    public string? Environment { get; init; }
+
+    /// <summary>Resolved workspace identifier, when known.</summary>
+    public string? WorkspaceId { get; init; }
+
+    /// <summary>Whether a workspace was available for the request.</summary>
+    public bool WorkspaceAvailable { get; init; }
+
+    /// <summary>Reason code explaining an unavailable workspace, when applicable.</summary>
+    public string? WorkspaceReasonCode { get; init; }
+
+    /// <summary>Whether the caller was authenticated.</summary>
+    public bool Authenticated { get; init; }
+}
+
+/// <summary>Server and API version information carried by a capability manifest.</summary>
+public sealed record CapabilityManifestServerInfo
+{
+    /// <summary>Server build version.</summary>
+    public string? ServerVersion { get; init; }
+
+    /// <summary>Public API version.</summary>
+    public string? ApiVersion { get; init; }
+
+    /// <summary>Metadata API version.</summary>
+    public string? MetadataApiVersion { get; init; }
+
+    /// <summary>Metadata schema version.</summary>
+    public string? MetadataSchemaVersion { get; init; }
+
+    /// <summary>Deployment environment label, for example <c>production</c>.</summary>
+    public string? DeploymentEnvironment { get; init; }
+}
+
+/// <summary>Environment (metadata snapshot) availability state for a capability manifest.</summary>
+public sealed record CapabilityManifestEnvironment
+{
+    /// <summary>Resolved environment identifier, when known.</summary>
+    public string? EnvironmentId { get; init; }
+
+    /// <summary>Whether a specific environment was requested.</summary>
+    public bool Requested { get; init; }
+
+    /// <summary>Whether the environment is available.</summary>
+    public bool Available { get; init; }
+
+    /// <summary>Reason code explaining an unavailable environment, when applicable.</summary>
+    public string? ReasonCode { get; init; }
+
+    /// <summary>Environment revision, when known.</summary>
+    public long? Revision { get; init; }
+
+    /// <summary>Timestamp when the environment snapshot was loaded, when known.</summary>
+    public DateTimeOffset? LoadedAt { get; init; }
+}
+
+/// <summary>Package schema versions and family support state for a capability manifest.</summary>
+public sealed record CapabilityManifestPackages
+{
+    /// <summary>Supported package schema versions.</summary>
+    public IReadOnlyList<string> SchemaVersions { get; init; } = Array.Empty<string>();
+
+    /// <summary>Package families, including unsupported families.</summary>
+    public IReadOnlyList<CapabilityPackageFamily> Families { get; init; } = Array.Empty<CapabilityPackageFamily>();
+
+    /// <summary>Families that can be persisted through the Studio lifecycle.</summary>
+    public IReadOnlyList<string> StorageFamilies { get; init; } = Array.Empty<string>();
+
+    /// <summary>Families that can be published.</summary>
+    public IReadOnlyList<string> PublicationFamilies { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>One package family advertised by a capability manifest.</summary>
+public sealed record CapabilityPackageFamily
+{
+    /// <summary>Family identifier, for example <c>map</c>.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Family kind classifier.</summary>
+    public string? Kind { get; init; }
+
+    /// <summary>Current schema version for the family.</summary>
+    public string? SchemaVersion { get; init; }
+
+    /// <summary>Whether the family is supported in this deployment.</summary>
+    public bool Supported { get; init; }
+}
+
+/// <summary>
+/// One advertised capability entry. Mirrors the frozen server
+/// <c>honua.capability_manifest.v1</c> capability shape and the honua-sdk-js
+/// <c>StudioCapabilityEntry</c> projection (JS <c>enabled</c> maps to
+/// <see cref="Available"/>).
+/// </summary>
+public sealed record CapabilityEntry
+{
+    /// <summary>Stable capability identifier.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Capability category.</summary>
+    public string? Category { get; init; }
+
+    /// <summary>Whether the server implements the capability at all.</summary>
+    public bool Supported { get; init; }
+
+    /// <summary>Whether the capability is available in the current scope.</summary>
+    public bool Available { get; init; }
+
+    /// <summary>Machine-friendly reason code explaining the availability state.</summary>
+    public string? ReasonCode { get; init; }
+
+    /// <summary>Primary entitlement key gating the capability, when applicable.</summary>
+    public string? EntitlementKey { get; init; }
+
+    /// <summary>All entitlement keys gating the capability, when applicable.</summary>
+    public IReadOnlyList<string>? EntitlementKeys { get; init; }
+
+    /// <summary>Minimum edition required for the capability, when applicable.</summary>
+    public string? MinimumEdition { get; init; }
+
+    /// <summary>Localization message key describing the capability state, when applicable.</summary>
+    public string? MessageKey { get; init; }
+}
+
+/// <summary>Transport availability and mTLS state for a capability manifest.</summary>
+public sealed record CapabilityManifestTransports
+{
+    /// <summary>Per-transport availability states.</summary>
+    public IReadOnlyList<CapabilityTransportState> Items { get; init; } = Array.Empty<CapabilityTransportState>();
+
+    /// <summary>Mutual-TLS mode, for example <c>disabled</c> or <c>required</c>.</summary>
+    public string? MtlsMode { get; init; }
+
+    /// <summary>Whether forwarded client-certificate headers are honored.</summary>
+    public bool ForwardedClientCertificateEnabled { get; init; }
+}
+
+/// <summary>Availability state of one transport (for example HTTP, gRPC, gRPC-Web).</summary>
+public sealed record CapabilityTransportState
+{
+    /// <summary>Transport identifier.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Whether the transport is supported by the build.</summary>
+    public bool Supported { get; init; }
+
+    /// <summary>Whether the transport is available in the current deployment.</summary>
+    public bool Available { get; init; }
+
+    /// <summary>Reason code explaining an unavailable transport, when applicable.</summary>
+    public string? ReasonCode { get; init; }
+
+    /// <summary>Localization message key describing the transport state, when applicable.</summary>
+    public string? MessageKey { get; init; }
+}
+
+/// <summary>Operational limits advertised by a capability manifest.</summary>
+public sealed record CapabilityManifestLimits
+{
+    /// <summary>Preview limits.</summary>
+    public CapabilityPreviewLimits? Preview { get; init; }
+
+    /// <summary>Query limits.</summary>
+    public CapabilityQueryLimits? Query { get; init; }
+
+    /// <summary>Analysis limits.</summary>
+    public CapabilityAnalysisLimits? Analysis { get; init; }
+
+    /// <summary>Publication limits.</summary>
+    public CapabilityPublicationLimits? Publication { get; init; }
+
+    /// <summary>Job limits.</summary>
+    public CapabilityJobLimits? Job { get; init; }
+
+    /// <summary>Upload limits.</summary>
+    public CapabilityUploadLimits? Upload { get; init; }
+
+    /// <summary>Streaming limits.</summary>
+    public CapabilityStreamingLimits? Streaming { get; init; }
+
+    /// <summary>Edit limits.</summary>
+    public CapabilityEditLimits? Edit { get; init; }
+
+    /// <summary>Geometry limits.</summary>
+    public CapabilityGeometryLimits? Geometry { get; init; }
+
+    /// <summary>Attachment limits.</summary>
+    public CapabilityAttachmentLimits? Attachment { get; init; }
+}
+
+/// <summary>Preview limits advertised by a capability manifest.</summary>
+public sealed record CapabilityPreviewLimits
+{
+    /// <summary>Maximum preview payload size in bytes.</summary>
+    public long MaxPreviewSizeBytes { get; init; }
+
+    /// <summary>Maximum number of preview features.</summary>
+    public int MaxPreviewFeatures { get; init; }
+
+    /// <summary>Maximum number of features scanned for a preview count.</summary>
+    public int MaxPreviewCountScan { get; init; }
+}
+
+/// <summary>Query limits advertised by a capability manifest.</summary>
+public sealed record CapabilityQueryLimits
+{
+    /// <summary>Default record count for a query.</summary>
+    public int DefaultRecordCount { get; init; }
+
+    /// <summary>Maximum record count for a query.</summary>
+    public int MaxRecordCount { get; init; }
+
+    /// <summary>Maximum number of features returnable by a query.</summary>
+    public int MaxFeatures { get; init; }
+
+    /// <summary>Maximum page size.</summary>
+    public int MaxPageSize { get; init; }
+
+    /// <summary>Query timeout in seconds.</summary>
+    public int QueryTimeoutSeconds { get; init; }
+
+    /// <summary>Maximum bounding-box area in square kilometers.</summary>
+    public double MaxBboxAreaSqKm { get; init; }
+
+    /// <summary>Maximum filter nesting depth.</summary>
+    public int MaxFilterDepth { get; init; }
+
+    /// <summary>Maximum number of spatial operations per query.</summary>
+    public int MaxSpatialOperations { get; init; }
+}
+
+/// <summary>Analysis limits advertised by a capability manifest.</summary>
+public sealed record CapabilityAnalysisLimits
+{
+    /// <summary>Maximum number of input features.</summary>
+    public int MaxInputFeatures { get; init; }
+
+    /// <summary>Maximum number of clusters.</summary>
+    public int MaxClusters { get; init; }
+
+    /// <summary>Maximum DBSCAN epsilon in meters.</summary>
+    public double MaxDbscanEpsMeters { get; init; }
+
+    /// <summary>Maximum k for k-means.</summary>
+    public int MaxKMeansK { get; init; }
+
+    /// <summary>Maximum buffer distance in meters.</summary>
+    public double MaxBufferDistanceMeters { get; init; }
+
+    /// <summary>Minimum density cell size in meters.</summary>
+    public double MinDensityCellSizeMeters { get; init; }
+
+    /// <summary>Maximum density cell size in meters.</summary>
+    public double MaxDensityCellSizeMeters { get; init; }
+
+    /// <summary>Maximum number of density cells.</summary>
+    public int MaxDensityCells { get; init; }
+
+    /// <summary>Maximum d-within distance in meters.</summary>
+    public double MaxDWithinDistanceMeters { get; init; }
+
+    /// <summary>Maximum number of H3 cells per query.</summary>
+    public int MaxH3CellsPerQuery { get; init; }
+
+    /// <summary>Maximum number of spatial operations.</summary>
+    public int MaxSpatialOperations { get; init; }
+
+    /// <summary>Maximum number of joins.</summary>
+    public int MaxJoins { get; init; }
+}
+
+/// <summary>Publication limits advertised by a capability manifest.</summary>
+public sealed record CapabilityPublicationLimits
+{
+    /// <summary>Number of configured deploy targets.</summary>
+    public int ConfiguredDeployTargetCount { get; init; }
+
+    /// <summary>Whether GitOps manifest export is supported.</summary>
+    public bool GitOpsManifestExportSupported { get; init; }
+}
+
+/// <summary>Job limits advertised by a capability manifest.</summary>
+public sealed record CapabilityJobLimits
+{
+    /// <summary>Number of configured workloads.</summary>
+    public int ConfiguredWorkloadCount { get; init; }
+
+    /// <summary>Number of available job backends.</summary>
+    public int AvailableBackendCount { get; init; }
+
+    /// <summary>Whether job cancellation is supported.</summary>
+    public bool SupportsCancellation { get; init; }
+
+    /// <summary>Whether job progress polling is supported.</summary>
+    public bool SupportsProgressPolling { get; init; }
+}
+
+/// <summary>Upload limits advertised by a capability manifest.</summary>
+public sealed record CapabilityUploadLimits
+{
+    /// <summary>Maximum total upload size in bytes.</summary>
+    public long MaxUploadSizeBytes { get; init; }
+
+    /// <summary>Maximum single-file size in bytes.</summary>
+    public long MaxFileSizeBytes { get; init; }
+
+    /// <summary>Maximum number of concurrent uploads.</summary>
+    public int MaxConcurrentUploads { get; init; }
+
+    /// <summary>Maximum number of queued uploads.</summary>
+    public int MaxQueuedUploads { get; init; }
+
+    /// <summary>Maximum size scanned for security in bytes.</summary>
+    public long MaxSecurityScanSizeBytes { get; init; }
+}
+
+/// <summary>Streaming limits advertised by a capability manifest.</summary>
+public sealed record CapabilityStreamingLimits
+{
+    /// <summary>Maximum number of concurrent streaming sessions.</summary>
+    public int MaxConcurrentSessions { get; init; }
+
+    /// <summary>Maximum buffer per connection.</summary>
+    public int MaxBufferPerConnection { get; init; }
+
+    /// <summary>Maximum subscriptions per session.</summary>
+    public int MaxSubscriptionsPerSession { get; init; }
+
+    /// <summary>Maximum subscription identifier length.</summary>
+    public int MaxSubscriptionIdLength { get; init; }
+
+    /// <summary>Maximum control-frame size in bytes.</summary>
+    public int MaxControlFrameBytes { get; init; }
+
+    /// <summary>Cursor retention limit.</summary>
+    public int CursorRetentionLimit { get; init; }
+
+    /// <summary>Heartbeat interval in seconds.</summary>
+    public double HeartbeatIntervalSeconds { get; init; }
+
+    /// <summary>gRPC stream batch size.</summary>
+    public int GrpcStreamBatchSize { get; init; }
+}
+
+/// <summary>Edit limits advertised by a capability manifest.</summary>
+public sealed record CapabilityEditLimits
+{
+    /// <summary>Maximum number of features per edit.</summary>
+    public int MaxFeaturesPerEdit { get; init; }
+
+    /// <summary>Maximum number of edits per transaction.</summary>
+    public int MaxEditsPerTransaction { get; init; }
+
+    /// <summary>Maximum edit payload size in bytes.</summary>
+    public long MaxPayloadSizeBytes { get; init; }
+}
+
+/// <summary>Geometry limits advertised by a capability manifest.</summary>
+public sealed record CapabilityGeometryLimits
+{
+    /// <summary>Maximum number of vertices per geometry.</summary>
+    public int MaxVerticesPerGeometry { get; init; }
+
+    /// <summary>Maximum geometry size in bytes.</summary>
+    public long MaxGeometrySizeBytes { get; init; }
+
+    /// <summary>Maximum coordinate precision.</summary>
+    public int MaxCoordinatePrecision { get; init; }
+}
+
+/// <summary>Attachment limits advertised by a capability manifest.</summary>
+public sealed record CapabilityAttachmentLimits
+{
+    /// <summary>Maximum number of attachments per feature.</summary>
+    public int MaxAttachmentsPerFeature { get; init; }
+
+    /// <summary>Maximum attachment size in bytes.</summary>
+    public long MaxAttachmentSizeBytes { get; init; }
+}
+
+/// <summary>Edition, license, and entitlement policy state for a capability manifest.</summary>
+public sealed record CapabilityManifestPolicies
+{
+    /// <summary>Current server edition.</summary>
+    public string? CurrentEdition { get; init; }
+
+    /// <summary>License validation state.</summary>
+    public string? LicenseValidationState { get; init; }
+
+    /// <summary>Whether the license is valid.</summary>
+    public bool LicenseValid { get; init; }
+
+    /// <summary>Capabilities granted to the caller.</summary>
+    public IReadOnlyList<string> CallerCapabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>Per-entitlement decisions.</summary>
+    public IReadOnlyList<CapabilityEntitlementDecision> Entitlements { get; init; } = Array.Empty<CapabilityEntitlementDecision>();
+
+    /// <summary>Human-readable authorization notice.</summary>
+    public string? AuthorizationNotice { get; init; }
+}
+
+/// <summary>One entitlement decision advertised by a capability manifest.</summary>
+public sealed record CapabilityEntitlementDecision
+{
+    /// <summary>Entitlement key.</summary>
+    public string Key { get; init; } = string.Empty;
+
+    /// <summary>Whether the entitlement is active.</summary>
+    public bool Active { get; init; }
+
+    /// <summary>Minimum edition required for the entitlement.</summary>
+    public string? MinimumEdition { get; init; }
+
+    /// <summary>Reason code explaining an inactive entitlement, when applicable.</summary>
+    public string? ReasonCode { get; init; }
+}
+
+/// <summary>A related resource link advertised by a capability manifest.</summary>
+public sealed record CapabilityManifestLink
+{
+    /// <summary>Link relation.</summary>
+    public string Rel { get; init; } = string.Empty;
+
+    /// <summary>Link target.</summary>
+    public string Href { get; init; } = string.Empty;
+
+    /// <summary>Media type of the link target.</summary>
+    [JsonPropertyName("type")]
+    public string? MediaType { get; init; }
+}

--- a/src/Honua.Sdk.Studio/Capabilities/CapabilityManifestJsonContext.cs
+++ b/src/Honua.Sdk.Studio/Capabilities/CapabilityManifestJsonContext.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Studio.Capabilities;
+
+/// <summary>
+/// Source-generated JSON context for the capability manifest projection.
+/// Trimming/AOT-safe: the entire <see cref="CapabilityManifest"/> graph resolves
+/// through this context without reflection, matching the server
+/// <c>honua.capability_manifest.v1</c> camelCase wire format.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(CapabilityManifest))]
+[JsonSerializable(typeof(CapabilityManifestScope))]
+[JsonSerializable(typeof(CapabilityManifestServerInfo))]
+[JsonSerializable(typeof(CapabilityManifestEnvironment))]
+[JsonSerializable(typeof(CapabilityManifestPackages))]
+[JsonSerializable(typeof(CapabilityPackageFamily))]
+[JsonSerializable(typeof(CapabilityEntry))]
+[JsonSerializable(typeof(CapabilityManifestTransports))]
+[JsonSerializable(typeof(CapabilityTransportState))]
+[JsonSerializable(typeof(CapabilityManifestLimits))]
+[JsonSerializable(typeof(CapabilityPreviewLimits))]
+[JsonSerializable(typeof(CapabilityQueryLimits))]
+[JsonSerializable(typeof(CapabilityAnalysisLimits))]
+[JsonSerializable(typeof(CapabilityPublicationLimits))]
+[JsonSerializable(typeof(CapabilityJobLimits))]
+[JsonSerializable(typeof(CapabilityUploadLimits))]
+[JsonSerializable(typeof(CapabilityStreamingLimits))]
+[JsonSerializable(typeof(CapabilityEditLimits))]
+[JsonSerializable(typeof(CapabilityGeometryLimits))]
+[JsonSerializable(typeof(CapabilityAttachmentLimits))]
+[JsonSerializable(typeof(CapabilityManifestPolicies))]
+[JsonSerializable(typeof(CapabilityEntitlementDecision))]
+[JsonSerializable(typeof(CapabilityManifestLink))]
+internal sealed partial class CapabilityManifestJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Sdk.Studio/Capabilities/HonuaCapabilityManifestClient.cs
+++ b/src/Honua.Sdk.Studio/Capabilities/HonuaCapabilityManifestClient.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using Honua.Sdk.Studio.Internal;
+
+namespace Honua.Sdk.Studio.Capabilities;
+
+/// <summary>
+/// HTTP client for the Honua server capability manifest.
+/// </summary>
+public sealed class HonuaCapabilityManifestClient : IHonuaCapabilityManifestClient
+{
+    private const string BasePath = "/api/v1/capabilities/manifest";
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaCapabilityManifestClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and auth handlers.</param>
+    public HonuaCapabilityManifestClient(HttpClient httpClient)
+    {
+        _http = httpClient;
+    }
+
+    /// <inheritdoc />
+    public async Task<CapabilityManifest> GetManifestAsync(
+        string? environment = null,
+        string? workspaceId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = BuildQuery(environment, workspaceId);
+        using var response = await _http
+            .GetAsync(new Uri(BasePath + query, UriKind.RelativeOrAbsolute), cancellationToken)
+            .ConfigureAwait(false);
+
+        return await StudioHttpResponseReader.ReadAsync(
+            response,
+            CapabilityManifestJsonContext.Default.CapabilityManifest,
+            "GetCapabilityManifest",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string BuildQuery(string? environment, string? workspaceId)
+    {
+        var parts = new List<string>(2);
+        if (!string.IsNullOrWhiteSpace(environment))
+        {
+            parts.Add($"environment={Uri.EscapeDataString(environment)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(workspaceId))
+        {
+            parts.Add($"workspaceId={Uri.EscapeDataString(workspaceId)}");
+        }
+
+        return parts.Count == 0 ? string.Empty : "?" + string.Join('&', parts);
+    }
+}

--- a/src/Honua.Sdk.Studio/Capabilities/IHonuaCapabilityManifestClient.cs
+++ b/src/Honua.Sdk.Studio/Capabilities/IHonuaCapabilityManifestClient.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Studio.Capabilities;
+
+/// <summary>
+/// Typed client for the Honua server capability manifest
+/// (<c>GET /api/v1/capabilities/manifest</c>). Lets a Console/MCP host gate
+/// authoring UI and tool exposure on what the connected server actually supports
+/// for the current tenant, workspace, environment, and caller policy scope.
+/// </summary>
+public interface IHonuaCapabilityManifestClient
+{
+    /// <summary>
+    /// Fetches the capability manifest for the current caller scope.
+    /// </summary>
+    /// <param name="environment">Optional environment identifier to scope the manifest to.</param>
+    /// <param name="workspaceId">Optional workspace identifier to scope the manifest to.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The parsed capability manifest.</returns>
+    Task<CapabilityManifest> GetManifestAsync(
+        string? environment = null,
+        string? workspaceId = null,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.Studio/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
 using Honua.Sdk.Internal.Http;
+using Honua.Sdk.Studio.Capabilities;
+using Honua.Sdk.Studio.Packages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -13,8 +15,13 @@ namespace Honua.Sdk.Studio.Extensions;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the Honua Console Studio analysis-report client.
+    /// Registers the Honua Console Studio clients: the analysis-report read
+    /// client, the capability-manifest client, and the Studio package-family
+    /// lifecycle client.
     /// </summary>
+    /// <param name="services">The service collection to register with.</param>
+    /// <param name="configure">Configuration delegate for client options.</param>
+    /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddHonuaStudio(
         this IServiceCollection services,
         Action<HonuaStudioClientOptions> configure)
@@ -29,16 +36,27 @@ public static class ServiceCollectionExtensions
 
         services.AddSingleton<IOptions<HonuaStudioClientOptions>>(Options.Create(snapshot));
         services.AddTransient<HonuaStudioAuthHandler>();
-        var httpBuilder = services.AddHttpClient<IHonuaStudioReportsClient, HonuaStudioReportsClient>((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<HonuaStudioClientOptions>>().Value;
-            client.BaseAddress = options.BaseAddress;
-            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
-        })
-        .AddHttpMessageHandler<HonuaStudioAuthHandler>();
 
-        httpBuilder.ConfigureHonuaRestHttpClient(snapshot);
+        RegisterClient<IHonuaStudioReportsClient, HonuaStudioReportsClient>(services, snapshot);
+        RegisterClient<IHonuaCapabilityManifestClient, HonuaCapabilityManifestClient>(services, snapshot);
+        RegisterClient<IHonuaStudioPackageClient, HonuaStudioPackageClient>(services, snapshot);
 
         return services;
+    }
+
+    private static void RegisterClient<TClient, TImplementation>(
+        IServiceCollection services,
+        HonuaStudioClientOptions snapshot)
+        where TClient : class
+        where TImplementation : class, TClient
+    {
+        services.AddHttpClient<TClient, TImplementation>((sp, client) =>
+            {
+                var options = sp.GetRequiredService<IOptions<HonuaStudioClientOptions>>().Value;
+                client.BaseAddress = options.BaseAddress;
+                client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
+            })
+            .AddHttpMessageHandler<HonuaStudioAuthHandler>()
+            .ConfigureHonuaRestHttpClient(snapshot);
     }
 }

--- a/src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj
+++ b/src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Honua.Sdk.Studio</PackageId>
-    <Description>Console Studio read clients (analysis report retrieve/render) and shared report contracts for Honua Console hosts</Description>
+    <Description>Console Studio clients for Honua Console hosts: analysis report retrieve/render, the server capability manifest, and the Studio package-family lifecycle (draft/validate/preview/version/publish)</Description>
     <RootNamespace>Honua.Sdk.Studio</RootNamespace>
     <Authors>Honua</Authors>
     <Copyright>Copyright (c) Honua</Copyright>

--- a/src/Honua.Sdk.Studio/Internal/StudioHttpResponseReader.cs
+++ b/src/Honua.Sdk.Studio/Internal/StudioHttpResponseReader.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Sdk.Studio.Exceptions;
+using Honua.Sdk.Studio.Models;
+
+namespace Honua.Sdk.Studio.Internal;
+
+/// <summary>
+/// Shared HTTP response handling for Studio clients: RFC 7807 problem mapping to
+/// <see cref="HonuaStudioApiException"/> and source-generated deserialization of
+/// successful bodies to <see cref="HonuaStudioContractException"/> on drift.
+/// </summary>
+internal static class StudioHttpResponseReader
+{
+    /// <summary>
+    /// Reads a successful JSON response body into <typeparamref name="T"/>, mapping
+    /// error status codes and malformed/empty bodies to the appropriate Studio
+    /// exception.
+    /// </summary>
+    public static async Task<T> ReadAsync<T>(
+        HttpResponseMessage response,
+        JsonTypeInfo<T> typeInfo,
+        string operation,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw CreateApiException(response.StatusCode, body);
+        }
+
+        T? value;
+        try
+        {
+            value = JsonSerializer.Deserialize(body, typeInfo);
+        }
+        catch (JsonException ex)
+        {
+            throw new HonuaStudioContractException(
+                $"Failed to deserialize the Studio '{operation}' response envelope.",
+                operation,
+                body,
+                ex);
+        }
+
+        return value
+            ?? throw new HonuaStudioContractException(
+                $"Server returned an empty Studio '{operation}' response envelope.",
+                operation,
+                body);
+    }
+
+    /// <summary>Builds a <see cref="HonuaStudioApiException"/> from an error response body.</summary>
+    public static HonuaStudioApiException CreateApiException(HttpStatusCode statusCode, string body)
+    {
+        if (TryParseProblem(body, out var problem) && problem is not null)
+        {
+            var message = problem.Detail ?? problem.Title ?? "Studio API request failed.";
+            return new HonuaStudioApiException(statusCode, message, body, problem.Title, problem.Detail);
+        }
+
+        return new HonuaStudioApiException(statusCode, "Studio API request failed.", body);
+    }
+
+    private static bool TryParseProblem(string body, out StudioProblem? problem)
+    {
+        try
+        {
+            problem = JsonSerializer.Deserialize(body, StudioJsonContext.Default.StudioProblem);
+            return problem is not null;
+        }
+        catch (JsonException)
+        {
+            problem = null;
+            return false;
+        }
+    }
+}

--- a/src/Honua.Sdk.Studio/Packages/HonuaStudioPackageClient.cs
+++ b/src/Honua.Sdk.Studio/Packages/HonuaStudioPackageClient.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Honua.Sdk.Studio.Exceptions;
+using Honua.Sdk.Studio.Internal;
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// HTTP client for the Console Studio package lifecycle endpoints.
+/// </summary>
+public sealed class HonuaStudioPackageClient : IHonuaStudioPackageClient
+{
+    private const string BasePath = "/api/v1/studio";
+    private readonly HttpClient _http;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaStudioPackageClient"/> class.
+    /// </summary>
+    /// <param name="httpClient">HTTP client configured with base address and auth handlers.</param>
+    public HonuaStudioPackageClient(HttpClient httpClient)
+    {
+        _http = httpClient;
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPackageFamilyCapabilities> GetPackageFamiliesAsync(CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Get,
+            $"{BasePath}/package-families",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPackageFamilyCapabilities,
+            "GetPackageFamilies",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft> CreateDraftAsync(
+        CreateStudioPackageDraftRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/package-drafts",
+            JsonBody(request, StudioPackageJsonContext.Default.CreateStudioPackageDraftRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPackageDraft,
+            "CreateDraft",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft> GetDraftAsync(Guid draftId, CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Get,
+            $"{BasePath}/package-drafts/{draftId}",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPackageDraft,
+            "GetDraft",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft> UpdateDraftAsync(
+        Guid draftId,
+        UpdateStudioPackageDraftRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Put,
+            $"{BasePath}/package-drafts/{draftId}",
+            JsonBody(request, StudioPackageJsonContext.Default.UpdateStudioPackageDraftRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPackageDraft,
+            "UpdateDraft",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteDraftAsync(Guid draftId, CancellationToken cancellationToken = default)
+    {
+        using var response = await _http
+            .DeleteAsync(new Uri($"{BasePath}/package-drafts/{draftId}", UriKind.RelativeOrAbsolute), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw StudioHttpResponseReader.CreateApiException(response.StatusCode, body);
+        }
+    }
+
+    /// <inheritdoc />
+    public Task<StudioValidationSummary> ValidateDraftAsync(Guid draftId, CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/package-drafts/{draftId}/validate",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioValidationSummary,
+            "ValidateDraft",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioPreviewPlan> PreviewPlanAsync(Guid draftId, CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/package-drafts/{draftId}/preview-plan",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPreviewPlan,
+            "PreviewPlan",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioContentVersion> CreateContentVersionAsync(
+        Guid draftId,
+        SaveStudioContentVersionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/package-drafts/{draftId}/content-versions",
+            JsonBody(request, StudioPackageJsonContext.Default.SaveStudioContentVersionRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioContentVersion,
+            "CreateContentVersion",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<StudioContentVersionList> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Get,
+            $"{BasePath}/content-items/{itemId}/versions",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioContentVersionList,
+            "ListVersions",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioContentVersion> GetVersionAsync(
+        Guid itemId,
+        Guid versionId,
+        CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Get,
+            $"{BasePath}/content-items/{itemId}/versions/{versionId}",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioContentVersion,
+            "GetVersion",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioVersionComparison> CompareVersionsAsync(
+        Guid itemId,
+        CompareStudioContentVersionsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/content-items/{itemId}/version-comparisons",
+            JsonBody(request, StudioPackageJsonContext.Default.CompareStudioContentVersionsRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioVersionComparison,
+            "CompareVersions",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPublicationRequest> CreatePublishRequestAsync(
+        Guid itemId,
+        Guid versionId,
+        CreateStudioPublicationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/content-items/{itemId}/versions/{versionId}/publish-requests",
+            JsonBody(request, StudioPackageJsonContext.Default.CreateStudioPublicationRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPublicationRequest,
+            "CreatePublishRequest",
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<StudioPackageDraft> ReopenVersionAsync(
+        Guid itemId,
+        Guid versionId,
+        CancellationToken cancellationToken = default)
+        => SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/content-items/{itemId}/versions/{versionId}/reopen",
+            content: null,
+            StudioPackageJsonContext.Default.StudioApiResponseStudioPackageDraft,
+            "ReopenVersion",
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<StudioRollbackRequest> RollbackAsync(
+        Guid itemId,
+        CreateStudioRollbackRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return SendAsync(
+            HttpMethod.Post,
+            $"{BasePath}/content-items/{itemId}/rollback-requests",
+            JsonBody(request, StudioPackageJsonContext.Default.CreateStudioRollbackRequest),
+            StudioPackageJsonContext.Default.StudioApiResponseStudioRollbackRequest,
+            "Rollback",
+            cancellationToken);
+    }
+
+    private async Task<TData> SendAsync<TData>(
+        HttpMethod method,
+        string path,
+        HttpContent? content,
+        JsonTypeInfo<StudioApiResponse<TData>> typeInfo,
+        string operation,
+        CancellationToken cancellationToken)
+        where TData : class
+    {
+        using var message = new HttpRequestMessage(method, new Uri(path, UriKind.RelativeOrAbsolute));
+        if (content is not null)
+        {
+            message.Content = content;
+        }
+
+        using var response = await _http.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        var envelope = await StudioHttpResponseReader
+            .ReadAsync(response, typeInfo, operation, cancellationToken)
+            .ConfigureAwait(false);
+
+        return envelope.Data
+            ?? throw new HonuaStudioContractException(
+                $"Server returned a Studio '{operation}' response without a data payload.",
+                operation);
+    }
+
+    private static StringContent JsonBody<T>(T value, JsonTypeInfo<T> typeInfo)
+        => new(JsonSerializer.Serialize(value, typeInfo), Encoding.UTF8, "application/json");
+}

--- a/src/Honua.Sdk.Studio/Packages/IHonuaStudioPackageClient.cs
+++ b/src/Honua.Sdk.Studio/Packages/IHonuaStudioPackageClient.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// Typed client for the Console Studio package lifecycle
+/// (<c>/api/v1/studio/*</c>): family capability discovery, draft CRUD, validate,
+/// preview-plan, content-version, publish-request, reopen, and rollback across
+/// every in-scope package family (query, map, analysis, dashboard, report, form,
+/// app, workflow, gp, etl). The family discriminant travels on the package
+/// envelope, so one client serves every family.
+/// </summary>
+public interface IHonuaStudioPackageClient
+{
+    /// <summary>Lists Studio package family capability descriptors for Console authoring.</summary>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPackageFamilyCapabilities> GetPackageFamiliesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a mutable Studio package draft.</summary>
+    /// <param name="request">Draft creation request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPackageDraft> CreateDraftAsync(
+        CreateStudioPackageDraftRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a mutable Studio package draft.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPackageDraft> GetDraftAsync(Guid draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Replaces a mutable Studio package draft using optimistic generation checks.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="request">Draft update request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPackageDraft> UpdateDraftAsync(
+        Guid draftId,
+        UpdateStudioPackageDraftRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes a mutable Studio package draft.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task DeleteDraftAsync(Guid draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Validates a mutable Studio package draft.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioValidationSummary> ValidateDraftAsync(Guid draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a preview plan for a mutable Studio package draft.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPreviewPlan> PreviewPlanAsync(Guid draftId, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves a draft as an immutable content version.</summary>
+    /// <param name="draftId">Draft identifier.</param>
+    /// <param name="request">Content-version save request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioContentVersion> CreateContentVersionAsync(
+        Guid draftId,
+        SaveStudioContentVersionRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Lists immutable content versions for a content item.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioContentVersionList> ListVersionsAsync(Guid itemId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets a single immutable content version.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="versionId">Version identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioContentVersion> GetVersionAsync(
+        Guid itemId,
+        Guid versionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Compares two immutable content versions.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="request">Comparison request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioVersionComparison> CompareVersionsAsync(
+        Guid itemId,
+        CompareStudioContentVersionsRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Creates a publication request for an immutable content version.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="versionId">Version identifier.</param>
+    /// <param name="request">Publication request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPublicationRequest> CreatePublishRequestAsync(
+        Guid itemId,
+        Guid versionId,
+        CreateStudioPublicationRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Reopens an immutable content version as a new mutable draft.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="versionId">Version identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioPackageDraft> ReopenVersionAsync(
+        Guid itemId,
+        Guid versionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Rolls a content item pointer back to an immutable version.</summary>
+    /// <param name="itemId">Content item identifier.</param>
+    /// <param name="request">Rollback request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<StudioRollbackRequest> RollbackAsync(
+        Guid itemId,
+        CreateStudioRollbackRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Honua.Sdk.Studio/Packages/StudioApiResponse.cs
+++ b/src/Honua.Sdk.Studio/Packages/StudioApiResponse.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// Generic success envelope returned by the Console Studio lifecycle endpoints.
+/// Mirrors the server <c>ApiResponse&lt;T&gt;</c> wrapper.
+/// </summary>
+/// <typeparam name="T">Type of the response data payload.</typeparam>
+public sealed record StudioApiResponse<T>
+    where T : class
+{
+    /// <summary>Whether the request was successful.</summary>
+    public bool Success { get; init; }
+
+    /// <summary>The response data payload.</summary>
+    public T? Data { get; init; }
+
+    /// <summary>Optional message about the response.</summary>
+    public string? Message { get; init; }
+
+    /// <summary>Timestamp when the response was generated.</summary>
+    public DateTimeOffset Timestamp { get; init; }
+}

--- a/src/Honua.Sdk.Studio/Packages/StudioPackageEnums.cs
+++ b/src/Honua.Sdk.Studio/Packages/StudioPackageEnums.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// Studio package families supported by the shared package lifecycle. Mirrors the
+/// server <c>StudioPackageFamily</c> and the honua-sdk-js
+/// <c>HonuaStudioPackageFamily</c> discriminants.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackageFamily>))]
+public enum StudioPackageFamily
+{
+    /// <summary>Saved query package.</summary>
+    [JsonStringEnumMemberName("query")]
+    Query,
+
+    /// <summary>Analysis package.</summary>
+    [JsonStringEnumMemberName("analysis")]
+    Analysis,
+
+    /// <summary>Map package.</summary>
+    [JsonStringEnumMemberName("map")]
+    Map,
+
+    /// <summary>Dashboard package.</summary>
+    [JsonStringEnumMemberName("dashboard")]
+    Dashboard,
+
+    /// <summary>Report package.</summary>
+    [JsonStringEnumMemberName("report")]
+    Report,
+
+    /// <summary>Form package.</summary>
+    [JsonStringEnumMemberName("form")]
+    Form,
+
+    /// <summary>Generated application package.</summary>
+    [JsonStringEnumMemberName("app")]
+    App,
+
+    /// <summary>Workflow package.</summary>
+    [JsonStringEnumMemberName("workflow")]
+    Workflow,
+
+    /// <summary>Geoprocessing package.</summary>
+    [JsonStringEnumMemberName("gp")]
+    Geoprocessing,
+
+    /// <summary>Extract-transform-load package.</summary>
+    [JsonStringEnumMemberName("etl")]
+    Etl,
+}
+
+/// <summary>Lifecycle operations that can be advertised per Studio package family.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackageOperation>))]
+public enum StudioPackageOperation
+{
+    /// <summary>Create a mutable draft.</summary>
+    [JsonStringEnumMemberName("draft.create")]
+    DraftCreate,
+
+    /// <summary>Read a mutable draft.</summary>
+    [JsonStringEnumMemberName("draft.read")]
+    DraftRead,
+
+    /// <summary>Update a mutable draft.</summary>
+    [JsonStringEnumMemberName("draft.update")]
+    DraftUpdate,
+
+    /// <summary>Validate package content.</summary>
+    [JsonStringEnumMemberName("validate")]
+    Validate,
+
+    /// <summary>Generate a preview plan.</summary>
+    [JsonStringEnumMemberName("preview-plan")]
+    PreviewPlan,
+
+    /// <summary>Save immutable content versions.</summary>
+    [JsonStringEnumMemberName("content-version.create")]
+    ContentVersionCreate,
+
+    /// <summary>Read immutable content versions.</summary>
+    [JsonStringEnumMemberName("content-version.read")]
+    ContentVersionRead,
+
+    /// <summary>Compare immutable content versions.</summary>
+    [JsonStringEnumMemberName("content-version.compare")]
+    ContentVersionCompare,
+
+    /// <summary>Create publication requests.</summary>
+    [JsonStringEnumMemberName("publish-request.create")]
+    PublishRequestCreate,
+
+    /// <summary>Reopen an immutable version as a new mutable draft.</summary>
+    [JsonStringEnumMemberName("reopen")]
+    Reopen,
+
+    /// <summary>Rollback current or published pointers to an earlier version.</summary>
+    [JsonStringEnumMemberName("rollback")]
+    Rollback,
+}
+
+/// <summary>Advertised support level for a Studio package family.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackageSupportLevel>))]
+public enum StudioPackageSupportLevel
+{
+    /// <summary>The family is unavailable in this deployment context.</summary>
+    [JsonStringEnumMemberName("unsupported")]
+    Unsupported,
+
+    /// <summary>The lifecycle is available with envelope validation only.</summary>
+    [JsonStringEnumMemberName("limited")]
+    Limited,
+
+    /// <summary>The lifecycle and family-specific validation are available.</summary>
+    [JsonStringEnumMemberName("supported")]
+    Supported,
+}
+
+/// <summary>Persistence mode backing the Studio package lifecycle.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackagePersistenceMode>))]
+public enum StudioPackagePersistenceMode
+{
+    /// <summary>Package data is persisted only in process memory.</summary>
+    [JsonStringEnumMemberName("in-memory")]
+    InMemory,
+
+    /// <summary>Package data is persisted in durable storage.</summary>
+    [JsonStringEnumMemberName("durable")]
+    Durable,
+}
+
+/// <summary>Validation status for package drafts and immutable content versions.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackageValidationStatus>))]
+public enum StudioPackageValidationStatus
+{
+    /// <summary>The package has not been validated.</summary>
+    [JsonStringEnumMemberName("not-validated")]
+    NotValidated,
+
+    /// <summary>The package is valid.</summary>
+    [JsonStringEnumMemberName("valid")]
+    Valid,
+
+    /// <summary>The package is valid but includes warnings.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>The package is invalid.</summary>
+    [JsonStringEnumMemberName("invalid")]
+    Invalid,
+}
+
+/// <summary>Severity for one Studio validation diagnostic.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPackageDiagnosticSeverity>))]
+public enum StudioPackageDiagnosticSeverity
+{
+    /// <summary>Informational diagnostic.</summary>
+    [JsonStringEnumMemberName("info")]
+    Info,
+
+    /// <summary>Warning diagnostic.</summary>
+    [JsonStringEnumMemberName("warning")]
+    Warning,
+
+    /// <summary>Error diagnostic.</summary>
+    [JsonStringEnumMemberName("error")]
+    Error,
+
+    /// <summary>Blocking diagnostic.</summary>
+    [JsonStringEnumMemberName("blocker")]
+    Blocker,
+}
+
+/// <summary>Current state of a persisted Studio publication request.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioPublicationRequestStatus>))]
+public enum StudioPublicationRequestStatus
+{
+    /// <summary>The request has been accepted and persisted.</summary>
+    [JsonStringEnumMemberName("accepted")]
+    Accepted,
+
+    /// <summary>The request is waiting for asynchronous publication execution.</summary>
+    [JsonStringEnumMemberName("pending")]
+    Pending,
+
+    /// <summary>The request was rejected before execution.</summary>
+    [JsonStringEnumMemberName("rejected")]
+    Rejected,
+}
+
+/// <summary>Pointer updated by a Studio rollback request.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<StudioRollbackPointer>))]
+public enum StudioRollbackPointer
+{
+    /// <summary>Update only the current editing pointer.</summary>
+    [JsonStringEnumMemberName("current")]
+    Current,
+
+    /// <summary>Update only the published pointer.</summary>
+    [JsonStringEnumMemberName("published")]
+    Published,
+
+    /// <summary>Update both current and published pointers.</summary>
+    [JsonStringEnumMemberName("both")]
+    Both,
+}

--- a/src/Honua.Sdk.Studio/Packages/StudioPackageJsonContext.cs
+++ b/src/Honua.Sdk.Studio/Packages/StudioPackageJsonContext.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// Source-generated JSON context for the Studio package lifecycle projection.
+/// Trimming/AOT-safe: every request body, response envelope, and package
+/// sub-shape resolves through this context without reflection, matching the
+/// server camelCase wire format.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(StudioApiResponse<StudioPackageFamilyCapabilities>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioPackageDraft>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioValidationSummary>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioPreviewPlan>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioContentVersion>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioContentVersionList>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioVersionComparison>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioPublicationRequest>))]
+[JsonSerializable(typeof(StudioApiResponse<StudioRollbackRequest>))]
+[JsonSerializable(typeof(CreateStudioPackageDraftRequest))]
+[JsonSerializable(typeof(UpdateStudioPackageDraftRequest))]
+[JsonSerializable(typeof(SaveStudioContentVersionRequest))]
+[JsonSerializable(typeof(CompareStudioContentVersionsRequest))]
+[JsonSerializable(typeof(CreateStudioPublicationRequest))]
+[JsonSerializable(typeof(CreateStudioRollbackRequest))]
+[JsonSerializable(typeof(StudioPackageEnvelope))]
+[JsonSerializable(typeof(StudioPackageFamilyCapabilities))]
+[JsonSerializable(typeof(StudioPackageDraft))]
+[JsonSerializable(typeof(StudioValidationSummary))]
+[JsonSerializable(typeof(StudioPreviewPlan))]
+[JsonSerializable(typeof(StudioContentVersion))]
+[JsonSerializable(typeof(StudioContentVersionList))]
+[JsonSerializable(typeof(StudioVersionComparison))]
+[JsonSerializable(typeof(StudioPublicationRequest))]
+[JsonSerializable(typeof(StudioRollbackRequest))]
+internal sealed partial class StudioPackageJsonContext : JsonSerializerContext
+{
+}

--- a/src/Honua.Sdk.Studio/Packages/StudioPackageModels.cs
+++ b/src/Honua.Sdk.Studio/Packages/StudioPackageModels.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Text.Json;
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>
+/// Shared package envelope for every Studio-authored artifact family. Mirrors the
+/// server <c>StudioPackageEnvelope</c>. The <see cref="Bindings"/>,
+/// <see cref="Dependencies"/>, and <see cref="Provenance"/> collections are
+/// always serialized as arrays (never <see langword="null"/>) — the server
+/// rejects a null for any of them.
+/// </summary>
+public sealed record StudioPackageEnvelope
+{
+    /// <summary>Package family.</summary>
+    public required StudioPackageFamily Family { get; init; }
+
+    /// <summary>Schema version for the family envelope.</summary>
+    public required string SchemaVersion { get; init; }
+
+    /// <summary>Family-specific package format advertised by package-family capabilities.</summary>
+    public string? Format { get; init; }
+
+    /// <summary>Data, service, content, field, CRS, unit, or permission bindings.</summary>
+    public IReadOnlyList<StudioPackageBinding> Bindings { get; init; } = Array.Empty<StudioPackageBinding>();
+
+    /// <summary>Lineage, runtime, item, version, job, or artifact dependencies.</summary>
+    public IReadOnlyList<StudioPackageDependency> Dependencies { get; init; } = Array.Empty<StudioPackageDependency>();
+
+    /// <summary>Last validation summary known for the package envelope.</summary>
+    public StudioValidationSummary Validation { get; init; } = StudioValidationSummary.NotValidated;
+
+    /// <summary>Publication route, visibility, embed, service, schedule, or job intent.</summary>
+    public StudioPublicationIntent? PublicationIntent { get; init; }
+
+    /// <summary>Prompt, tool, source, audit, or generated-artifact provenance references.</summary>
+    public IReadOnlyList<StudioProvenanceRef> Provenance { get; init; } = Array.Empty<StudioProvenanceRef>();
+
+    /// <summary>Family-specific JSON payload.</summary>
+    public JsonElement? Body { get; init; }
+}
+
+/// <summary>One binding declared by a Studio package.</summary>
+public sealed record StudioPackageBinding
+{
+    /// <summary>Stable binding key within the package.</summary>
+    public required string Key { get; init; }
+
+    /// <summary>Binding kind, such as data-source, content-item, layer, field, route, or permission.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Referenced item, resource, field, route, or permission identifier.</summary>
+    public required string Ref { get; init; }
+
+    /// <summary>Optional CRS identifier, such as EPSG:4326.</summary>
+    public string? Crs { get; init; }
+
+    /// <summary>Optional integer spatial reference identifier.</summary>
+    public int? Srid { get; init; }
+
+    /// <summary>Optional units associated with this binding.</summary>
+    public string? Units { get; init; }
+
+    /// <summary>Permissions required to use this binding.</summary>
+    public IReadOnlyList<string> RequiredPermissions { get; init; } = Array.Empty<string>();
+
+    /// <summary>Additional binding metadata.</summary>
+    public JsonElement? Metadata { get; init; }
+}
+
+/// <summary>One dependency declared by a Studio package.</summary>
+public sealed record StudioPackageDependency
+{
+    /// <summary>Referenced dependency identifier.</summary>
+    public required string Ref { get; init; }
+
+    /// <summary>Dependency kind, such as content-item, content-version, service, job, or artifact.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Optional immutable dependency version identifier.</summary>
+    public string? VersionId { get; init; }
+
+    /// <summary>True when the dependency is required at runtime.</summary>
+    public bool Required { get; init; } = true;
+
+    /// <summary>Additional dependency metadata.</summary>
+    public JsonElement? Metadata { get; init; }
+}
+
+/// <summary>
+/// Validation summary attached to drafts, versions, and publication requests.
+/// The .NET analogue of the honua-sdk-js <c>StudioPackageValidationResponse</c>
+/// envelope.
+/// </summary>
+public sealed record StudioValidationSummary
+{
+    /// <summary>Shared not-validated summary.</summary>
+    public static StudioValidationSummary NotValidated { get; } = new()
+    {
+        Status = StudioPackageValidationStatus.NotValidated,
+        GeneratedAt = null,
+    };
+
+    /// <summary>Validation status.</summary>
+    public required StudioPackageValidationStatus Status { get; init; }
+
+    /// <summary>Validation diagnostics.</summary>
+    public IReadOnlyList<StudioValidationDiagnostic> Diagnostics { get; init; } = Array.Empty<StudioValidationDiagnostic>();
+
+    /// <summary>Capabilities that are unsupported or limited for the package.</summary>
+    public IReadOnlyList<string> UnsupportedCapabilities { get; init; } = Array.Empty<string>();
+
+    /// <summary>Timestamp when the summary was generated.</summary>
+    public DateTimeOffset? GeneratedAt { get; init; }
+}
+
+/// <summary>One validation diagnostic produced for a package envelope.</summary>
+public sealed record StudioValidationDiagnostic
+{
+    /// <summary>Machine-friendly diagnostic code.</summary>
+    public required string Code { get; init; }
+
+    /// <summary>Diagnostic severity.</summary>
+    public required StudioPackageDiagnosticSeverity Severity { get; init; }
+
+    /// <summary>JSON pointer or field path associated with the diagnostic.</summary>
+    public string? Path { get; init; }
+
+    /// <summary>Human-readable diagnostic message.</summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>Publication intent declared by a Studio package.</summary>
+public sealed record StudioPublicationIntent
+{
+    /// <summary>Optional target route key.</summary>
+    public string? Route { get; init; }
+
+    /// <summary>Optional visibility target.</summary>
+    public string? Visibility { get; init; }
+
+    /// <summary>True when embedding should be enabled for the published package.</summary>
+    public bool? Embed { get; init; }
+
+    /// <summary>Optional service publication hint.</summary>
+    public string? Service { get; init; }
+
+    /// <summary>Optional schedule expression or key.</summary>
+    public string? Schedule { get; init; }
+
+    /// <summary>Optional job publication hint.</summary>
+    public string? Job { get; init; }
+
+    /// <summary>Additional publication metadata.</summary>
+    public JsonElement? Metadata { get; init; }
+}
+
+/// <summary>Provenance reference attached to a Studio package.</summary>
+public sealed record StudioProvenanceRef
+{
+    /// <summary>Provenance kind, such as prompt, tool, source, audit, or generated-by.</summary>
+    public required string Kind { get; init; }
+
+    /// <summary>Referenced provenance identifier.</summary>
+    public required string Ref { get; init; }
+
+    /// <summary>Relationship to the package.</summary>
+    public required string Rel { get; init; }
+
+    /// <summary>Actor associated with the provenance reference.</summary>
+    public string? ActorId { get; init; }
+
+    /// <summary>Timestamp associated with the provenance reference.</summary>
+    public DateTimeOffset? Timestamp { get; init; }
+}
+
+/// <summary>Capability descriptor for one Studio package family.</summary>
+public sealed record StudioPackageFamilyDescriptor
+{
+    /// <summary>Package family.</summary>
+    public required StudioPackageFamily Family { get; init; }
+
+    /// <summary>Current schema version for the family.</summary>
+    public required string CurrentSchemaVersion { get; init; }
+
+    /// <summary>Canonical family-specific format identifier.</summary>
+    public required string Format { get; init; }
+
+    /// <summary>Support level in the current deployment context.</summary>
+    public required StudioPackageSupportLevel SupportLevel { get; init; }
+
+    /// <summary>Operations supported by this family.</summary>
+    public IReadOnlyList<StudioPackageOperation> SupportedOperations { get; init; } = Array.Empty<StudioPackageOperation>();
+
+    /// <summary>Validation depth advertised for this family.</summary>
+    public required string ValidationDepth { get; init; }
+
+    /// <summary>Limitations that clients should surface as disabled or limited states.</summary>
+    public IReadOnlyList<string> Limitations { get; init; } = Array.Empty<string>();
+
+    /// <summary>Maximum serialized package size in bytes.</summary>
+    public int MaxPackageBytes { get; init; }
+
+    /// <summary>True when preview planning is available.</summary>
+    public bool PreviewSupported { get; init; }
+
+    /// <summary>True when publication requests are available.</summary>
+    public bool PublishSupported { get; init; }
+}
+
+/// <summary>Response payload for package family capability discovery.</summary>
+public sealed record StudioPackageFamilyCapabilities
+{
+    /// <summary>Persistence mode backing package lifecycle operations.</summary>
+    public required StudioPackagePersistenceMode PersistenceMode { get; init; }
+
+    /// <summary>True when the backing store is durable.</summary>
+    public required bool Durable { get; init; }
+
+    /// <summary>Package families, including unsupported or limited families.</summary>
+    public IReadOnlyList<StudioPackageFamilyDescriptor> Families { get; init; } = Array.Empty<StudioPackageFamilyDescriptor>();
+}
+
+/// <summary>Mutable Studio package draft.</summary>
+public sealed record StudioPackageDraft
+{
+    /// <summary>Draft identifier.</summary>
+    public required Guid DraftId { get; init; }
+
+    /// <summary>Content item identifier owned by the Studio lifecycle.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Machine-friendly package key.</summary>
+    public required string PackageKey { get; init; }
+
+    /// <summary>Workspace identifier.</summary>
+    public string? WorkspaceId { get; init; }
+
+    /// <summary>Owner principal identifier.</summary>
+    public string? OwnerId { get; init; }
+
+    /// <summary>Package family.</summary>
+    public required StudioPackageFamily Family { get; init; }
+
+    /// <summary>Package envelope.</summary>
+    public required StudioPackageEnvelope Envelope { get; init; }
+
+    /// <summary>Last validation summary known for the draft.</summary>
+    public StudioValidationSummary Validation { get; init; } = StudioValidationSummary.NotValidated;
+
+    /// <summary>Version this draft was reopened from, when applicable.</summary>
+    public Guid? BaseVersionId { get; init; }
+
+    /// <summary>Optimistic concurrency generation.</summary>
+    public long Generation { get; init; }
+
+    /// <summary>Identifier of the actor that created the draft.</summary>
+    public string? CreatedBy { get; init; }
+
+    /// <summary>Identifier of the actor that last updated the draft.</summary>
+    public string? UpdatedBy { get; init; }
+
+    /// <summary>Timestamp when the draft was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>Timestamp when the draft was last updated.</summary>
+    public required DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>Immutable Studio content version.</summary>
+public sealed record StudioContentVersion
+{
+    /// <summary>Content item identifier.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Machine-friendly package key captured when the version was created.</summary>
+    public required string PackageKey { get; init; }
+
+    /// <summary>Workspace identifier captured when the version was created.</summary>
+    public string? WorkspaceId { get; init; }
+
+    /// <summary>Owner principal identifier captured when the version was created.</summary>
+    public string? OwnerId { get; init; }
+
+    /// <summary>Version identifier.</summary>
+    public required Guid VersionId { get; init; }
+
+    /// <summary>Monotonic version number within an item.</summary>
+    public required int VersionNumber { get; init; }
+
+    /// <summary>SHA-256 hash of the immutable package envelope with volatile validation timestamps excluded.</summary>
+    public required string ContentHash { get; init; }
+
+    /// <summary>Immutable package envelope.</summary>
+    public required StudioPackageEnvelope Envelope { get; init; }
+
+    /// <summary>Validation summary captured at version creation.</summary>
+    public required StudioValidationSummary Validation { get; init; }
+
+    /// <summary>Dependency sidecars captured from the immutable package envelope.</summary>
+    public IReadOnlyList<StudioPackageDependency> Dependencies { get; init; } = Array.Empty<StudioPackageDependency>();
+
+    /// <summary>Provenance captured from the immutable package envelope.</summary>
+    public IReadOnlyList<StudioProvenanceRef> Provenance { get; init; } = Array.Empty<StudioProvenanceRef>();
+
+    /// <summary>Source draft identifier.</summary>
+    public Guid? SourceDraftId { get; init; }
+
+    /// <summary>Base version identifier when this version came from a reopened draft.</summary>
+    public Guid? BaseVersionId { get; init; }
+
+    /// <summary>Optional author change note.</summary>
+    public string? ChangeNote { get; init; }
+
+    /// <summary>Identifier of the actor that created the immutable version.</summary>
+    public string? CreatedBy { get; init; }
+
+    /// <summary>Timestamp when the immutable version was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>Response body for listing immutable content versions.</summary>
+public sealed record StudioContentVersionList
+{
+    /// <summary>Content item identifier.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Immutable versions ordered by version number.</summary>
+    public IReadOnlyList<StudioContentVersion> Versions { get; init; } = Array.Empty<StudioContentVersion>();
+}
+
+/// <summary>Current and published version pointers for a Studio content item.</summary>
+public sealed record StudioContentItemPointers
+{
+    /// <summary>Content item identifier.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Current version identifier.</summary>
+    public Guid? CurrentVersionId { get; init; }
+
+    /// <summary>Published version identifier.</summary>
+    public Guid? PublishedVersionId { get; init; }
+}
+
+/// <summary>Durable publication request for an immutable Studio content version.</summary>
+public sealed record StudioPublicationRequest
+{
+    /// <summary>Publication request identifier.</summary>
+    public required Guid RequestId { get; init; }
+
+    /// <summary>Content item identifier.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Immutable version identifier requested for publication.</summary>
+    public required Guid VersionId { get; init; }
+
+    /// <summary>Publication intent.</summary>
+    public StudioPublicationIntent? Intent { get; init; }
+
+    /// <summary>Persisted request status.</summary>
+    public required StudioPublicationRequestStatus Status { get; init; }
+
+    /// <summary>Validation evidence captured for the request.</summary>
+    public StudioValidationSummary Validation { get; init; } = StudioValidationSummary.NotValidated;
+
+    /// <summary>Optional acknowledgement text for validation warnings.</summary>
+    public string? WarningAcknowledgement { get; init; }
+
+    /// <summary>Identifier of the actor that requested publication.</summary>
+    public string? RequestedBy { get; init; }
+
+    /// <summary>Timestamp when the request was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}
+
+/// <summary>Result of a deterministic comparison between two immutable content versions.</summary>
+public sealed record StudioVersionComparison
+{
+    /// <summary>Source version identifier.</summary>
+    public required Guid LeftVersionId { get; init; }
+
+    /// <summary>Target version identifier.</summary>
+    public required Guid RightVersionId { get; init; }
+
+    /// <summary>True when the version content hashes match.</summary>
+    public required bool ContentEqual { get; init; }
+
+    /// <summary>True when dependency sets match.</summary>
+    public required bool DependenciesEqual { get; init; }
+
+    /// <summary>True when validation status and diagnostics match.</summary>
+    public required bool ValidationEqual { get; init; }
+
+    /// <summary>True when provenance sets match.</summary>
+    public required bool ProvenanceEqual { get; init; }
+
+    /// <summary>Deterministic change labels for clients to render.</summary>
+    public IReadOnlyList<string> Changes { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>Stable preview plan for a mutable Studio package draft.</summary>
+public sealed record StudioPreviewPlan
+{
+    /// <summary>Draft identifier.</summary>
+    public required Guid DraftId { get; init; }
+
+    /// <summary>Package family.</summary>
+    public required StudioPackageFamily Family { get; init; }
+
+    /// <summary>True when preview can run synchronously.</summary>
+    public required bool Synchronous { get; init; }
+
+    /// <summary>True when preview requires a background job.</summary>
+    public required bool RequiresJob { get; init; }
+
+    /// <summary>Preview steps.</summary>
+    public IReadOnlyList<string> Steps { get; init; } = Array.Empty<string>();
+
+    /// <summary>Validation summary used for the preview plan.</summary>
+    public required StudioValidationSummary Validation { get; init; }
+}
+
+/// <summary>Durable rollback request and resulting pointer state.</summary>
+public sealed record StudioRollbackRequest
+{
+    /// <summary>Rollback request identifier.</summary>
+    public required Guid RequestId { get; init; }
+
+    /// <summary>Content item identifier.</summary>
+    public required Guid ItemId { get; init; }
+
+    /// <summary>Version identifier selected as the rollback target.</summary>
+    public required Guid TargetVersionId { get; init; }
+
+    /// <summary>Pointer updated by the rollback.</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("pointer")]
+    public required StudioRollbackPointer Target { get; init; }
+
+    /// <summary>Resulting current/published pointers.</summary>
+    public required StudioContentItemPointers Pointers { get; init; }
+
+    /// <summary>Identifier of the actor that requested rollback.</summary>
+    public string? RequestedBy { get; init; }
+
+    /// <summary>Reason supplied by the actor.</summary>
+    public string? Reason { get; init; }
+
+    /// <summary>Timestamp when the request was created.</summary>
+    public required DateTimeOffset CreatedAt { get; init; }
+}

--- a/src/Honua.Sdk.Studio/Packages/StudioPackageRequests.cs
+++ b/src/Honua.Sdk.Studio/Packages/StudioPackageRequests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+namespace Honua.Sdk.Studio.Packages;
+
+/// <summary>Request body for creating a mutable Studio package draft.</summary>
+public sealed record CreateStudioPackageDraftRequest
+{
+    /// <summary>Optional existing content item id; omit to create a new item.</summary>
+    public Guid? ItemId { get; init; }
+
+    /// <summary>Machine-friendly package key.</summary>
+    public required string PackageKey { get; init; }
+
+    /// <summary>Workspace identifier.</summary>
+    public string? WorkspaceId { get; init; }
+
+    /// <summary>Owner principal identifier.</summary>
+    public string? OwnerId { get; init; }
+
+    /// <summary>Package envelope.</summary>
+    public required StudioPackageEnvelope Envelope { get; init; }
+}
+
+/// <summary>Request body for updating a mutable Studio package draft.</summary>
+public sealed record UpdateStudioPackageDraftRequest
+{
+    /// <summary>Machine-friendly package key.</summary>
+    public required string PackageKey { get; init; }
+
+    /// <summary>Workspace identifier.</summary>
+    public string? WorkspaceId { get; init; }
+
+    /// <summary>Owner principal identifier.</summary>
+    public string? OwnerId { get; init; }
+
+    /// <summary>Package envelope.</summary>
+    public required StudioPackageEnvelope Envelope { get; init; }
+
+    /// <summary>Expected draft generation for optimistic concurrency.</summary>
+    public long? Generation { get; init; }
+}
+
+/// <summary>Request body for saving a draft as an immutable content version.</summary>
+public sealed record SaveStudioContentVersionRequest
+{
+    /// <summary>Optional author change note.</summary>
+    public string? ChangeNote { get; init; }
+}
+
+/// <summary>Request body for comparing two immutable content versions.</summary>
+public sealed record CompareStudioContentVersionsRequest
+{
+    /// <summary>Left-side version identifier.</summary>
+    public required Guid LeftVersionId { get; init; }
+
+    /// <summary>Right-side version identifier.</summary>
+    public required Guid RightVersionId { get; init; }
+}
+
+/// <summary>Request body for creating a publication request.</summary>
+public sealed record CreateStudioPublicationRequest
+{
+    /// <summary>Optional publication intent override.</summary>
+    public StudioPublicationIntent? Intent { get; init; }
+
+    /// <summary>Optional acknowledgement for validation warnings.</summary>
+    public string? WarningAcknowledgement { get; init; }
+}
+
+/// <summary>Request body for rolling a content item pointer back to an immutable version.</summary>
+public sealed record CreateStudioRollbackRequest
+{
+    /// <summary>Version identifier selected as the rollback target.</summary>
+    public required Guid TargetVersionId { get; init; }
+
+    /// <summary>Pointer to update.</summary>
+    [System.Text.Json.Serialization.JsonPropertyName("pointer")]
+    public StudioRollbackPointer Target { get; init; } = StudioRollbackPointer.Current;
+
+    /// <summary>Optional reason supplied by the actor.</summary>
+    public string? Reason { get; init; }
+}

--- a/src/Honua.Sdk.Studio/README.md
+++ b/src/Honua.Sdk.Studio/README.md
@@ -1,9 +1,24 @@
 # Honua.Sdk.Studio
 
-Browser-safe Console Studio read client and shared analysis-report contracts for
-Honua Console hosts (Blazor Web and optional .NET MAUI Blazor Hybrid).
+Browser-safe Console Studio clients and shared contracts for Honua Console hosts
+(Blazor Web and optional .NET MAUI Blazor Hybrid). The package ships three typed
+clients registered by a single `AddHonuaStudio` call:
 
-Install directly when a host only needs to retrieve and render analysis reports:
+- `IHonuaStudioReportsClient` — retrieve/render analysis reports.
+- `IHonuaCapabilityManifestClient` — fetch the server capability manifest
+  (`GET /api/v1/capabilities/manifest`, schema `honua.capability_manifest.v1`) to
+  gate authoring UI and tool exposure on what the connected server supports.
+- `IHonuaStudioPackageClient` — the Studio package lifecycle
+  (`/api/v1/studio/*`): family capabilities, draft CRUD, validate, preview-plan,
+  content-version, publish-request, reopen, and rollback across every in-scope
+  package family (query, map, analysis, dashboard, report, form, app, workflow,
+  gp, etl).
+
+The projected shapes mirror the honua-sdk-js Studio contract
+(`src/studio/{types,validation,capability-manifest}.ts`) so the .NET and JS
+projections do not diverge.
+
+Install:
 
 ```bash
 dotnet add package Honua.Sdk.Studio
@@ -88,12 +103,57 @@ Non-success HTTP statuses throw `HonuaStudioApiException` (preserving
 responses whose body does not satisfy the report contract throw
 `HonuaStudioContractException`.
 
+## Capability manifest
+
+`IHonuaCapabilityManifestClient.GetManifestAsync` fetches the frozen
+`honua.capability_manifest.v1` document into a `CapabilityManifest`. Query
+helpers mirror the JS `getCapability`/`hasCapability` helpers:
+
+```csharp
+var manifest = await capabilities.GetManifestAsync(cancellationToken: ct);
+
+if (manifest.IsAvailable("studio.map")) { /* enable the map builder */ }
+if (!manifest.IsAvailable("studio.ai.generate"))
+{
+    var reason = manifest.GetReasonCode("studio.ai.generate"); // e.g. "entitlement-inactive"
+}
+if (manifest.HasPackageFamily("dashboard")) { /* show the dashboard family */ }
+```
+
+`GetCapability(id)` returns the full `CapabilityEntry` (`Supported`, `Available`,
+`ReasonCode`, `EntitlementKey`, `MinimumEdition`, …). The manifest also carries
+scope, server/environment info, transports, limits, and entitlement policy.
+
+## Studio package lifecycle
+
+`IHonuaStudioPackageClient` covers the family-agnostic lifecycle; the family
+discriminant travels on `StudioPackageEnvelope`. The envelope's `Bindings`,
+`Dependencies`, and `Provenance` collections always serialize as arrays (the
+server rejects null for any of them).
+
+```csharp
+var draft = await packages.CreateDraftAsync(new CreateStudioPackageDraftRequest
+{
+    PackageKey = "my-map",
+    Envelope = new StudioPackageEnvelope
+    {
+        Family = StudioPackageFamily.Map,
+        SchemaVersion = "honua_map_package.v1",
+    },
+}, ct);
+
+var validation = await packages.ValidateDraftAsync(draft.DraftId, ct);
+var plan = await packages.PreviewPlanAsync(draft.DraftId, ct);
+var version = await packages.CreateContentVersionAsync(
+    draft.DraftId, new SaveStudioContentVersionRequest { ChangeNote = "v1" }, ct);
+var publish = await packages.CreatePublishRequestAsync(
+    version.ItemId, version.VersionId, new CreateStudioPublicationRequest(), ct);
+```
+
 ## Scope
 
-This package wraps the analysis-report read path that the server exposes today.
-Map/App package bodies, publication/share/embed, and discrete
-query/dashboard/form/workflow/ETL package clients are gated on server contracts
-that do not yet exist and are tracked as separate, server-paired tickets.
+AI generate endpoints (`/api/v1/studio/{map,app}-packages/generate`) return
+AI-specific result shapes and are tracked separately.
 
 ## Documentation
 

--- a/tests/Honua.Sdk.Studio.Tests/CapabilityManifestClientTests.cs
+++ b/tests/Honua.Sdk.Studio.Tests/CapabilityManifestClientTests.cs
@@ -212,8 +212,14 @@ public sealed class CapabilityManifestClientTests
         => new(new MockHttpHandler(handler)) { BaseAddress = new Uri("https://server.example") };
 
     private static Task<HttpResponseMessage> JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
-        => Task.FromResult(new HttpResponseMessage(statusCode)
+        => Task.FromResult(CreateJsonResponse(json, statusCode));
+
+    private static HttpResponseMessage CreateJsonResponse(string json, HttpStatusCode statusCode)
+    {
+        var response = new HttpResponseMessage(statusCode)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json"),
-        });
+        };
+        return response;
+    }
 }

--- a/tests/Honua.Sdk.Studio.Tests/CapabilityManifestClientTests.cs
+++ b/tests/Honua.Sdk.Studio.Tests/CapabilityManifestClientTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using Honua.Sdk.Studio.Capabilities;
+using Honua.Sdk.Studio.Exceptions;
+using Honua.Sdk.Studio.Extensions;
+using Honua.Sdk.Studio.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.Studio.Tests;
+
+public sealed class CapabilityManifestClientTests
+{
+    private const string ManifestJson = """
+        {
+          "schemaVersion": "honua.capability_manifest.v1",
+          "issuedAt": "2026-07-01T12:00:00Z",
+          "scope": {
+            "tenantId": "acme",
+            "tenantSource": "header",
+            "environment": "prod",
+            "workspaceId": "ws-1",
+            "workspaceAvailable": true,
+            "authenticated": true
+          },
+          "server": {
+            "serverVersion": "1.9.0",
+            "apiVersion": "1",
+            "metadataApiVersion": "2",
+            "metadataSchemaVersion": "honua.metadata.v2",
+            "deploymentEnvironment": "production"
+          },
+          "environment": { "environmentId": "prod", "requested": true, "available": true, "revision": 42 },
+          "packages": {
+            "schemaVersions": ["honua_map_package.v1"],
+            "families": [
+              { "id": "map", "kind": "storage", "schemaVersion": "honua_map_package.v1", "supported": true },
+              { "id": "etl", "kind": "storage", "schemaVersion": "honua_etl_package.v1", "supported": false }
+            ],
+            "storageFamilies": ["map"],
+            "publicationFamilies": ["map"]
+          },
+          "capabilities": [
+            { "id": "studio.map", "category": "studio", "supported": true, "available": true },
+            {
+              "id": "studio.ai.generate",
+              "category": "studio",
+              "supported": true,
+              "available": false,
+              "reasonCode": "entitlement-inactive",
+              "entitlementKey": "ai.generation",
+              "entitlementKeys": ["ai.generation"],
+              "minimumEdition": "enterprise",
+              "messageKey": "capability.ai.disabled"
+            }
+          ],
+          "transports": {
+            "items": [ { "id": "grpc", "supported": true, "available": true } ],
+            "mtlsMode": "disabled",
+            "forwardedClientCertificateEnabled": false
+          },
+          "limits": {
+            "preview": { "maxPreviewSizeBytes": 1048576, "maxPreviewFeatures": 500, "maxPreviewCountScan": 10000 },
+            "query": {
+              "defaultRecordCount": 100, "maxRecordCount": 2000, "maxFeatures": 5000, "maxPageSize": 1000,
+              "queryTimeoutSeconds": 30, "maxBboxAreaSqKm": 100000.0, "maxFilterDepth": 8, "maxSpatialOperations": 4
+            },
+            "analysis": {
+              "maxInputFeatures": 100000, "maxClusters": 50, "maxDbscanEpsMeters": 5000.0, "maxKMeansK": 25,
+              "maxBufferDistanceMeters": 100000.0, "minDensityCellSizeMeters": 10.0, "maxDensityCellSizeMeters": 100000.0,
+              "maxDensityCells": 100000, "maxDWithinDistanceMeters": 50000.0, "maxH3CellsPerQuery": 10000,
+              "maxSpatialOperations": 8, "maxJoins": 4
+            },
+            "publication": { "configuredDeployTargetCount": 2, "gitOpsManifestExportSupported": true },
+            "job": { "configuredWorkloadCount": 3, "availableBackendCount": 1, "supportsCancellation": true, "supportsProgressPolling": true },
+            "upload": {
+              "maxUploadSizeBytes": 104857600, "maxFileSizeBytes": 52428800, "maxConcurrentUploads": 4,
+              "maxQueuedUploads": 16, "maxSecurityScanSizeBytes": 10485760
+            },
+            "streaming": {
+              "maxConcurrentSessions": 100, "maxBufferPerConnection": 1000, "maxSubscriptionsPerSession": 20,
+              "maxSubscriptionIdLength": 128, "maxControlFrameBytes": 65536, "cursorRetentionLimit": 1000,
+              "heartbeatIntervalSeconds": 15.0, "grpcStreamBatchSize": 100
+            },
+            "edit": { "maxFeaturesPerEdit": 1000, "maxEditsPerTransaction": 100, "maxPayloadSizeBytes": 10485760 },
+            "geometry": { "maxVerticesPerGeometry": 100000, "maxGeometrySizeBytes": 1048576, "maxCoordinatePrecision": 15 },
+            "attachment": { "maxAttachmentsPerFeature": 25, "maxAttachmentSizeBytes": 10485760 }
+          },
+          "policies": {
+            "currentEdition": "enterprise",
+            "licenseValidationState": "valid",
+            "licenseValid": true,
+            "callerCapabilities": ["studio.map"],
+            "entitlements": [
+              { "key": "ai.generation", "active": false, "minimumEdition": "enterprise", "reasonCode": "entitlement-inactive" }
+            ],
+            "authorizationNotice": "Authorized for tenant acme."
+          },
+          "links": [ { "rel": "self", "href": "/api/v1/capabilities/manifest", "type": "application/json" } ]
+        }
+        """;
+
+    [Fact]
+    public async Task GetManifestAsync_DeserializesFrozenWireAndSurfacesReasonCodes()
+    {
+        HttpRequestMessage? captured = null;
+        using var http = CreateHttpClient(request =>
+        {
+            captured = request;
+            return JsonResponse(ManifestJson);
+        });
+        var client = new HonuaCapabilityManifestClient(http);
+
+        var manifest = await client.GetManifestAsync();
+
+        Assert.Equal(HttpMethod.Get, captured?.Method);
+        Assert.Equal("/api/v1/capabilities/manifest", captured?.RequestUri?.PathAndQuery);
+        Assert.Equal("honua.capability_manifest.v1", manifest.SchemaVersion);
+        Assert.Equal("acme", manifest.Scope?.TenantId);
+        Assert.Equal("1.9.0", manifest.Server?.ServerVersion);
+        Assert.Equal(42, manifest.Environment?.Revision);
+        Assert.Equal(2, manifest.Capabilities.Count);
+        Assert.Equal("application/json", manifest.Links.Single().MediaType);
+
+        // Query helpers (parity with the JS getCapability / hasCapability helpers).
+        Assert.True(manifest.IsAvailable("studio.map"));
+        Assert.True(manifest.IsSupported("studio.ai.generate"));
+        Assert.False(manifest.IsAvailable("studio.ai.generate"));
+        Assert.Equal("entitlement-inactive", manifest.GetReasonCode("studio.ai.generate"));
+        Assert.Equal("ai.generation", manifest.GetCapability("studio.ai.generate")?.EntitlementKey);
+        Assert.Null(manifest.GetCapability("nope"));
+        Assert.False(manifest.IsAvailable("nope"));
+
+        // Package-family gating.
+        Assert.True(manifest.HasPackageFamily("map"));
+        Assert.False(manifest.HasPackageFamily("etl"));
+
+        // A representative limit round-trips.
+        Assert.Equal(2000, manifest.Limits?.Query?.MaxRecordCount);
+        Assert.False(manifest.Policies?.Entitlements.Single().Active);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_AppendsScopeQueryParameters()
+    {
+        HttpRequestMessage? captured = null;
+        using var http = CreateHttpClient(request =>
+        {
+            captured = request;
+            return JsonResponse(ManifestJson);
+        });
+        var client = new HonuaCapabilityManifestClient(http);
+
+        await client.GetManifestAsync(environment: "prod env", workspaceId: "ws-1");
+
+        Assert.Equal(
+            "/api/v1/capabilities/manifest?environment=prod%20env&workspaceId=ws-1",
+            captured?.RequestUri?.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_ToleratesUnknownAdditiveFields()
+    {
+        const string json = """
+            {
+              "schemaVersion": "honua.capability_manifest.v1",
+              "issuedAt": "2026-07-01T12:00:00Z",
+              "capabilities": [ { "id": "studio.map", "supported": true, "available": true, "futureField": 7 } ],
+              "somethingNew": { "nested": true }
+            }
+            """;
+        using var http = CreateHttpClient(_ => JsonResponse(json));
+        var client = new HonuaCapabilityManifestClient(http);
+
+        var manifest = await client.GetManifestAsync();
+
+        Assert.True(manifest.IsAvailable("studio.map"));
+    }
+
+    [Fact]
+    public async Task GetManifestAsync_ProblemResponse_ThrowsApiException()
+    {
+        using var http = CreateHttpClient(_ => JsonResponse(
+            """{ "title": "Bad Request", "status": 400, "detail": "environment contains unsupported characters." }""",
+            HttpStatusCode.BadRequest));
+        var client = new HonuaCapabilityManifestClient(http);
+
+        var ex = await Assert.ThrowsAsync<HonuaStudioApiException>(() => client.GetManifestAsync());
+
+        Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
+        Assert.Equal("Bad Request", ex.ProblemTitle);
+    }
+
+    [Fact]
+    public void AddHonuaStudio_ResolvesCapabilityManifestClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaStudio(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.IsType<HonuaCapabilityManifestClient>(provider.GetRequiredService<IHonuaCapabilityManifestClient>());
+    }
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        => new(new MockHttpHandler(handler)) { BaseAddress = new Uri("https://server.example") };
+
+    private static Task<HttpResponseMessage> JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+        => Task.FromResult(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        });
+}

--- a/tests/Honua.Sdk.Studio.Tests/StudioPackageClientTests.cs
+++ b/tests/Honua.Sdk.Studio.Tests/StudioPackageClientTests.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text;
+using Honua.Sdk.Studio.Exceptions;
+using Honua.Sdk.Studio.Extensions;
+using Honua.Sdk.Studio.Packages;
+using Honua.Sdk.Studio.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Honua.Sdk.Studio.Tests;
+
+public sealed class StudioPackageClientTests
+{
+    private static readonly Guid DraftId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ItemId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid VersionId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    [Fact]
+    public async Task GetPackageFamiliesAsync_UnwrapsEnvelopeData()
+    {
+        const string json = """
+            {
+              "success": true,
+              "data": {
+                "persistenceMode": "durable",
+                "durable": true,
+                "families": [
+                  {
+                    "family": "map",
+                    "currentSchemaVersion": "honua_map_package.v1",
+                    "format": "honua_map_package.v1",
+                    "supportLevel": "supported",
+                    "supportedOperations": ["draft.create", "validate", "preview-plan", "publish-request.create"],
+                    "validationDepth": "family",
+                    "maxPackageBytes": 1048576,
+                    "previewSupported": true,
+                    "publishSupported": true
+                  }
+                ]
+              },
+              "timestamp": "2026-07-01T12:00:00Z"
+            }
+            """;
+        HttpRequestMessage? captured = null;
+        using var http = CreateHttpClient(request =>
+        {
+            captured = request;
+            return JsonResponse(json);
+        });
+        var client = new HonuaStudioPackageClient(http);
+
+        var capabilities = await client.GetPackageFamiliesAsync();
+
+        Assert.Equal("/api/v1/studio/package-families", captured?.RequestUri?.PathAndQuery);
+        Assert.Equal(StudioPackagePersistenceMode.Durable, capabilities.PersistenceMode);
+        var family = Assert.Single(capabilities.Families);
+        Assert.Equal(StudioPackageFamily.Map, family.Family);
+        Assert.Equal(StudioPackageSupportLevel.Supported, family.SupportLevel);
+        Assert.Contains(StudioPackageOperation.PreviewPlan, family.SupportedOperations);
+    }
+
+    [Fact]
+    public async Task CreateDraftAsync_SerializesEnvelopeCollectionsAsArrays()
+    {
+        string? sentBody = null;
+        using var http = CreateHttpClient(async request =>
+        {
+            sentBody = await request.Content!.ReadAsStringAsync();
+            return await JsonResponse(DraftEnvelope());
+        });
+        var client = new HonuaStudioPackageClient(http);
+
+        var request = new CreateStudioPackageDraftRequest
+        {
+            PackageKey = "my-map",
+            Envelope = new StudioPackageEnvelope
+            {
+                Family = StudioPackageFamily.Map,
+                SchemaVersion = "honua_map_package.v1",
+            },
+        };
+
+        var draft = await client.CreateDraftAsync(request);
+
+        Assert.NotNull(sentBody);
+        // The server rejects null bindings/dependencies/provenance; they must
+        // serialize as arrays even when empty.
+        Assert.Contains("\"bindings\":[]", sentBody, StringComparison.Ordinal);
+        Assert.Contains("\"dependencies\":[]", sentBody, StringComparison.Ordinal);
+        Assert.Contains("\"provenance\":[]", sentBody, StringComparison.Ordinal);
+        Assert.Contains("\"family\":\"map\"", sentBody, StringComparison.Ordinal);
+        Assert.Equal(DraftId, draft.DraftId);
+        Assert.Equal(StudioPackageFamily.Map, draft.Family);
+    }
+
+    [Fact]
+    public async Task ValidateDraftAsync_PostsAndReturnsSummary()
+    {
+        const string json = """
+            {
+              "success": true,
+              "data": {
+                "status": "warning",
+                "diagnostics": [ { "code": "map.layer.unbound", "severity": "warning", "message": "Layer is unbound." } ],
+                "unsupportedCapabilities": [],
+                "generatedAt": "2026-07-01T12:00:00Z"
+              },
+              "timestamp": "2026-07-01T12:00:00Z"
+            }
+            """;
+        HttpRequestMessage? captured = null;
+        using var http = CreateHttpClient(request =>
+        {
+            captured = request;
+            return JsonResponse(json);
+        });
+        var client = new HonuaStudioPackageClient(http);
+
+        var summary = await client.ValidateDraftAsync(DraftId);
+
+        Assert.Equal(HttpMethod.Post, captured?.Method);
+        Assert.Equal($"/api/v1/studio/package-drafts/{DraftId}/validate", captured?.RequestUri?.PathAndQuery);
+        Assert.Equal(StudioPackageValidationStatus.Warning, summary.Status);
+        Assert.Equal(StudioPackageDiagnosticSeverity.Warning, summary.Diagnostics.Single().Severity);
+    }
+
+    [Fact]
+    public async Task PreviewPlanAsync_ReturnsPlan()
+    {
+        const string json = """
+            {
+              "success": true,
+              "data": {
+                "draftId": "11111111-1111-1111-1111-111111111111",
+                "family": "map",
+                "synchronous": true,
+                "requiresJob": false,
+                "steps": ["compose", "render"],
+                "validation": { "status": "valid" }
+              },
+              "timestamp": "2026-07-01T12:00:00Z"
+            }
+            """;
+        using var http = CreateHttpClient(_ => JsonResponse(json));
+        var client = new HonuaStudioPackageClient(http);
+
+        var plan = await client.PreviewPlanAsync(DraftId);
+
+        Assert.True(plan.Synchronous);
+        Assert.Equal(2, plan.Steps.Count);
+        Assert.Equal(StudioPackageValidationStatus.Valid, plan.Validation.Status);
+    }
+
+    [Fact]
+    public async Task CreatePublishRequestAsync_PostsToVersionScopedRoute()
+    {
+        const string json = """
+            {
+              "success": true,
+              "data": {
+                "requestId": "44444444-4444-4444-4444-444444444444",
+                "itemId": "22222222-2222-2222-2222-222222222222",
+                "versionId": "33333333-3333-3333-3333-333333333333",
+                "status": "accepted",
+                "validation": { "status": "valid" },
+                "createdAt": "2026-07-01T12:00:00Z"
+              },
+              "timestamp": "2026-07-01T12:00:00Z"
+            }
+            """;
+        HttpRequestMessage? captured = null;
+        using var http = CreateHttpClient(request =>
+        {
+            captured = request;
+            return JsonResponse(json, HttpStatusCode.Created);
+        });
+        var client = new HonuaStudioPackageClient(http);
+
+        var publication = await client.CreatePublishRequestAsync(
+            ItemId,
+            VersionId,
+            new CreateStudioPublicationRequest { WarningAcknowledgement = "reviewed" });
+
+        Assert.Equal(
+            $"/api/v1/studio/content-items/{ItemId}/versions/{VersionId}/publish-requests",
+            captured?.RequestUri?.PathAndQuery);
+        Assert.Equal(StudioPublicationRequestStatus.Accepted, publication.Status);
+    }
+
+    [Fact]
+    public async Task RollbackAsync_SerializesPointerField()
+    {
+        string? sentBody = null;
+        using var http = CreateHttpClient(async request =>
+        {
+            sentBody = await request.Content!.ReadAsStringAsync();
+            return await JsonResponse("""
+                {
+                  "success": true,
+                  "data": {
+                    "requestId": "44444444-4444-4444-4444-444444444444",
+                    "itemId": "22222222-2222-2222-2222-222222222222",
+                    "targetVersionId": "33333333-3333-3333-3333-333333333333",
+                    "pointer": "both",
+                    "pointers": { "itemId": "22222222-2222-2222-2222-222222222222" },
+                    "createdAt": "2026-07-01T12:00:00Z"
+                  },
+                  "timestamp": "2026-07-01T12:00:00Z"
+                }
+                """, HttpStatusCode.Created);
+        });
+        var client = new HonuaStudioPackageClient(http);
+
+        var rollback = await client.RollbackAsync(
+            ItemId,
+            new CreateStudioRollbackRequest { TargetVersionId = VersionId, Target = StudioRollbackPointer.Both });
+
+        Assert.NotNull(sentBody);
+        Assert.Contains("\"pointer\":\"both\"", sentBody, StringComparison.Ordinal);
+        Assert.Equal(StudioRollbackPointer.Both, rollback.Target);
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_ThrowsApiExceptionOnConflict()
+    {
+        using var http = CreateHttpClient(_ => JsonResponse(
+            """{ "title": "Conflict", "status": 409, "detail": "Draft is locked." }""",
+            HttpStatusCode.Conflict));
+        var client = new HonuaStudioPackageClient(http);
+
+        var ex = await Assert.ThrowsAsync<HonuaStudioApiException>(() => client.DeleteDraftAsync(DraftId));
+
+        Assert.Equal(HttpStatusCode.Conflict, ex.StatusCode);
+        Assert.Equal("Conflict", ex.ProblemTitle);
+    }
+
+    [Fact]
+    public async Task ListVersionsAsync_MissingDataPayload_ThrowsContractException()
+    {
+        using var http = CreateHttpClient(_ => JsonResponse("""{ "success": true, "timestamp": "2026-07-01T12:00:00Z" }"""));
+        var client = new HonuaStudioPackageClient(http);
+
+        var ex = await Assert.ThrowsAsync<HonuaStudioContractException>(() => client.ListVersionsAsync(ItemId));
+
+        Assert.Equal("ListVersions", ex.Operation);
+    }
+
+    [Fact]
+    public void AddHonuaStudio_ResolvesPackageClient()
+    {
+        var services = new ServiceCollection();
+        services.AddHonuaStudio(options =>
+        {
+            options.BaseAddress = new Uri("https://localhost:5001");
+            options.EnableRetry = false;
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.IsType<HonuaStudioPackageClient>(provider.GetRequiredService<IHonuaStudioPackageClient>());
+    }
+
+    private static string DraftEnvelope() => """
+        {
+          "success": true,
+          "data": {
+            "draftId": "11111111-1111-1111-1111-111111111111",
+            "itemId": "22222222-2222-2222-2222-222222222222",
+            "packageKey": "my-map",
+            "family": "map",
+            "envelope": { "family": "map", "schemaVersion": "honua_map_package.v1", "bindings": [], "dependencies": [], "provenance": [], "validation": { "status": "not-validated" } },
+            "generation": 1,
+            "createdAt": "2026-07-01T12:00:00Z",
+            "updatedAt": "2026-07-01T12:00:00Z"
+          },
+          "timestamp": "2026-07-01T12:00:00Z"
+        }
+        """;
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        => new(new MockHttpHandler(handler)) { BaseAddress = new Uri("https://server.example") };
+
+    private static Task<HttpResponseMessage> JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
+        => Task.FromResult(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        });
+}

--- a/tests/Honua.Sdk.Studio.Tests/StudioPackageClientTests.cs
+++ b/tests/Honua.Sdk.Studio.Tests/StudioPackageClientTests.cs
@@ -283,8 +283,14 @@ public sealed class StudioPackageClientTests
         => new(new MockHttpHandler(handler)) { BaseAddress = new Uri("https://server.example") };
 
     private static Task<HttpResponseMessage> JsonResponse(string json, HttpStatusCode statusCode = HttpStatusCode.OK)
-        => Task.FromResult(new HttpResponseMessage(statusCode)
+        => Task.FromResult(CreateJsonResponse(json, statusCode));
+
+    private static HttpResponseMessage CreateJsonResponse(string json, HttpStatusCode statusCode)
+    {
+        var response = new HttpResponseMessage(statusCode)
         {
             Content = new StringContent(json, Encoding.UTF8, "application/json"),
-        });
+        };
+        return response;
+    }
 }


### PR DESCRIPTION
## Summary

Completes the **Track C1 remainder** that #169 left out. `Honua.Sdk.Studio`
previously shipped only the analysis-report read client; this PR adds the two
missing keystone .NET projections the console Studio binding (Track D,
honua-console #265/#266) depends on:

1. **Capability-manifest client (keystone for D2)** — `IHonuaCapabilityManifestClient` / `CapabilityManifest`.
2. **Studio package-family lifecycle clients (for D1 shim replacement)** — `IHonuaStudioPackageClient` + DTOs.

Both extend the existing `Honua.Sdk.Studio` project and are registered by the
existing `AddHonuaStudio` call. The analysis-report client is untouched.

## Changes Made

- Added `IHonuaCapabilityManifestClient` + `HonuaCapabilityManifestClient` fetching `GET /api/v1/capabilities/manifest` (schema `honua.capability_manifest.v1`) into a faithful `CapabilityManifest` graph (scope, server, environment, packages, capabilities, transports, limits, policies, links).
- Query helpers on `CapabilityManifest`: `GetCapability(id)`, `IsAvailable(id)`, `IsSupported(id)`, `GetReasonCode(id)`, `HasPackageFamily(id)` — parity with the JS `getCapability`/`hasCapability` helpers (`enabled` ↔ `available`).
- Added `IHonuaStudioPackageClient` + `HonuaStudioPackageClient` covering `/api/v1/studio/*`: package-families, draft CRUD, validate, preview-plan, content-versions (list/get/compare), publish-request, reopen, and rollback. The family discriminant travels on the envelope, so one client serves every in-scope family (query, map, analysis, dashboard, report, form, app, workflow, gp, etl).
- Added the package DTOs (`StudioPackageEnvelope` + bindings/dependencies/validation/publication-intent/provenance, drafts, versions, publish/rollback requests, preview plan, family capabilities, comparison) and the `StudioApiResponse<T>` envelope. Envelope `Bindings`/`Dependencies`/`Provenance` always serialize as arrays (server rejects null).
- Mirrored the server string enums exactly via `[JsonStringEnumMemberName]` (e.g. `gp`, `not-validated`, `preview-plan`).
- Source-generated JSON contexts (`CapabilityManifestJsonContext`, `StudioPackageJsonContext`) for trimming/AOT safety; shared `StudioHttpResponseReader` for RFC 7807 problem mapping and contract-drift detection.
- `AddHonuaStudio` now registers all three typed clients over the shared `ConfigureHonuaRestHttpClient` transport (credential-safe no-redirect + resilience).
- Added 21 unit tests (mock HTTP layer, no live server) and refreshed the package README + description.

## Cross-SDK parity

Projected shapes mirror honua-sdk-js `src/studio/{types,validation,capability-manifest}.ts` (`StudioCapabilityManifest`/`StudioCapabilityEntry`, package families, validation envelope) so the .NET and JS projections do not diverge. The .NET DTOs additionally deserialize the full frozen server wire.

## Breaking Changes

None. Purely additive public surface; `AddHonuaStudio` signature is unchanged.

## Testing

- [x] `dotnet test tests/Honua.Sdk.Studio.Tests` Release, warnings-as-errors — 28 passed (7 existing + 21 new).
- [x] `dotnet format --verify-no-changes` clean on the Studio project and test project.
- Tests mock the HTTP layer (`MockHttpHandler`); no live server required.

## Follow-ups

- AI generate endpoints (`/api/v1/studio/{map,app}-packages/generate`) return AI-specific result shapes and are out of scope here.

Closes #252
Refs honua-io/honua-release#32
