### PR TITLE
fix: integrate workflow and SDK audit fixes

### DIFF
--- a/.github/actions/setup-dotnet-and-nuget/action.yml
+++ b/.github/actions/setup-dotnet-and-nuget/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Cache NuGet packages
-      uses: actions/cache@v5
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
       with:
         path: ~/.nuget/packages
         key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -28,7 +28,7 @@ runs:
           ${{ github.repository }}-${{ runner.os }}-nuget-
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ permissions:
   packages: read
 
 jobs:
+  workflow-validation:
+    name: GitHub Workflow Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Validate workflow syntax
+        shell: bash
+        run: |
+          docker run --rm \
+            -v "${PWD}:/repo" \
+            -w /repo \
+            docker.io/rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -no-color -shellcheck= -pyflakes=
+
   security-audit:
     name: Security Audit (NuGet)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     name: GitHub Workflow Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Validate workflow syntax
         shell: bash
@@ -36,10 +36,10 @@ jobs:
     name: Security Audit (NuGet)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -47,7 +47,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -89,10 +89,10 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -100,7 +100,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: code-coverage-${{ github.run_id }}
           path: ./coverage/report
@@ -192,12 +192,12 @@ jobs:
     name: API Compatibility
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -305,7 +305,7 @@ jobs:
             tests:
               - tests/Honua.Sdk.MetaSmoke.Tests/Honua.Sdk.MetaSmoke.Tests.csproj
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup .NET + NuGet
         uses: ./.github/actions/setup-dotnet-and-nuget
@@ -337,7 +337,7 @@ jobs:
     name: Browser WASM Smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup .NET + NuGet
         uses: ./.github/actions/setup-dotnet-and-nuget
@@ -347,7 +347,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.cache/ms-playwright
           key: ${{ github.repository }}-${{ runner.os }}-playwright-${{ hashFiles('tests/Honua.Sdk.BrowserSmoke.Tests/Honua.Sdk.BrowserSmoke.Tests.csproj') }}
@@ -372,7 +372,7 @@ jobs:
     name: Admin Bootstrap Sample
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Setup .NET + NuGet
         uses: ./.github/actions/setup-dotnet-and-nuget

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
     name: Analyze (csharp)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -38,7 +38,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -46,7 +46,7 @@ jobs:
         run: dotnet nuget update source github-honua --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           languages: csharp
           queries: security-and-quality
@@ -55,6 +55,6 @@ jobs:
         run: dotnet build Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           category: "/language:csharp"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -66,7 +66,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       # 1. Enforce the fixture/schema pin equality before doing anything else.
       - name: Verify fixture version matches pinned Geospatial.Grpc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -39,7 +39,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           global-json-file: global.json
 
@@ -62,15 +62,15 @@ jobs:
 
       - name: Configure GitHub Pages
         if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
       - name: Upload DocFX site artifact
         if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs/_site
 
       - name: Deploy to GitHub Pages
         id: deployment
         if: vars.DEPLOY_GITHUB_PAGES == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -330,9 +330,10 @@ jobs:
           # not trusted by default — `dotnet nuget verify` would reject it (NU3018). Register
           # the author signer (allowing the untrusted self-signed root) JUST for verification;
           # the EXIT trap removes it again immediately after.
-          first_pkg="$(ls ./nupkgs/*.nupkg | head -n1)"
+          nupkg_files=(./nupkgs/*.nupkg)
+          first_pkg="${nupkg_files[0]}"
           dotnet nuget trust author honua-sdk-self "${first_pkg}" --allow-untrusted-root
-          for nupkg in ./nupkgs/*.nupkg; do
+          for nupkg in "${nupkg_files[@]}"; do
             dotnet nuget verify "${nupkg}"
           done
 

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -31,12 +31,12 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -44,7 +44,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -296,7 +296,7 @@ jobs:
           done
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-sboms
           path: ./sboms/**/*.cdx.json
@@ -631,7 +631,7 @@ jobs:
           popd >/dev/null
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-packages
           path: ./nupkgs/*.nupkg
@@ -672,13 +672,13 @@ jobs:
       packages: write
     steps:
       - name: Download package artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: ${{ github.event.repository.name }}-publish-dotnet-sdk-${{ github.run_id }}-packages
           path: ./nupkgs
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,10 +15,12 @@ permissions:
   actions: read
 
 jobs:
+  # Pin shared security workflows to an immutable commit so this repo is not
+  # exposed to parser or behavior drift on honua-io/.github@main.
   trivy:
-    uses: honua-io/.github/.github/workflows/reusable-trivy.yml@main
+    uses: honua-io/.github/.github/workflows/reusable-trivy.yml@aebfacd3f3c6b551fa9bf703501c0a12a050faf3
     with:
       scan-type: fs
 
   scorecard:
-    uses: honua-io/.github/.github/workflows/reusable-scorecard.yml@main
+    uses: honua-io/.github/.github/workflows/reusable-scorecard.yml@aebfacd3f3c6b551fa9bf703501c0a12a050faf3

--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -48,10 +48,10 @@ jobs:
       TEST_RESULTS_FILE: staging-integration.trx
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ~/.nuget/packages
           key: ${{ github.repository }}-${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -59,7 +59,7 @@ jobs:
             ${{ github.repository }}-${{ runner.os }}-nuget-
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload staging test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.event.repository.name }}-staging-integration-${{ github.run_id }}-test-results
           path: ${{ github.workspace }}/artifacts/test-results/
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload staging evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ github.event.repository.name }}-staging-integration-${{ github.run_id }}-evidence
           path: ${{ github.workspace }}/artifacts/evidence/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
   </ItemGroup>
 

--- a/src/Honua.Sdk.Admin/AdminHttpHelper.cs
+++ b/src/Honua.Sdk.Admin/AdminHttpHelper.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Honua. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
+
+using System.Net;
+using System.Text.Json;
+using Honua.Sdk.Abstractions;
+using Honua.Sdk.Admin.Exceptions;
+
+namespace Honua.Sdk.Admin;
+
+internal static class AdminHttpHelper
+{
+    public static Task EnsureSuccessAsync(
+        HttpResponseMessage response,
+        string body,
+        string fallbackMessage,
+        bool inspectGeoServicesErrorEnvelope = false)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            if (inspectGeoServicesErrorEnvelope)
+            {
+                EnsureGeoServicesEnvelopeSucceeded(response.StatusCode, body);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        var message = TryExtractErrorMessage(body, preferGeoServicesError: inspectGeoServicesErrorEnvelope) ??
+            response.ReasonPhrase ??
+            fallbackMessage;
+        throw new HonuaAdminApiException(response.StatusCode, message, body);
+    }
+
+    public static void EnsureEnvelopeSucceeded(HttpResponseMessage response, string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            if (doc.RootElement.TryGetProperty("success", out var success) &&
+                success.ValueKind == JsonValueKind.False)
+            {
+                var message = TryExtractErrorMessage(body) ?? "API response indicated failure.";
+                throw new HonuaAdminApiException(response.StatusCode, message, body);
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON or invalid JSON envelope, ignore.
+        }
+    }
+
+    public static string? TryExtractErrorMessage(string body, bool preferGeoServicesError = false)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            if (preferGeoServicesError &&
+                TryGetErrorObjectMessage(doc.RootElement, out var preferredErrorMessage))
+            {
+                return preferredErrorMessage;
+            }
+
+            if (doc.RootElement.TryGetProperty("message", out var message) &&
+                message.ValueKind == JsonValueKind.String)
+            {
+                return message.GetString();
+            }
+
+            if (TryGetErrorObjectMessage(doc.RootElement, out var errorMessage))
+            {
+                return errorMessage;
+            }
+        }
+        catch (JsonException)
+        {
+            // Not JSON, that's fine.
+            return null;
+        }
+
+        return HonuaProblemDetailsParser.TryParse(body, out var problem)
+            ? problem?.Detail ?? problem?.Title
+            : null;
+    }
+
+    private static void EnsureGeoServicesEnvelopeSucceeded(HttpStatusCode statusCode, string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                !doc.RootElement.TryGetProperty("error", out var errorElement) ||
+                errorElement.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            var message = TryGetString(errorElement, "message") ?? "Geocoding service returned an error.";
+            var responseStatus = statusCode;
+            if (errorElement.TryGetProperty("code", out var codeProperty) &&
+                codeProperty.TryGetInt32(out var errorCode) &&
+                errorCode is >= 100 and <= 599)
+            {
+                responseStatus = (HttpStatusCode)errorCode;
+            }
+
+            throw new HonuaAdminApiException(responseStatus, message, body);
+        }
+        catch (JsonException)
+        {
+            // Not JSON, ignore.
+        }
+    }
+
+    private static bool TryGetErrorObjectMessage(JsonElement root, out string? message)
+    {
+        message = null;
+        if (root.TryGetProperty("error", out var errorElement) &&
+            errorElement.ValueKind == JsonValueKind.Object)
+        {
+            message = TryGetString(errorElement, "message");
+            return message is not null;
+        }
+
+        return false;
+    }
+
+    private static string? TryGetString(JsonElement element, string propertyName)
+        => element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+}

--- a/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
+++ b/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
@@ -37,7 +37,14 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         var normalizedOptions = NormalizeOptions(options);
         var metadata = await LoadMetadataIndexAsync(cancellationToken).ConfigureAwait(false);
-        var services = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
+        var serviceLoad = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
+        var services = serviceLoad.Services;
+
+        if (CanPageLayersFromSummaries(normalizedOptions))
+        {
+            return await SearchLayerPageFromSummariesAsync(serviceLoad, metadata, normalizedOptions, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         var items = new List<CatalogItem>();
         if (IncludesKind(normalizedOptions, CatalogItemKind.Service))
@@ -47,7 +54,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
 
         if (IncludesKind(normalizedOptions, CatalogItemKind.Layer))
         {
-            var layers = await LoadLayersAsync(services, metadata, cancellationToken).ConfigureAwait(false);
+            var layers = await LoadLayersAsync(serviceLoad, metadata, cancellationToken).ConfigureAwait(false);
             items.AddRange(layers.Select(ToItem));
         }
 
@@ -71,7 +78,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         var normalizedOptions = NormalizeOptions(options);
         var metadata = await LoadMetadataIndexAsync(cancellationToken).ConfigureAwait(false);
-        var services = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
+        var services = (await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false)).Services;
         return ApplyDetailQuery(services, WithoutKindFilter(normalizedOptions), ToItem, static item => item.Service!);
     }
 
@@ -81,7 +88,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
 
         var metadata = await LoadMetadataIndexAsync(cancellationToken).ConfigureAwait(false);
-        var services = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
+        var services = (await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false)).Services;
         return services.FirstOrDefault(service => string.Equals(service.Name, serviceName, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -92,8 +99,8 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         var normalizedOptions = NormalizeOptions(options);
         var metadata = await LoadMetadataIndexAsync(cancellationToken).ConfigureAwait(false);
-        var services = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
-        var layers = await LoadLayersAsync(services, metadata, cancellationToken).ConfigureAwait(false);
+        var serviceLoad = await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false);
+        var layers = await LoadLayersAsync(serviceLoad, metadata, cancellationToken).ConfigureAwait(false);
         return ApplyDetailQuery(layers, WithoutKindFilter(normalizedOptions), ToItem, static item => item.Layer!);
     }
 
@@ -103,7 +110,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
         ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
 
         var metadata = await LoadMetadataIndexAsync(cancellationToken).ConfigureAwait(false);
-        var service = (await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false))
+        var service = (await LoadServicesAsync(metadata, cancellationToken).ConfigureAwait(false)).Services
             .FirstOrDefault(candidate => string.Equals(candidate.Name, serviceName, StringComparison.OrdinalIgnoreCase));
         if (service is null)
         {
@@ -163,7 +170,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
         return resource is null ? null : TryBuildSourceDescriptor(resource);
     }
 
-    private async Task<IReadOnlyList<CatalogService>> LoadServicesAsync(
+    private async Task<CatalogServiceLoadResult> LoadServicesAsync(
         CatalogMetadataIndex metadata,
         CancellationToken cancellationToken)
     {
@@ -173,33 +180,40 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
             cancellationToken).ConfigureAwait(false) ?? [];
 
         var services = new List<CatalogService>(summaries.Length);
+        var featureServerInfo = new Dictionary<string, CatalogFeatureServerServiceInfo?>(StringComparer.OrdinalIgnoreCase);
         foreach (var summary in summaries.OrderBy(static service => service.ServiceName, StringComparer.OrdinalIgnoreCase))
         {
             var serviceMetadata = metadata.FindService(summary.ServiceName);
-            var serviceInfo = HasServiceType(summary.EnabledProtocols, FeatureServerProtocol)
+            var isFeatureServer = HasServiceType(summary.EnabledProtocols, FeatureServerProtocol);
+            var serviceInfo = isFeatureServer
                 ? await GetFeatureServerServiceInfoOrNullAsync(summary.ServiceName, cancellationToken).ConfigureAwait(false)
                 : null;
+
+            if (isFeatureServer)
+            {
+                featureServerInfo[summary.ServiceName] = serviceInfo;
+            }
 
             services.Add(BuildCatalogService(summary, serviceInfo, serviceMetadata));
         }
 
-        return services.AsReadOnly();
+        return new CatalogServiceLoadResult(services.AsReadOnly(), featureServerInfo);
     }
 
     private async Task<IReadOnlyList<CatalogLayer>> LoadLayersAsync(
-        IReadOnlyList<CatalogService> services,
+        CatalogServiceLoadResult serviceLoad,
         CatalogMetadataIndex metadata,
         CancellationToken cancellationToken)
     {
         var layers = new List<CatalogLayer>();
-        foreach (var service in services)
+        foreach (var service in serviceLoad.Services)
         {
             if (!HasServiceType(service.ServiceTypes, FeatureServerProtocol))
             {
                 continue;
             }
 
-            var serviceInfo = await GetFeatureServerServiceInfoOrNullAsync(service.Name, cancellationToken).ConfigureAwait(false);
+            var serviceInfo = serviceLoad.GetFeatureServerInfo(service);
             if (serviceInfo?.Layers is not { Count: > 0 })
             {
                 continue;
@@ -216,6 +230,61 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
         }
 
         return layers.AsReadOnly();
+    }
+
+    private async Task<CatalogSearchResult> SearchLayerPageFromSummariesAsync(
+        CatalogServiceLoadResult serviceLoad,
+        CatalogMetadataIndex metadata,
+        CatalogQueryOptions options,
+        CancellationToken cancellationToken)
+    {
+        var offset = options.Offset.GetValueOrDefault();
+        var limit = options.Limit.GetValueOrDefault();
+        var selected = new List<(CatalogService Service, CatalogFeatureServerLayerSummary Layer)>(limit);
+        var totalCount = 0;
+
+        foreach (var service in EnumerateServicesForLayerSummaryPage(serviceLoad, options))
+        {
+            if (!MatchesAny(service.ServiceTypes, options.ServiceTypes))
+            {
+                continue;
+            }
+
+            var serviceInfo = serviceLoad.GetFeatureServerInfo(service);
+            if (serviceInfo?.Layers is not { Count: > 0 })
+            {
+                continue;
+            }
+
+            foreach (var layerSummary in serviceInfo.Layers)
+            {
+                if (totalCount >= offset && selected.Count < limit)
+                {
+                    selected.Add((service, layerSummary));
+                }
+
+                totalCount++;
+            }
+        }
+
+        var items = new List<CatalogItem>(selected.Count);
+        foreach (var (service, layerSummary) in selected)
+        {
+            var layer = await GetFeatureServerLayerInfoOrNullAsync(service.Name, layerSummary.Id, cancellationToken)
+                .ConfigureAwait(false);
+            if (layer is not null)
+            {
+                items.Add(ToItem(BuildCatalogLayer(service, layer, metadata)));
+            }
+        }
+
+        return new CatalogSearchResult
+        {
+            Items = items.AsReadOnly(),
+            TotalCount = totalCount,
+            Offset = offset,
+            NextOffset = limit + offset < totalCount ? limit + offset : null
+        };
     }
 
     private async Task<CatalogMetadataIndex> LoadMetadataIndexAsync(CancellationToken cancellationToken)
@@ -632,6 +701,29 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     private static bool IncludesKind(CatalogQueryOptions options, CatalogItemKind kind)
         => options.Kinds is null or { Count: 0 } || options.Kinds.Contains(kind);
 
+    private static bool CanPageLayersFromSummaries(CatalogQueryOptions options)
+        => options.Limit.HasValue &&
+           HasOnlyKind(options, CatalogItemKind.Layer) &&
+           string.IsNullOrWhiteSpace(options.Query) &&
+           IsEmpty(options.Tags) &&
+           string.IsNullOrWhiteSpace(options.Owner) &&
+           string.IsNullOrWhiteSpace(options.Namespace) &&
+           IsEmpty(options.GeometryTypes) &&
+           IsEmpty(options.Capabilities) &&
+           options.SortBy is CatalogSortBy.Kind or CatalogSortBy.ServiceName;
+
+    private static bool HasOnlyKind(CatalogQueryOptions options, CatalogItemKind kind)
+        => options.Kinds is { Count: 1 } && options.Kinds[0] == kind;
+
+    private static bool IsEmpty<T>(IReadOnlyList<T>? values) => values is null or { Count: 0 };
+
+    private static IEnumerable<CatalogService> EnumerateServicesForLayerSummaryPage(
+        CatalogServiceLoadResult serviceLoad,
+        CatalogQueryOptions options)
+        => options is { SortBy: CatalogSortBy.ServiceName, SortDirection: CatalogSortDirection.Descending }
+            ? serviceLoad.Services.Reverse()
+            : serviceLoad.Services;
+
     private static CatalogQueryOptions NormalizeOptions(CatalogQueryOptions? options)
     {
         var normalized = options ?? new CatalogQueryOptions();
@@ -658,8 +750,8 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Catalog request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, typeInfo);
         return envelope is not null ? envelope.Data : default;
@@ -672,85 +764,9 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Catalog request failed").ConfigureAwait(false);
 
         return JsonSerializer.Deserialize(body, typeInfo);
-    }
-
-    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string body)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        var message = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "Catalog request failed";
-        throw new HonuaAdminApiException(response.StatusCode, message, body);
-    }
-
-    private static void EnsureEnvelopeSucceeded(HttpResponseMessage response, string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
-                doc.RootElement.TryGetProperty("success", out var success) &&
-                success.ValueKind == JsonValueKind.False)
-            {
-                var message = TryExtractErrorMessage(body) ?? "API response indicated failure.";
-                throw new HonuaAdminApiException(response.StatusCode, message, body);
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON or invalid JSON envelope, ignore.
-        }
-    }
-
-    private static string? TryExtractErrorMessage(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
-            {
-                return msg.GetString();
-            }
-
-            if (doc.RootElement.TryGetProperty("error", out var error) &&
-                error.ValueKind == JsonValueKind.Object &&
-                error.TryGetProperty("message", out var errorMessage) &&
-                errorMessage.ValueKind == JsonValueKind.String)
-            {
-                return errorMessage.GetString();
-            }
-
-            if (doc.RootElement.TryGetProperty("detail", out var detail) && detail.ValueKind == JsonValueKind.String)
-            {
-                return detail.GetString();
-            }
-
-            if (doc.RootElement.TryGetProperty("title", out var title) && title.ValueKind == JsonValueKind.String)
-            {
-                return title.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON, that's fine.
-        }
-
-        return null;
     }
 
     private static bool TryReadSourceDescriptor(JsonElement spec, out SourceDescriptor descriptor)
@@ -988,6 +1004,24 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     }
 
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
+
+    private sealed class CatalogServiceLoadResult
+    {
+        public CatalogServiceLoadResult(
+            IReadOnlyList<CatalogService> services,
+            IReadOnlyDictionary<string, CatalogFeatureServerServiceInfo?> featureServerInfoByServiceName)
+        {
+            Services = services;
+            FeatureServerInfoByServiceName = featureServerInfoByServiceName;
+        }
+
+        public IReadOnlyList<CatalogService> Services { get; }
+
+        private IReadOnlyDictionary<string, CatalogFeatureServerServiceInfo?> FeatureServerInfoByServiceName { get; }
+
+        public CatalogFeatureServerServiceInfo? GetFeatureServerInfo(CatalogService service)
+            => FeatureServerInfoByServiceName.TryGetValue(service.Name, out var serviceInfo) ? serviceInfo : null;
+    }
 
     private sealed class CatalogMetadataIndex
     {

--- a/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
+++ b/src/Honua.Sdk.Admin/Catalog/HonuaCatalogClient.cs
@@ -240,7 +240,7 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
     {
         var offset = options.Offset.GetValueOrDefault();
         var limit = options.Limit.GetValueOrDefault();
-        var selected = new List<(CatalogService Service, CatalogFeatureServerLayerSummary Layer)>(limit);
+        var items = new List<CatalogItem>(limit);
         var totalCount = 0;
 
         foreach (var service in EnumerateServicesForLayerSummaryPage(serviceLoad, options))
@@ -258,23 +258,19 @@ public sealed class HonuaCatalogClient : IHonuaCatalogClient
 
             foreach (var layerSummary in serviceInfo.Layers)
             {
-                if (totalCount >= offset && selected.Count < limit)
+                var layer = await GetFeatureServerLayerInfoOrNullAsync(service.Name, layerSummary.Id, cancellationToken)
+                    .ConfigureAwait(false);
+                if (layer is null)
                 {
-                    selected.Add((service, layerSummary));
+                    continue;
+                }
+
+                if (totalCount >= offset && items.Count < limit)
+                {
+                    items.Add(ToItem(BuildCatalogLayer(service, layer, metadata)));
                 }
 
                 totalCount++;
-            }
-        }
-
-        var items = new List<CatalogItem>(selected.Count);
-        foreach (var (service, layerSummary) in selected)
-        {
-            var layer = await GetFeatureServerLayerInfoOrNullAsync(service.Name, layerSummary.Id, cancellationToken)
-                .ConfigureAwait(false);
-            if (layer is not null)
-            {
-                items.Add(ToItem(BuildCatalogLayer(service, layer, metadata)));
             }
         }
 

--- a/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
+++ b/src/Honua.Sdk.Admin/Geocoding/HonuaGeocodingClient.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Collections.ObjectModel;
 using System.Text.Json;
-using Honua.Sdk.Admin.Exceptions;
 
 namespace Honua.Sdk.Admin.Geocoding;
 
@@ -83,7 +82,7 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
 
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Geocoding request failed", inspectGeoServicesErrorEnvelope: true).ConfigureAwait(false);
 
         var result = JsonSerializer.Deserialize(body, GeocodingJsonContext.Default.GeoServicesFindAddressCandidatesResponse);
         if (result?.Candidates is null or { Count: 0 })
@@ -128,7 +127,7 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
 
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Geocoding request failed", inspectGeoServicesErrorEnvelope: true).ConfigureAwait(false);
 
         var result = JsonSerializer.Deserialize(body, GeocodingJsonContext.Default.GeoServicesReverseGeocodeResponse);
         if (result?.Address is null || result.Location is null)
@@ -197,7 +196,7 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
 
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Geocoding request failed", inspectGeoServicesErrorEnvelope: true).ConfigureAwait(false);
 
         var result = JsonSerializer.Deserialize(body, GeocodingJsonContext.Default.GeoServicesSuggestResponse);
         if (result?.Suggestions is null or { Count: 0 })
@@ -279,99 +278,13 @@ public sealed class HonuaGeocodingClient : IHonuaBatchGeocodingClient
 
         using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Geocoding request failed", inspectGeoServicesErrorEnvelope: true).ConfigureAwait(false);
 
         var result = JsonSerializer.Deserialize(body, GeocodingJsonContext.Default.GeoServicesBatchGeocodeResponse);
         return MapBatchResults(addresses, result);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
-
-    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string body)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            // GeoServices may return 200 with an error payload; check for "error" in body
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                try
-                {
-                    using var doc = JsonDocument.Parse(body);
-                    if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
-                        errorElement.ValueKind == JsonValueKind.Object)
-                    {
-                        var message = "Geocoding service returned an error.";
-                        if (errorElement.TryGetProperty("message", out var msgProp) &&
-                            msgProp.ValueKind == JsonValueKind.String)
-                        {
-                            message = msgProp.GetString() ?? message;
-                        }
-
-                        var code = response.StatusCode;
-                        if (errorElement.TryGetProperty("code", out var codeProp) &&
-                            codeProp.TryGetInt32(out var errorCode))
-                        {
-                            // GeoServices error.code is an independent Esri code space (e.g. 400 is a
-                            // real status but 1000/4001 are not). Only adopt it as the HTTP status when
-                            // it is a valid HTTP status (100-599); otherwise keep the transport status,
-                            // mirroring GeoServicesHttp.MapErrorCodeToStatus. Blindly casting an Esri
-                            // code yields a nonsensical HttpStatus that breaks retry/auth branching.
-                            if (errorCode is >= 100 and <= 599)
-                            {
-                                code = (System.Net.HttpStatusCode)errorCode;
-                            }
-                        }
-
-                        throw new HonuaAdminApiException(code, message, body);
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Not JSON, ignore
-                }
-            }
-
-            return;
-        }
-
-        var errorMessage = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "Geocoding request failed";
-        throw new HonuaAdminApiException(response.StatusCode, errorMessage, body);
-    }
-
-    private static string? TryExtractErrorMessage(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-
-            // GeoServices error format: { "error": { "message": "..." } }
-            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
-                errorElement.ValueKind == JsonValueKind.Object &&
-                errorElement.TryGetProperty("message", out var msg) &&
-                msg.ValueKind == JsonValueKind.String)
-            {
-                return msg.GetString();
-            }
-
-            // Fallback: top-level message
-            if (doc.RootElement.TryGetProperty("message", out var topMsg) &&
-                topMsg.ValueKind == JsonValueKind.String)
-            {
-                return topMsg.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON
-        }
-
-        return null;
-    }
 
     private static Dictionary<string, string?> FlattenAttributes(Dictionary<string, object?>? attributes)
     {

--- a/src/Honua.Sdk.Admin/HonuaAdminClient.cs
+++ b/src/Honua.Sdk.Admin/HonuaAdminClient.cs
@@ -134,8 +134,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         var url = $"{ApiPrefix}/metadata/resources/{Uri.EscapeDataString(kind)}/{Uri.EscapeDataString(ns)}/{Uri.EscapeDataString(name)}";
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseMetadataResource);
         var resource = envelope?.Data ?? throw new HonuaAdminOperationException("Server returned null metadata resource.", "GetMetadataResource");
@@ -184,8 +184,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
         using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
     }
 
     private async Task<MetadataResourceResponse> SendMetadataResourceAsync(
@@ -206,8 +206,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
         using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseMetadataResource);
         var responseResource = envelope?.Data ?? throw new HonuaAdminOperationException("Server returned null response.", operation);
@@ -349,8 +349,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var response = await _http.DeleteAsync(
             CreateRequestUri($"{ApiPrefix}/connections/{Uri.EscapeDataString(connectionId)}"), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
     }
 
     /// <inheritdoc />
@@ -441,7 +441,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         var url = $"{ApiPrefix}/connections/{Uri.EscapeDataString(normalizedConnectionId)}/tables";
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
         // Table discovery returns TableDiscoveryResponse directly (not wrapped in ApiResponse)
         var result = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.TableDiscoveryResponse);
@@ -506,7 +506,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     {
         using var response = await _http.GetAsync(CreateRequestUri($"{ApiPrefix}/config"), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
         return JsonSerializer.Deserialize<JsonElement>(body);
     }
@@ -534,8 +534,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             return null;
         }
 
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseOidcProviderResponse);
         return envelope?.Data;
@@ -571,8 +571,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var response = await _http.DeleteAsync(
             CreateRequestUri($"{ApiPrefix}/oidc/providers/{providerId:D}"), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
     }
 
     /// <inheritdoc />
@@ -634,8 +634,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             return null;
         }
 
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseRoleResponse);
         return envelope?.Data;
@@ -725,8 +725,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
             return null;
         }
 
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseUserResponse);
         return envelope?.Data;
@@ -811,8 +811,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
 
         using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.ApiResponseLicenseStatusResponse);
         return envelope?.Data ?? throw new HonuaAdminOperationException("Server returned null license status.", "UploadLicense");
@@ -882,7 +882,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var response = await _http.PostAsync(
             CreateRequestUri($"{ApiPrefix}/import/raster/"), form, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
         return JsonSerializer.Deserialize(body, HonuaAdminJsonContext.Default.RasterImportResult)
             ?? throw new HonuaAdminOperationException("Server returned null raster import result.", "ImportRaster");
@@ -1140,8 +1140,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, typeInfo);
         return envelope is not null ? envelope.Data : default;
@@ -1154,7 +1154,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
         return JsonSerializer.Deserialize(body, typeInfo);
     }
@@ -1182,8 +1182,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         {
             using var response = await _http.PostAsync(CreateRequestUri(url), content, cancellationToken).ConfigureAwait(false);
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-            EnsureEnvelopeSucceeded(response, body);
+            await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+            AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
             var envelope = JsonSerializer.Deserialize(body, responseTypeInfo);
             return envelope is not null ? envelope.Data : default;
@@ -1200,8 +1200,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var content = JsonContent.Create(requestBody, requestTypeInfo);
         using var response = await _http.PostAsync(CreateRequestUri(url), content, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, responseTypeInfo);
         return envelope is not null ? envelope.Data : default;
@@ -1230,7 +1230,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         {
             using var response = await _http.PostAsync(CreateRequestUri(url), content, cancellationToken).ConfigureAwait(false);
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+            await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
             return JsonSerializer.Deserialize(body, responseTypeInfo);
         }
@@ -1246,7 +1246,7 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var content = JsonContent.Create(requestBody, requestTypeInfo);
         using var response = await _http.PostAsync(CreateRequestUri(url), content, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
 
         return JsonSerializer.Deserialize(body, responseTypeInfo);
     }
@@ -1261,8 +1261,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var content = JsonContent.Create(requestBody, requestTypeInfo);
         using var response = await _http.PutAsync(CreateRequestUri(url), content, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
 
         var envelope = JsonSerializer.Deserialize(body, responseTypeInfo);
         return envelope is not null ? envelope.Data : default;
@@ -1273,76 +1273,8 @@ public sealed class HonuaAdminClient : IHonuaAdminClient
         using var response = await _http.DeleteAsync(
             CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        await EnsureSuccessAsync(response, body).ConfigureAwait(false);
-        EnsureEnvelopeSucceeded(response, body);
-    }
-
-    private static async Task EnsureSuccessAsync(HttpResponseMessage response, string body)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        var message = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "Request failed";
-        throw new HonuaAdminApiException(response.StatusCode, message, body);
-    }
-
-    private static void EnsureEnvelopeSucceeded(HttpResponseMessage response, string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.ValueKind != JsonValueKind.Object)
-            {
-                return;
-            }
-
-            if (doc.RootElement.TryGetProperty("success", out var success) &&
-                success.ValueKind == JsonValueKind.False)
-            {
-                var message = TryExtractErrorMessage(body) ?? "API response indicated failure.";
-                throw new HonuaAdminApiException(response.StatusCode, message, body);
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON or invalid JSON envelope, ignore.
-        }
-    }
-
-    private static string? TryExtractErrorMessage(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
-                doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
-            {
-                // Admin envelope shape: { "message": "..." }.
-                return msg.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON, that's fine.
-            return null;
-        }
-
-        // RFC 7807 problem details via the shared Abstractions parser (detail, then title).
-        return Honua.Sdk.Abstractions.HonuaProblemDetailsParser.TryParse(body, out var problem)
-            ? problem?.Detail ?? problem?.Title
-            : null;
+        await AdminHttpHelper.EnsureSuccessAsync(response, body, "Request failed").ConfigureAwait(false);
+        AdminHttpHelper.EnsureEnvelopeSucceeded(response, body);
     }
 
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Honua.Sdk.GeoServices.ImageServer;
 using Honua.Sdk.GeoServices.Routing;
 using Honua.Sdk.Internal.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Polly;
@@ -36,13 +37,9 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var snapshot = new HonuaGeoServicesClientOptions();
-        configure(snapshot);
-        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
-        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+        var snapshot = CaptureSnapshot(configure);
 
-        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
-        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        TryAddGeoServicesOptions(services, snapshot);
         var httpBuilder = services.AddHttpClient<HonuaFeatureServerClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
@@ -76,13 +73,9 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var snapshot = new HonuaGeoServicesClientOptions();
-        configure(snapshot);
-        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
-        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+        var snapshot = CaptureSnapshot(configure);
 
-        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
-        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        TryAddGeoServicesOptions(services, snapshot);
         var httpBuilder = services.AddHttpClient<HonuaRoutingClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
@@ -109,13 +102,9 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var snapshot = new HonuaGeoServicesClientOptions();
-        configure(snapshot);
-        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
-        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+        var snapshot = CaptureSnapshot(configure);
 
-        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
-        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        TryAddGeoServicesOptions(services, snapshot);
         var httpBuilder = services.AddHttpClient<HonuaImageServerClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
@@ -147,13 +136,9 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var snapshot = new HonuaGeoServicesClientOptions();
-        configure(snapshot);
-        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
-        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+        var snapshot = CaptureSnapshot(configure);
 
-        services.AddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
-        services.AddTransient<HonuaGeoServicesAuthHandler>();
+        TryAddGeoServicesOptions(services, snapshot);
         var httpBuilder = services.AddHttpClient<HonuaGeometryServerClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
@@ -181,5 +166,25 @@ public static class ServiceCollectionExtensions
             // DisableForUnsafeHttpMethods(), which would drop the /query POST.
             return ValueTask.FromResult(GeoServicesRetryPolicy.IsRetryableRequest(args.Context.GetRequestMessage()));
         };
+    }
+
+    private static HonuaGeoServicesClientOptions CaptureSnapshot(Action<HonuaGeoServicesClientOptions> configure)
+    {
+        var snapshot = new HonuaGeoServicesClientOptions();
+        configure(snapshot);
+        HonuaGeoServicesClientOptions.ValidateBaseAddress(snapshot.BaseAddress);
+        HonuaGeoServicesClientOptions.ValidateTimeout(snapshot.Timeout);
+        return snapshot;
+    }
+
+    private static void TryAddGeoServicesOptions(IServiceCollection services, HonuaGeoServicesClientOptions snapshot)
+    {
+        // TryAdd: if a sibling GeoServices extension (FeatureServer, Routing,
+        // ImageServer, or GeometryServer) already registered shared GeoServices
+        // options, share that snapshot rather than silently overwriting it.
+        // The first AddHonua* wins; subsequent registrations must use compatible
+        // BaseAddress / auth configuration.
+        services.TryAddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
+        services.TryAddTransient<HonuaGeoServicesAuthHandler>();
     }
 }

--- a/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Honua.Sdk.GeoServices/Extensions/ServiceCollectionExtensions.cs
@@ -21,6 +21,11 @@ namespace Honua.Sdk.GeoServices.Extensions;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
+    private const string FeatureServerHttpClientName = "Honua.Sdk.GeoServices.FeatureServer";
+    private const string RoutingHttpClientName = "Honua.Sdk.GeoServices.Routing";
+    private const string ImageServerHttpClientName = "Honua.Sdk.GeoServices.ImageServer";
+    private const string GeometryServerHttpClientName = "Honua.Sdk.GeoServices.GeometryServer";
+
     /// <summary>
     /// Registers the Honua FeatureServer client and related services with the DI container.
     /// The supplied <paramref name="configure"/> delegate is invoked exactly once to capture
@@ -40,13 +45,9 @@ public static class ServiceCollectionExtensions
         var snapshot = CaptureSnapshot(configure);
 
         TryAddGeoServicesOptions(services, snapshot);
-        var httpBuilder = services.AddHttpClient<HonuaFeatureServerClient>((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
-            client.BaseAddress = options.BaseAddress;
-            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
-        })
-        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = AddGeoServicesHttpClient(services, FeatureServerHttpClientName, snapshot);
+        services.AddTransient(sp =>
+            new HonuaFeatureServerClient(sp.GetRequiredService<IHttpClientFactory>().CreateClient(FeatureServerHttpClientName)));
         services.AddTransient<IHonuaFeatureServerClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureServerEditClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
         services.AddTransient<IHonuaFeatureQueryClient>(sp => sp.GetRequiredService<HonuaFeatureServerClient>());
@@ -76,13 +77,9 @@ public static class ServiceCollectionExtensions
         var snapshot = CaptureSnapshot(configure);
 
         TryAddGeoServicesOptions(services, snapshot);
-        var httpBuilder = services.AddHttpClient<HonuaRoutingClient>((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
-            client.BaseAddress = options.BaseAddress;
-            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
-        })
-        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = AddGeoServicesHttpClient(services, RoutingHttpClientName, snapshot);
+        services.AddTransient(sp =>
+            new HonuaRoutingClient(sp.GetRequiredService<IHttpClientFactory>().CreateClient(RoutingHttpClientName), snapshot));
         services.AddTransient<IHonuaRoutingClient>(sp => sp.GetRequiredService<HonuaRoutingClient>());
 
         httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
@@ -105,13 +102,9 @@ public static class ServiceCollectionExtensions
         var snapshot = CaptureSnapshot(configure);
 
         TryAddGeoServicesOptions(services, snapshot);
-        var httpBuilder = services.AddHttpClient<HonuaImageServerClient>((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
-            client.BaseAddress = options.BaseAddress;
-            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
-        })
-        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = AddGeoServicesHttpClient(services, ImageServerHttpClientName, snapshot);
+        services.AddTransient(sp =>
+            new HonuaImageServerClient(sp.GetRequiredService<IHttpClientFactory>().CreateClient(ImageServerHttpClientName)));
 
         // Provider-neutral raster data client (metadata, coverage statistics, windowed
         // reads) so a raster geoprocessing tool can resolve IHonuaRasterDataClient from DI.
@@ -139,13 +132,11 @@ public static class ServiceCollectionExtensions
         var snapshot = CaptureSnapshot(configure);
 
         TryAddGeoServicesOptions(services, snapshot);
-        var httpBuilder = services.AddHttpClient<HonuaGeometryServerClient>((sp, client) =>
-        {
-            var options = sp.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
-            client.BaseAddress = options.BaseAddress;
-            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(options.Timeout, options.EnableRetry);
-        })
-        .AddHttpMessageHandler<HonuaGeoServicesAuthHandler>();
+        var httpBuilder = AddGeoServicesHttpClient(services, GeometryServerHttpClientName, snapshot);
+        services.AddTransient(sp =>
+            new HonuaGeometryServerClient(
+                sp.GetRequiredService<IHttpClientFactory>().CreateClient(GeometryServerHttpClientName),
+                snapshot));
 
         httpBuilder.ConfigureHonuaRestHttpClient(snapshot, ConfigureGeoServicesRetry);
         return services;
@@ -179,12 +170,22 @@ public static class ServiceCollectionExtensions
 
     private static void TryAddGeoServicesOptions(IServiceCollection services, HonuaGeoServicesClientOptions snapshot)
     {
-        // TryAdd: if a sibling GeoServices extension (FeatureServer, Routing,
-        // ImageServer, or GeometryServer) already registered shared GeoServices
-        // options, share that snapshot rather than silently overwriting it.
-        // The first AddHonua* wins; subsequent registrations must use compatible
-        // BaseAddress / auth configuration.
+        // Keep a first-registration IOptions<T> fallback for consumers that resolve
+        // options directly; typed GeoServices clients use their own captured snapshot.
         services.TryAddSingleton<IOptions<HonuaGeoServicesClientOptions>>(Options.Create(snapshot));
         services.TryAddTransient<HonuaGeoServicesAuthHandler>();
     }
+
+    private static IHttpClientBuilder AddGeoServicesHttpClient(
+        IServiceCollection services,
+        string name,
+        HonuaGeoServicesClientOptions snapshot)
+        => services.AddHttpClient(name, client =>
+        {
+            client.BaseAddress = snapshot.BaseAddress;
+            client.Timeout = Honua.Sdk.Abstractions.HonuaResilienceTimeouts.HttpClientTimeout(
+                snapshot.Timeout,
+                snapshot.EnableRetry);
+        })
+        .AddHttpMessageHandler(_ => new HonuaGeoServicesAuthHandler(snapshot));
 }

--- a/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
+++ b/src/Honua.Sdk.GeoServices/FeatureServer/HonuaFeatureServerClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
@@ -62,6 +63,7 @@ public sealed class HonuaFeatureServerClient :
     };
 
     private readonly HttpClient _http;
+    private readonly ConcurrentDictionary<(string ServiceId, int LayerId), string> _objectIdFieldCache = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HonuaFeatureServerClient"/> class.
@@ -318,12 +320,12 @@ public sealed class HonuaFeatureServerClient :
         if (!response.IsSuccessStatusCode)
         {
             // Read the body and run the status check while the response is still alive,
-            // then dispose. EnsureSuccess reads response.StatusCode, so it must run before
+            // then dispose. GeoServicesHttp.EnsureSuccess reads response.StatusCode, so it must run before
             // Dispose to remain correct under refactoring.
             var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                EnsureSuccess(response, body);
+                GeoServicesHttp.EnsureSuccess(response, body);
             }
             finally
             {
@@ -611,7 +613,7 @@ public sealed class HonuaFeatureServerClient :
 
     /// <summary>
     /// Validates an unbuffered streaming response without consuming the body on success. On a
-    /// non-success status the (small) error body is read and routed through <see cref="EnsureSuccess"/>
+    /// non-success status the (small) error body is read and routed through <see cref="GeoServicesHttp.EnsureSuccess"/>
     /// so callers still observe the normal <see cref="HonuaFeatureServerException"/>.
     /// </summary>
     private static async Task EnsureSuccessStreamingAsync(HttpResponseMessage response, CancellationToken cancellationToken)
@@ -622,7 +624,7 @@ public sealed class HonuaFeatureServerClient :
         }
 
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────
@@ -631,7 +633,7 @@ public sealed class HonuaFeatureServerClient :
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
         return body;
     }
 
@@ -658,7 +660,7 @@ public sealed class HonuaFeatureServerClient :
 
         using var response = await _http.PostAsync(CreateRequestUri(path), content, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
         return body;
     }
 
@@ -699,103 +701,9 @@ public sealed class HonuaFeatureServerClient :
 
         using var response = await _http.PostAsync(CreateRequestUri(path), form, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
         return JsonSerializer.Deserialize(body, FeatureServerJsonContext.Default.FeatureServerAttachmentEditResponse)
             ?? throw new HonuaFeatureServerException(HttpStatusCode.OK, "Failed to deserialize attachment edit response.", body);
-    }
-
-    private static void EnsureSuccess(HttpResponseMessage response, string body)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            // GeoServices may return 200 with an error payload
-            if (!string.IsNullOrWhiteSpace(body))
-            {
-                try
-                {
-                    using var doc = JsonDocument.Parse(body);
-                    if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
-                        errorElement.ValueKind == JsonValueKind.Object)
-                    {
-                        var message = "FeatureServer returned an error.";
-                        int? geoServicesCode = null;
-                        IReadOnlyList<string>? details = null;
-
-                        if (errorElement.TryGetProperty("message", out var msgProp) &&
-                            msgProp.ValueKind == JsonValueKind.String)
-                        {
-                            message = msgProp.GetString() ?? message;
-                        }
-
-                        var httpCode = response.StatusCode;
-                        if (errorElement.TryGetProperty("code", out var codeProp) &&
-                            codeProp.TryGetInt32(out var errorCode))
-                        {
-                            geoServicesCode = errorCode;
-                            httpCode = GeoServicesHttp.MapErrorCodeToStatus(errorCode, response.StatusCode);
-                        }
-
-                        if (errorElement.TryGetProperty("details", out var detailsProp) &&
-                            detailsProp.ValueKind == JsonValueKind.Array)
-                        {
-                            var detailList = new List<string>();
-                            foreach (var item in detailsProp.EnumerateArray())
-                            {
-                                if (item.ValueKind == JsonValueKind.String)
-                                {
-                                    detailList.Add(item.GetString()!);
-                                }
-                            }
-                            details = detailList;
-                        }
-
-                        throw new HonuaFeatureServerException(httpCode, message, body, geoServicesCode, details);
-                    }
-                }
-                catch (JsonException)
-                {
-                    // Not JSON, ignore
-                }
-            }
-
-            return;
-        }
-
-        var errorMessage = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "FeatureServer request failed";
-        throw new HonuaFeatureServerException(response.StatusCode, errorMessage, body);
-    }
-
-    private static string? TryExtractErrorMessage(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-
-            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
-                errorElement.ValueKind == JsonValueKind.Object &&
-                errorElement.TryGetProperty("message", out var msg) &&
-                msg.ValueKind == JsonValueKind.String)
-            {
-                return msg.GetString();
-            }
-
-            if (doc.RootElement.TryGetProperty("message", out var topMsg) &&
-                topMsg.ValueKind == JsonValueKind.String)
-            {
-                return topMsg.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            // Not JSON
-        }
-
-        return null;
     }
 
     private static FeatureServerQueryResponse DeserializeQueryResponse(string body)
@@ -1238,6 +1146,12 @@ public sealed class HonuaFeatureServerClient :
             return null;
         }
 
+        var key = (serviceId, layerId);
+        if (_objectIdFieldCache.TryGetValue(key, out var cachedObjectIdField))
+        {
+            return cachedObjectIdField;
+        }
+
         var layer = await GetLayerInfoAsync(serviceId, layerId, cancellationToken).ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(layer.ObjectIdField))
         {
@@ -1245,6 +1159,7 @@ public sealed class HonuaFeatureServerClient :
                 "FeatureServer layer metadata does not expose an object ID field required for shared updates.");
         }
 
+        _objectIdFieldCache.TryAdd(key, layer.ObjectIdField);
         return layer.ObjectIdField;
     }
 
@@ -1335,10 +1250,10 @@ public sealed class HonuaFeatureServerClient :
 
     private static FeatureEditCapabilities BuildEditCapabilities(string? capabilities)
     {
-        var tokens = ParseCapabilities(capabilities);
-        var supportsAdds = tokens.Contains("CREATE") || tokens.Contains("EDITING");
-        var supportsUpdates = tokens.Contains("UPDATE") || tokens.Contains("EDITING");
-        var supportsDeletes = tokens.Contains("DELETE") || tokens.Contains("EDITING");
+        var tokens = SplitCapabilities(capabilities);
+        var supportsAdds = tokens.Contains("Create") || tokens.Contains("Editing");
+        var supportsUpdates = tokens.Contains("Update") || tokens.Contains("Editing");
+        var supportsDeletes = tokens.Contains("Delete") || tokens.Contains("Editing");
 
         return new FeatureEditCapabilities
         {
@@ -1348,15 +1263,6 @@ public sealed class HonuaFeatureServerClient :
             SupportsRollbackOnFailure = supportsAdds || supportsUpdates || supportsDeletes,
             NativeSurface = "GeoServices FeatureServer applyEdits"
         };
-    }
-
-    private static HashSet<string> ParseCapabilities(string? capabilities)
-    {
-        return string.IsNullOrWhiteSpace(capabilities)
-            ? []
-            : capabilities.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(capability => capability.ToUpperInvariant())
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);

--- a/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
+++ b/src/Honua.Sdk.GeoServices/HonuaGeoServicesAuthHandler.cs
@@ -16,7 +16,16 @@ internal sealed class HonuaGeoServicesAuthHandler : HonuaAuthHandler<HonuaGeoSer
     /// </summary>
     /// <param name="options">The GeoServices client options containing authentication credentials.</param>
     public HonuaGeoServicesAuthHandler(IOptions<HonuaGeoServicesClientOptions> options)
-        : base(options.Value, "geoservices", HonuaGeoServicesClientOptions.ValidateBaseAddress)
+        : this(options.Value)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HonuaGeoServicesAuthHandler"/> class.
+    /// </summary>
+    /// <param name="options">The GeoServices client options containing authentication credentials.</param>
+    public HonuaGeoServicesAuthHandler(HonuaGeoServicesClientOptions options)
+        : base(options, "geoservices", HonuaGeoServicesClientOptions.ValidateBaseAddress)
     {
     }
 }

--- a/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
+++ b/src/Honua.Sdk.GeoServices/Routing/HonuaRoutingClient.cs
@@ -3,11 +3,9 @@
 
 using System.Buffers;
 using System.Globalization;
-using System.Net;
 using System.Text;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Routing;
-using Honua.Sdk.GeoServices.FeatureServer.Exceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -326,7 +324,7 @@ public sealed class HonuaRoutingClient : IHonuaRoutingClient
     {
         using var response = await _http.GetAsync(CreateRequestUri(url), cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
         return body;
     }
 
@@ -342,7 +340,7 @@ public sealed class HonuaRoutingClient : IHonuaRoutingClient
 
         using var response = await _http.PostAsync(CreateRequestUri(path), content, cancellationToken).ConfigureAwait(false);
         var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-        EnsureSuccess(response, body);
+        GeoServicesHttp.EnsureSuccess(response, body);
         return body;
     }
 
@@ -576,105 +574,6 @@ public sealed class HonuaRoutingClient : IHonuaRoutingClient
         => startTime?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
 
     private static Uri CreateRequestUri(string url) => new(url, UriKind.RelativeOrAbsolute);
-
-    private static void EnsureSuccess(HttpResponseMessage response, string body)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            if (!string.IsNullOrWhiteSpace(body) && TryExtractGeoServicesError(body, response.StatusCode) is { } error)
-            {
-                throw error;
-            }
-
-            return;
-        }
-
-        var errorMessage = TryExtractErrorMessage(body) ?? response.ReasonPhrase ?? "GeoServices routing request failed";
-        throw new HonuaFeatureServerException(response.StatusCode, errorMessage, body);
-    }
-
-    private static HonuaFeatureServerException? TryExtractGeoServicesError(string body, HttpStatusCode fallbackStatus)
-    {
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (!doc.RootElement.TryGetProperty("error", out var errorElement) ||
-                errorElement.ValueKind != JsonValueKind.Object)
-            {
-                return null;
-            }
-
-            var message = "GeoServices routing returned an error.";
-            int? geoServicesCode = null;
-            IReadOnlyList<string>? details = null;
-            var httpCode = fallbackStatus;
-            if (errorElement.TryGetProperty("message", out var msgProp) &&
-                msgProp.ValueKind == JsonValueKind.String)
-            {
-                message = msgProp.GetString() ?? message;
-            }
-
-            if (errorElement.TryGetProperty("code", out var codeProp) &&
-                codeProp.TryGetInt32(out var errorCode))
-            {
-                geoServicesCode = errorCode;
-                httpCode = GeoServicesHttp.MapErrorCodeToStatus(errorCode, fallbackStatus);
-            }
-
-            if (errorElement.TryGetProperty("details", out var detailsProp) &&
-                detailsProp.ValueKind == JsonValueKind.Array)
-            {
-                var detailList = new List<string>();
-                foreach (var item in detailsProp.EnumerateArray())
-                {
-                    if (item.ValueKind == JsonValueKind.String)
-                    {
-                        detailList.Add(item.GetString()!);
-                    }
-                }
-
-                details = detailList;
-            }
-
-            return new HonuaFeatureServerException(httpCode, message, body, geoServicesCode, details);
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-    }
-
-    private static string? TryExtractErrorMessage(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        try
-        {
-            using var doc = JsonDocument.Parse(body);
-            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
-                errorElement.ValueKind == JsonValueKind.Object &&
-                errorElement.TryGetProperty("message", out var msg) &&
-                msg.ValueKind == JsonValueKind.String)
-            {
-                return msg.GetString();
-            }
-
-            if (doc.RootElement.TryGetProperty("message", out var topMsg) &&
-                topMsg.ValueKind == JsonValueKind.String)
-            {
-                return topMsg.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
-
-        return null;
-    }
 
     private static List<RouteTravelMode> ParseTravelModes(JsonElement root)
     {

--- a/src/Honua.Sdk.Geometry/GeoJsonGeometryConverter.cs
+++ b/src/Honua.Sdk.Geometry/GeoJsonGeometryConverter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Converters;
@@ -12,7 +13,8 @@ namespace Honua.Sdk.Geometry;
 /// </summary>
 public static class GeoJsonGeometryConverter
 {
-    private static readonly JsonSerializerOptions DefaultSerializerOptions = CreateSerializerOptions(null);
+    private static readonly JsonSerializerOptions DefaultSerializerOptions = CreateDefaultSerializerOptions();
+    private static readonly ConditionalWeakTable<GeometryFactory, JsonSerializerOptions> SerializerOptionsByGeometryFactory = new();
 
     /// <summary>
     /// Reads a GeoJSON geometry from a JSON element.
@@ -39,9 +41,7 @@ public static class GeoJsonGeometryConverter
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(geoJson);
 
-        var options = geometryFactory is null
-            ? DefaultSerializerOptions
-            : CreateSerializerOptions(geometryFactory);
+        var options = GetSerializerOptions(geometryFactory);
         return JsonSerializer.Deserialize<NetTopologySuite.Geometries.Geometry>(geoJson, options)
             ?? throw new JsonException("GeoJSON did not contain a geometry object.");
     }
@@ -70,12 +70,22 @@ public static class GeoJsonGeometryConverter
         return JsonSerializer.Serialize(geometry, DefaultSerializerOptions);
     }
 
-    private static JsonSerializerOptions CreateSerializerOptions(GeometryFactory? geometryFactory)
+    private static JsonSerializerOptions GetSerializerOptions(GeometryFactory? geometryFactory)
+        => geometryFactory is null
+            ? DefaultSerializerOptions
+            : SerializerOptionsByGeometryFactory.GetValue(geometryFactory, CreateSerializerOptions);
+
+    private static JsonSerializerOptions CreateDefaultSerializerOptions()
     {
         var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        options.Converters.Add(geometryFactory is null
-            ? new GeoJsonConverterFactory()
-            : new GeoJsonConverterFactory(geometryFactory));
+        options.Converters.Add(new GeoJsonConverterFactory());
+        return options;
+    }
+
+    private static JsonSerializerOptions CreateSerializerOptions(GeometryFactory geometryFactory)
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.Converters.Add(new GeoJsonConverterFactory(geometryFactory));
         return options;
     }
 }

--- a/src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj
+++ b/src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
+++ b/src/Honua.Sdk.Offline/OfflineSyncEngine.cs
@@ -3,13 +3,15 @@
 
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Offline.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Honua.Sdk.Offline;
 
 /// <summary>
 /// Provider-neutral offline sync engine for pushing local edits and pulling feature pages.
 /// </summary>
-public sealed class OfflineSyncEngine : IOfflineSyncRunner
+public sealed partial class OfflineSyncEngine : IOfflineSyncRunner
 {
     private const string MaxAttemptsReason = "max attempts reached";
 
@@ -21,6 +23,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
     private readonly IOfflineSyncStateStore? _stateStore;
     private readonly IOfflineConflictStore? _conflictStore;
     private readonly OfflineSyncEngineOptions _options;
+    private readonly ILogger<OfflineSyncEngine> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OfflineSyncEngine"/> class.
@@ -42,6 +45,41 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         OfflineSyncEngineOptions? options = null,
         IOfflineSyncStateStore? stateStore = null,
         IOfflineConflictStore? conflictStore = null)
+        : this(
+            queryClient,
+            editClient,
+            featureStore,
+            changeJournal,
+            checkpointStore,
+            options,
+            stateStore,
+            conflictStore,
+            null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OfflineSyncEngine"/> class.
+    /// </summary>
+    /// <param name="queryClient">Provider-neutral query client.</param>
+    /// <param name="editClient">Provider-neutral edit client.</param>
+    /// <param name="featureStore">Local feature store.</param>
+    /// <param name="changeJournal">Local change journal.</param>
+    /// <param name="checkpointStore">Sync checkpoint store.</param>
+    /// <param name="options">Sync engine options.</param>
+    /// <param name="stateStore">Optional sync state store.</param>
+    /// <param name="conflictStore">Optional conflict store.</param>
+    /// <param name="logger">Optional logger for sync phases and failure diagnostics.</param>
+    public OfflineSyncEngine(
+        IHonuaFeatureQueryClient queryClient,
+        IHonuaFeatureEditClient editClient,
+        IOfflineFeatureStore featureStore,
+        IOfflineChangeJournal changeJournal,
+        IOfflineSyncCheckpointStore checkpointStore,
+        OfflineSyncEngineOptions? options,
+        IOfflineSyncStateStore? stateStore,
+        IOfflineConflictStore? conflictStore,
+        ILogger<OfflineSyncEngine>? logger)
     {
         _queryClient = queryClient ?? throw new ArgumentNullException(nameof(queryClient));
         _editClient = editClient ?? throw new ArgumentNullException(nameof(editClient));
@@ -50,6 +88,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         _checkpointStore = checkpointStore ?? throw new ArgumentNullException(nameof(checkpointStore));
         _stateStore = stateStore;
         _conflictStore = conflictStore;
+        _logger = logger ?? NullLogger<OfflineSyncEngine>.Instance;
         _options = options ?? new OfflineSyncEngineOptions();
         _options.Validate();
     }
@@ -60,11 +99,17 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         ArgumentNullException.ThrowIfNull(manifest);
         ArgumentException.ThrowIfNullOrWhiteSpace(manifest.PackageId);
 
+        var currentPhase = OfflineSyncPhase.Pushing;
+        LogSyncStarted(_logger, manifest.PackageId);
+
         try
         {
+            LogPackagePhase(_logger, manifest.PackageId, OfflineSyncPhase.Pushing);
             await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Pushing, null, cancellationToken).ConfigureAwait(false);
             var push = await PushAsync(manifest.PackageId, cancellationToken).ConfigureAwait(false);
 
+            currentPhase = OfflineSyncPhase.Pulling;
+            LogPackagePhase(_logger, manifest.PackageId, OfflineSyncPhase.Pulling);
             await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Pulling, null, cancellationToken).ConfigureAwait(false);
             var pull = await PullAsync(manifest, cancellationToken).ConfigureAwait(false);
 
@@ -82,20 +127,38 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 result.Succeeded ? null : "sync completed with failures",
                 cancellationToken).ConfigureAwait(false);
 
+            if (result.Succeeded)
+            {
+                LogSyncCompleted(_logger, manifest.PackageId, push.Succeeded, pull.StoredFeatureCount);
+            }
+            else
+            {
+                LogSyncCompletedWithFailures(
+                    _logger,
+                    manifest.PackageId,
+                    push.Failures.Count,
+                    pull.Failures.Count);
+            }
+
             return result;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            LogSyncCanceled(_logger, manifest.PackageId, currentPhase);
             throw;
         }
         catch (HttpRequestException ex)
         {
-            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+            var diagnostic = FormatException(ex);
+            LogSyncFailed(_logger, ex, manifest.PackageId, currentPhase);
+            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
             throw;
         }
         catch (TimeoutException ex)
         {
-            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+            var diagnostic = FormatException(ex);
+            LogSyncFailed(_logger, ex, manifest.PackageId, currentPhase);
+            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
@@ -104,7 +167,9 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
             // safety-limit InvalidOperationException) must still drive the sync to a
             // terminal Failed state, otherwise operators are left with state stuck at
             // an in-progress phase with no record of why the run died.
-            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+            var diagnostic = FormatException(ex);
+            LogSyncFailed(_logger, ex, manifest.PackageId, currentPhase);
+            await SaveStateAsync(manifest.PackageId, null, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
             throw;
         }
     }
@@ -141,6 +206,8 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         var storedPageCount = 0;
         var storedFeatureCount = 0;
 
+        LogPullStarted(_logger, manifest.PackageId, manifest.Sources.Count);
+
         foreach (var source in manifest.Sources)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(source.SourceId);
@@ -148,6 +215,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
 
             try
             {
+                LogSourcePhase(_logger, manifest.PackageId, source.SourceId, OfflineSyncPhase.Pulling);
                 await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Pulling, null, cancellationToken).ConfigureAwait(false);
                 var checkpoint = await _checkpointStore.GetCheckpointAsync(manifest.PackageId, source.SourceId, cancellationToken).ConfigureAwait(false);
                 var request = OfflineDownloadPlanner.CreateRequest(manifest, source, checkpoint);
@@ -195,25 +263,33 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                     SyncToken = null,
                     PulledFeatureCount = sourceFeatureCount,
                 }, cancellationToken).ConfigureAwait(false);
+
+                LogPullSourceCompleted(_logger, manifest.PackageId, source.SourceId, sourceFeatureCount);
             }
             catch (HttpRequestException ex)
             {
+                var diagnostic = FormatException(ex);
+                LogPullSourceRetryableFailure(_logger, ex, manifest.PackageId, source.SourceId);
+                await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
                 failures.Add(new OfflineSyncFailure
                 {
                     PackageId = manifest.PackageId,
                     SourceId = source.SourceId,
                     Retryable = true,
-                    Reason = ex.Message,
+                    Reason = diagnostic,
                 });
             }
             catch (TimeoutException ex)
             {
+                var diagnostic = FormatException(ex);
+                LogPullSourceRetryableFailure(_logger, ex, manifest.PackageId, source.SourceId);
+                await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
                 failures.Add(new OfflineSyncFailure
                 {
                     PackageId = manifest.PackageId,
                     SourceId = source.SourceId,
                     Retryable = true,
-                    Reason = ex.Message,
+                    Reason = diagnostic,
                 });
             }
             catch (InvalidOperationException ex)
@@ -222,13 +298,15 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
                 // (QueryPagesAsync throws InvalidOperationException once MaxAutoPages is
                 // exceeded). Record it as a non-retryable failure for this source rather
                 // than letting it escape and abort every remaining source in the pull.
-                await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Failed, ex.Message, cancellationToken).ConfigureAwait(false);
+                var diagnostic = FormatException(ex);
+                LogPullSourceFatalFailure(_logger, ex, manifest.PackageId, source.SourceId);
+                await SaveStateAsync(manifest.PackageId, source.SourceId, OfflineSyncPhase.Failed, diagnostic, cancellationToken).ConfigureAwait(false);
                 failures.Add(new OfflineSyncFailure
                 {
                     PackageId = manifest.PackageId,
                     SourceId = source.SourceId,
                     Retryable = false,
-                    Reason = ex.Message,
+                    Reason = diagnostic,
                 });
             }
         }
@@ -273,6 +351,8 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         var retryableFailures = 0;
         var fatalFailures = 0;
 
+        LogPushStarted(_logger, packageId, pending.Count);
+
         for (var index = 0; index < pending.Count; index++)
         {
             var operation = pending[index];
@@ -280,6 +360,13 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
 
             if (operation.AttemptCount >= _options.MaxAttempts)
             {
+                LogPushOperationMaxAttempts(
+                    _logger,
+                    operation.PackageId,
+                    operation.SourceId,
+                    operation.OperationId,
+                    operation.AttemptCount,
+                    _options.MaxAttempts);
                 await _changeJournal.MarkFailedAsync(operation.OperationId, MaxAttemptsReason, cancellationToken).ConfigureAwait(false);
                 failures.Add(ToFailure(operation, MaxAttemptsReason, retryable: false));
                 fatalFailures++;
@@ -298,19 +385,24 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                LogPushCanceled(_logger, packageId, operation.OperationId);
                 await ReleasePendingOperationsAsync(pending, index).ConfigureAwait(false);
                 throw;
             }
             catch (HttpRequestException ex)
             {
-                await MarkRetryAsync(operation, ex.Message, cancellationToken).ConfigureAwait(false);
-                failures.Add(ToFailure(operation, ex.Message, retryable: true));
+                var diagnostic = FormatException(ex);
+                LogPushOperationRetryableException(_logger, ex, operation.PackageId, operation.SourceId, operation.OperationId);
+                await MarkRetryAsync(operation, diagnostic, cancellationToken).ConfigureAwait(false);
+                failures.Add(ToFailure(operation, diagnostic, retryable: true));
                 retryableFailures++;
             }
             catch (TimeoutException ex)
             {
-                await MarkRetryAsync(operation, ex.Message, cancellationToken).ConfigureAwait(false);
-                failures.Add(ToFailure(operation, ex.Message, retryable: true));
+                var diagnostic = FormatException(ex);
+                LogPushOperationRetryableException(_logger, ex, operation.PackageId, operation.SourceId, operation.OperationId);
+                await MarkRetryAsync(operation, diagnostic, cancellationToken).ConfigureAwait(false);
+                failures.Add(ToFailure(operation, diagnostic, retryable: true));
                 retryableFailures++;
             }
         }
@@ -335,6 +427,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         if (upload.Outcome == UploadEvaluationOutcome.Success)
         {
             await _changeJournal.MarkSucceededAsync(operation.OperationId, cancellationToken).ConfigureAwait(false);
+            LogPushOperationSucceeded(_logger, operation.PackageId, operation.SourceId, operation.OperationId);
             return UploadApplicationResult.Success;
         }
 
@@ -346,11 +439,13 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         if (upload.Outcome == UploadEvaluationOutcome.RetryableFailure)
         {
             var reason = upload.Reason ?? "retryable upload failure";
+            LogPushOperationRetryableProviderFailure(_logger, operation.PackageId, operation.SourceId, operation.OperationId, reason);
             await MarkRetryAsync(operation, reason, cancellationToken).ConfigureAwait(false);
             return UploadApplicationResult.RetryableFailure(ToFailure(operation, reason, retryable: true));
         }
 
         var fatalReason = upload.Reason ?? "fatal upload failure";
+        LogPushOperationFatalProviderFailure(_logger, operation.PackageId, operation.SourceId, operation.OperationId, fatalReason);
         await _changeJournal.MarkFailedAsync(operation.OperationId, fatalReason, cancellationToken).ConfigureAwait(false);
         return UploadApplicationResult.FatalFailure(ToFailure(operation, fatalReason, retryable: false));
     }
@@ -376,6 +471,7 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
         }
 
         var reason = upload.Reason ?? "conflict requires review";
+        LogPushOperationConflict(_logger, operation.PackageId, operation.SourceId, operation.OperationId, reason);
         var conflict = new OfflineConflictEnvelope
         {
             OperationId = operation.OperationId,
@@ -534,6 +630,9 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
     private static bool IsRetryable(FeatureEditError? error)
         => error?.Code is 408 or 429 or 500 or 502 or 503 or 504;
 
+    private static string FormatException(Exception exception)
+        => exception.ToString();
+
     private static OfflineSyncFailure ToFailure(OfflineChangeJournalEntry operation, string reason, bool retryable)
         => new()
         {
@@ -543,6 +642,160 @@ public sealed class OfflineSyncEngine : IOfflineSyncRunner
             Retryable = retryable,
             Reason = reason,
         };
+
+    [LoggerMessage(EventId = 1000, Level = LogLevel.Information, Message = "Starting offline sync for package {PackageId}.")]
+    private static partial void LogSyncStarted(ILogger logger, string packageId);
+
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Information, Message = "Offline sync package {PackageId} entered {Phase} phase.")]
+    private static partial void LogPackagePhase(ILogger logger, string packageId, OfflineSyncPhase phase);
+
+    [LoggerMessage(
+        EventId = 1002,
+        Level = LogLevel.Information,
+        Message = "Offline sync package {PackageId} source {SourceId} entered {Phase} phase.")]
+    private static partial void LogSourcePhase(ILogger logger, string packageId, string sourceId, OfflineSyncPhase phase);
+
+    [LoggerMessage(
+        EventId = 1003,
+        Level = LogLevel.Information,
+        Message = "Offline sync completed for package {PackageId}; pushed {SucceededOperations} operations and stored {StoredFeatureCount} features.")]
+    private static partial void LogSyncCompleted(
+        ILogger logger,
+        string packageId,
+        int succeededOperations,
+        int storedFeatureCount);
+
+    [LoggerMessage(
+        EventId = 1004,
+        Level = LogLevel.Warning,
+        Message = "Offline sync completed with failures for package {PackageId}; push failures: {PushFailureCount}; pull failures: {PullFailureCount}.")]
+    private static partial void LogSyncCompletedWithFailures(
+        ILogger logger,
+        string packageId,
+        int pushFailureCount,
+        int pullFailureCount);
+
+    [LoggerMessage(
+        EventId = 1005,
+        Level = LogLevel.Information,
+        Message = "Offline sync canceled for package {PackageId} during {Phase} phase.")]
+    private static partial void LogSyncCanceled(ILogger logger, string packageId, OfflineSyncPhase phase);
+
+    [LoggerMessage(
+        EventId = 1006,
+        Level = LogLevel.Error,
+        Message = "Offline sync failed for package {PackageId} during {Phase} phase.")]
+    private static partial void LogSyncFailed(ILogger logger, Exception exception, string packageId, OfflineSyncPhase phase);
+
+    [LoggerMessage(
+        EventId = 1010,
+        Level = LogLevel.Information,
+        Message = "Starting offline pull for package {PackageId} across {SourceCount} sources.")]
+    private static partial void LogPullStarted(ILogger logger, string packageId, int sourceCount);
+
+    [LoggerMessage(
+        EventId = 1011,
+        Level = LogLevel.Information,
+        Message = "Offline pull stored {StoredFeatureCount} features for package {PackageId} source {SourceId}.")]
+    private static partial void LogPullSourceCompleted(
+        ILogger logger,
+        string packageId,
+        string sourceId,
+        int storedFeatureCount);
+
+    [LoggerMessage(
+        EventId = 1012,
+        Level = LogLevel.Warning,
+        Message = "Offline pull source failed with a retryable exception for package {PackageId} source {SourceId}.")]
+    private static partial void LogPullSourceRetryableFailure(
+        ILogger logger,
+        Exception exception,
+        string packageId,
+        string sourceId);
+
+    [LoggerMessage(
+        EventId = 1013,
+        Level = LogLevel.Error,
+        Message = "Offline pull source failed with a non-retryable exception for package {PackageId} source {SourceId}.")]
+    private static partial void LogPullSourceFatalFailure(
+        ILogger logger,
+        Exception exception,
+        string packageId,
+        string sourceId);
+
+    [LoggerMessage(
+        EventId = 1020,
+        Level = LogLevel.Information,
+        Message = "Starting offline push for package {PackageId} with {PendingOperationCount} pending operations.")]
+    private static partial void LogPushStarted(ILogger logger, string packageId, int pendingOperationCount);
+
+    [LoggerMessage(
+        EventId = 1021,
+        Level = LogLevel.Warning,
+        Message = "Offline push canceled for package {PackageId} while operation {OperationId} was active.")]
+    private static partial void LogPushCanceled(ILogger logger, string packageId, string operationId);
+
+    [LoggerMessage(
+        EventId = 1022,
+        Level = LogLevel.Error,
+        Message = "Offline push operation {OperationId} for package {PackageId} source {SourceId} exceeded max attempts: {AttemptCount}/{MaxAttempts}.")]
+    private static partial void LogPushOperationMaxAttempts(
+        ILogger logger,
+        string packageId,
+        string sourceId,
+        string operationId,
+        int attemptCount,
+        int maxAttempts);
+
+    [LoggerMessage(
+        EventId = 1023,
+        Level = LogLevel.Debug,
+        Message = "Offline push operation {OperationId} succeeded for package {PackageId} source {SourceId}.")]
+    private static partial void LogPushOperationSucceeded(ILogger logger, string packageId, string sourceId, string operationId);
+
+    [LoggerMessage(
+        EventId = 1024,
+        Level = LogLevel.Warning,
+        Message = "Offline push operation {OperationId} for package {PackageId} source {SourceId} failed with a retryable exception.")]
+    private static partial void LogPushOperationRetryableException(
+        ILogger logger,
+        Exception exception,
+        string packageId,
+        string sourceId,
+        string operationId);
+
+    [LoggerMessage(
+        EventId = 1025,
+        Level = LogLevel.Warning,
+        Message = "Offline push operation {OperationId} for package {PackageId} source {SourceId} reported retryable provider failure: {Reason}.")]
+    private static partial void LogPushOperationRetryableProviderFailure(
+        ILogger logger,
+        string packageId,
+        string sourceId,
+        string operationId,
+        string reason);
+
+    [LoggerMessage(
+        EventId = 1026,
+        Level = LogLevel.Error,
+        Message = "Offline push operation {OperationId} for package {PackageId} source {SourceId} reported fatal provider failure: {Reason}.")]
+    private static partial void LogPushOperationFatalProviderFailure(
+        ILogger logger,
+        string packageId,
+        string sourceId,
+        string operationId,
+        string reason);
+
+    [LoggerMessage(
+        EventId = 1027,
+        Level = LogLevel.Warning,
+        Message = "Offline push operation {OperationId} for package {PackageId} source {SourceId} reported a conflict: {Reason}.")]
+    private static partial void LogPushOperationConflict(
+        ILogger logger,
+        string packageId,
+        string sourceId,
+        string operationId,
+        string reason);
 
     private sealed record EditRequestBuildResult
     {

--- a/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
@@ -218,7 +218,7 @@ public sealed class CatalogClientTests
     }
 
     [Fact]
-    public async Task SearchAsync_LayerOnlyLimitedQueryFetchesOnlyRequestedLayerDetails()
+    public async Task SearchAsync_LayerOnlyLimitedQuerySkipsMissingLayerDetailsBeforePaging()
     {
         var requests = new Dictionary<string, int>(StringComparer.Ordinal);
         var client = CreateCatalogClient(req =>
@@ -263,10 +263,14 @@ public sealed class CatalogClientTests
                     geometryType = "esriGeometryPoint",
                     capabilities = "Query"
                 })),
-                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                "/rest/services/beta/FeatureServer/0?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
                 {
-                    Content = new StringContent("""{"message":"not found"}""")
-                })
+                    id = 0,
+                    name = "Beta zero",
+                    geometryType = "esriGeometryPoint",
+                    capabilities = "Query"
+                })),
+                _ => Task.FromResult(TestHelpers.CreateRawJsonResponse(new { message = "not found" }, HttpStatusCode.NotFound))
             };
         });
 
@@ -274,20 +278,29 @@ public sealed class CatalogClientTests
         {
             Kinds = [CatalogItemKind.Layer],
             SortBy = CatalogSortBy.ServiceName,
-            Limit = 1
+            Limit = 2
         });
 
-        var item = Assert.Single(result.Items);
-        Assert.Equal("alpha", item.ServiceName);
-        Assert.Equal(0, item.LayerId);
-        Assert.Equal(4, result.TotalCount);
-        Assert.Equal(1, result.NextOffset);
+        Assert.Collection(
+            result.Items,
+            item =>
+            {
+                Assert.Equal("alpha", item.ServiceName);
+                Assert.Equal(0, item.LayerId);
+            },
+            item =>
+            {
+                Assert.Equal("beta", item.ServiceName);
+                Assert.Equal(0, item.LayerId);
+            });
+        Assert.Equal(2, result.TotalCount);
+        Assert.Null(result.NextOffset);
         Assert.Equal(1, requests["/rest/services/alpha/FeatureServer?f=json"]);
         Assert.Equal(1, requests["/rest/services/beta/FeatureServer?f=json"]);
         Assert.Equal(1, requests["/rest/services/alpha/FeatureServer/0?f=json"]);
-        Assert.DoesNotContain("/rest/services/alpha/FeatureServer/1?f=json", requests.Keys);
-        Assert.DoesNotContain("/rest/services/beta/FeatureServer/0?f=json", requests.Keys);
-        Assert.DoesNotContain("/rest/services/beta/FeatureServer/1?f=json", requests.Keys);
+        Assert.Equal(1, requests["/rest/services/alpha/FeatureServer/1?f=json"]);
+        Assert.Equal(1, requests["/rest/services/beta/FeatureServer/0?f=json"]);
+        Assert.Equal(1, requests["/rest/services/beta/FeatureServer/1?f=json"]);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
+++ b/tests/Honua.Sdk.Admin.Tests/CatalogClientTests.cs
@@ -24,9 +24,11 @@ public sealed class CatalogClientTests
     [Fact]
     public async Task SearchAsync_ReturnsServicesLayersGroupsAndSavedSourceDescriptors()
     {
+        var requests = new Dictionary<string, int>(StringComparer.Ordinal);
         var client = CreateCatalogClient(req =>
         {
             var pathAndQuery = req.RequestUri!.PathAndQuery;
+            requests[pathAndQuery] = requests.GetValueOrDefault(pathAndQuery) + 1;
             return pathAndQuery switch
             {
                 "/api/v1/admin/metadata/resources?kind=Service" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
@@ -145,6 +147,7 @@ public sealed class CatalogClientTests
 
         var descriptor = Assert.Single(result.Items, item => item.Kind == CatalogItemKind.SourceDescriptor);
         Assert.Equal("parks-source", descriptor.SourceDescriptor!.Descriptor.Id);
+        Assert.Equal(1, requests["/rest/services/parks/FeatureServer?f=json"]);
     }
 
     [Fact]
@@ -212,6 +215,79 @@ public sealed class CatalogClientTests
         Assert.Equal(CatalogItemKind.Layer, item.Kind);
         Assert.Equal(1, result.TotalCount);
         Assert.Null(result.NextOffset);
+    }
+
+    [Fact]
+    public async Task SearchAsync_LayerOnlyLimitedQueryFetchesOnlyRequestedLayerDetails()
+    {
+        var requests = new Dictionary<string, int>(StringComparer.Ordinal);
+        var client = CreateCatalogClient(req =>
+        {
+            var pathAndQuery = req.RequestUri!.PathAndQuery;
+            requests[pathAndQuery] = requests.GetValueOrDefault(pathAndQuery) + 1;
+            return pathAndQuery switch
+            {
+                "/api/v1/admin/metadata/resources?kind=Service" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/metadata/resources?kind=Layer" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/metadata/resources?kind=Group" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/metadata/resources?kind=SourceDescriptor" => Task.FromResult(TestHelpers.CreateJsonResponse(Array.Empty<object>())),
+                "/api/v1/admin/services/" => Task.FromResult(TestHelpers.CreateJsonResponse(new[]
+                {
+                    new
+                    {
+                        serviceName = "alpha",
+                        layerCount = 2,
+                        enabledProtocols = new[] { "FeatureServer" }
+                    },
+                    new
+                    {
+                        serviceName = "beta",
+                        layerCount = 2,
+                        enabledProtocols = new[] { "FeatureServer" }
+                    }
+                })),
+                "/rest/services/alpha/FeatureServer?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    capabilities = "Query",
+                    layers = new[] { new { id = 0, name = "Alpha zero" }, new { id = 1, name = "Alpha one" } }
+                })),
+                "/rest/services/beta/FeatureServer?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    capabilities = "Query",
+                    layers = new[] { new { id = 0, name = "Beta zero" }, new { id = 1, name = "Beta one" } }
+                })),
+                "/rest/services/alpha/FeatureServer/0?f=json" => Task.FromResult(TestHelpers.CreateRawJsonResponse(new
+                {
+                    id = 0,
+                    name = "Alpha zero",
+                    geometryType = "esriGeometryPoint",
+                    capabilities = "Query"
+                })),
+                _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("""{"message":"not found"}""")
+                })
+            };
+        });
+
+        var result = await client.SearchAsync(new CatalogQueryOptions
+        {
+            Kinds = [CatalogItemKind.Layer],
+            SortBy = CatalogSortBy.ServiceName,
+            Limit = 1
+        });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal("alpha", item.ServiceName);
+        Assert.Equal(0, item.LayerId);
+        Assert.Equal(4, result.TotalCount);
+        Assert.Equal(1, result.NextOffset);
+        Assert.Equal(1, requests["/rest/services/alpha/FeatureServer?f=json"]);
+        Assert.Equal(1, requests["/rest/services/beta/FeatureServer?f=json"]);
+        Assert.Equal(1, requests["/rest/services/alpha/FeatureServer/0?f=json"]);
+        Assert.DoesNotContain("/rest/services/alpha/FeatureServer/1?f=json", requests.Keys);
+        Assert.DoesNotContain("/rest/services/beta/FeatureServer/0?f=json", requests.Keys);
+        Assert.DoesNotContain("/rest/services/beta/FeatureServer/1?f=json", requests.Keys);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Honua.Sdk.GeoServices.Extensions;
 using Honua.Sdk.GeoServices.FeatureServer;
+using Honua.Sdk.GeoServices.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -79,6 +80,35 @@ public sealed class ClientOptionsTests
     }
 
     [Fact]
+    public void GeoServicesClientRegistrations_PreservePerClientSnapshots()
+    {
+        var featureBaseAddress = new Uri("https://feature.example");
+        var routingBaseAddress = new Uri("https://routing.example");
+        var routingTimeout = TimeSpan.FromSeconds(44);
+        var services = new ServiceCollection();
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = featureBaseAddress;
+            options.EnableRetry = false;
+            options.RoutingServiceId = "FeatureRouting";
+        });
+        services.AddHonuaRouting(options =>
+        {
+            options.BaseAddress = routingBaseAddress;
+            options.EnableRetry = false;
+            options.Timeout = routingTimeout;
+            options.RoutingServiceId = "Network";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var routingClient = provider.GetRequiredService<HonuaRoutingClient>();
+
+        Assert.Equal(routingBaseAddress, GetHttpClient(routingClient).BaseAddress);
+        Assert.Equal(routingTimeout, GetHttpClient(routingClient).Timeout);
+        Assert.Equal("Network", GetRoutingOptions(routingClient).RoutingServiceId);
+    }
+
+    [Fact]
     public void AddHonuaFeatureServer_InvalidTimeout_Throws()
     {
         var services = new ServiceCollection();
@@ -89,12 +119,21 @@ public sealed class ClientOptionsTests
         Assert.Contains("timeout", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static HttpClient GetHttpClient(HonuaFeatureServerClient client)
+    private static HttpClient GetHttpClient(object client)
     {
-        var field = typeof(HonuaFeatureServerClient).GetField("_http", BindingFlags.Instance | BindingFlags.NonPublic);
+        var field = client.GetType().GetField("_http", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);
 
         var value = field!.GetValue(client);
         return Assert.IsType<HttpClient>(value);
+    }
+
+    private static HonuaGeoServicesClientOptions GetRoutingOptions(HonuaRoutingClient client)
+    {
+        var field = typeof(HonuaRoutingClient).GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        var value = field!.GetValue(client);
+        return Assert.IsType<HonuaGeoServicesClientOptions>(value);
     }
 }

--- a/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/ClientOptionsTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Honua.Sdk.GeoServices.Extensions;
 using Honua.Sdk.GeoServices.FeatureServer;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Honua.Sdk.GeoServices.Tests;
 
@@ -34,6 +35,47 @@ public sealed class ClientOptionsTests
         var client = provider.GetRequiredService<HonuaFeatureServerClient>();
 
         Assert.Equal(timeout, GetHttpClient(client).Timeout);
+    }
+
+    [Fact]
+    public void GeoServicesClientRegistrations_DoNotOverwriteSharedOptions()
+    {
+        var firstBaseAddress = new Uri("https://first.example");
+        var firstTimeout = TimeSpan.FromSeconds(33);
+        var services = new ServiceCollection();
+        services.AddHonuaFeatureServer(options =>
+        {
+            options.BaseAddress = firstBaseAddress;
+            options.EnableRetry = false;
+            options.Timeout = firstTimeout;
+        });
+        services.AddHonuaRouting(options =>
+        {
+            options.BaseAddress = new Uri("https://routing.example");
+            options.EnableRetry = false;
+            options.Timeout = TimeSpan.FromSeconds(44);
+        });
+        services.AddHonuaImageServer(options =>
+        {
+            options.BaseAddress = new Uri("https://image.example");
+            options.EnableRetry = false;
+            options.Timeout = TimeSpan.FromSeconds(55);
+        });
+        services.AddHonuaGeometryServer(options =>
+        {
+            options.BaseAddress = new Uri("https://geometry.example");
+            options.EnableRetry = false;
+            options.Timeout = TimeSpan.FromSeconds(66);
+        });
+
+        Assert.Single(services, descriptor =>
+            descriptor.ServiceType == typeof(IOptions<HonuaGeoServicesClientOptions>));
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HonuaGeoServicesClientOptions>>().Value;
+
+        Assert.Equal(firstBaseAddress, options.BaseAddress);
+        Assert.Equal(firstTimeout, options.Timeout);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
+++ b/tests/Honua.Sdk.GeoServices.Tests/FeatureServer/HonuaFeatureServerClientTests.cs
@@ -613,6 +613,68 @@ public class HonuaFeatureServerClientTests
     }
 
     [Fact]
+    public async Task ApplyEditsAsync_SharedAbstraction_CachesObjectIdFieldPerLayer()
+    {
+        var metadataRequests = 0;
+        var editRequests = 0;
+        var capturedForms = new List<Dictionary<string, string?>>();
+        var client = TestHelpers.CreateFeatureServerClient(async req =>
+        {
+            var path = req.RequestUri?.AbsolutePath;
+            if (req.Method == HttpMethod.Get && path == "/rest/services/svc/FeatureServer/0")
+            {
+                metadataRequests++;
+                return TestHelpers.CreateRawJsonResponse(
+                    """{ "id": 0, "objectIdField": "OBJECTID", "capabilities": "Query,Create,Update,Delete" }""");
+            }
+
+            if (req.Method == HttpMethod.Post && path == "/rest/services/svc/FeatureServer/0/applyEdits")
+            {
+                editRequests++;
+                capturedForms.Add(await ParseFormAsync(req).ConfigureAwait(false));
+                return TestHelpers.CreateRawJsonResponse("""
+                {
+                    "addResults": [],
+                    "updateResults": [{ "objectId": 1, "success": true }],
+                    "deleteResults": []
+                }
+                """);
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {req.Method} {req.RequestUri}");
+        });
+
+        var edits = (IHonuaFeatureEditClient)client;
+
+        await edits.ApplyEditsAsync(BuildUpdateRequest(1));
+        await edits.ApplyEditsAsync(BuildUpdateRequest(2));
+
+        Assert.Equal(1, metadataRequests);
+        Assert.Equal(2, editRequests);
+        Assert.Equal(2, capturedForms.Count);
+        using var firstUpdates = JsonDocument.Parse(capturedForms[0]["updates"]!);
+        using var secondUpdates = JsonDocument.Parse(capturedForms[1]["updates"]!);
+        Assert.Equal(1, firstUpdates.RootElement[0].GetProperty("attributes").GetProperty("OBJECTID").GetInt64());
+        Assert.Equal(2, secondUpdates.RootElement[0].GetProperty("attributes").GetProperty("OBJECTID").GetInt64());
+
+        static FeatureEditRequest BuildUpdateRequest(long objectId) => new()
+        {
+            Source = new FeatureSource { ServiceId = "svc", LayerId = 0 },
+            Updates =
+            [
+                new FeatureEditFeature
+                {
+                    ObjectId = objectId,
+                    Attributes = new Dictionary<string, JsonElement>
+                    {
+                        ["NAME"] = JsonValue($"Feature {objectId}"),
+                    },
+                }
+            ],
+        };
+    }
+
+    [Fact]
     public async Task ApplyEditsAsync_SharedAbstraction_NonNumericDeleteId_Throws()
     {
         var client = TestHelpers.CreateFeatureServerClient(_ =>
@@ -820,7 +882,7 @@ public class HonuaFeatureServerClientTests
     {
         var client = TestHelpers.CreateFeatureServerClient(_ =>
             Task.FromResult(TestHelpers.CreateRawJsonResponse("""
-            { "id": 0, "objectIdField": "OBJECTID", "capabilities": "Query,Create,Update,Delete" }
+            { "id": 0, "objectIdField": "OBJECTID", "capabilities": "Query, create, UPDATE, delete" }
             """)));
 
         var capabilities = await client.GetEditCapabilitiesAsync("svc", 0);

--- a/tests/Honua.Sdk.Geometry.Tests/GeoJsonGeometryConverterTests.cs
+++ b/tests/Honua.Sdk.Geometry.Tests/GeoJsonGeometryConverterTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Honua. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root.
 
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Honua.Sdk.Geometry;
 using NetTopologySuite.Geometries;
@@ -20,6 +22,32 @@ public class GeoJsonGeometryConverterTests
         var point = Assert.IsType<Point>(geometry);
         Assert.Equal(-157.8583, point.X, precision: 4);
         Assert.Equal(21.3069, point.Y, precision: 4);
+    }
+
+    [Fact]
+    public void ReadGeometry_CachesSerializerOptionsForGeometryFactoryReference()
+    {
+        var cacheField = typeof(GeoJsonGeometryConverter).GetField(
+            "SerializerOptionsByGeometryFactory",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(cacheField);
+        var cache = Assert.IsType<ConditionalWeakTable<GeometryFactory, JsonSerializerOptions>>(cacheField.GetValue(null));
+        var factory = new GeometryFactory(new PrecisionModel(), 3857);
+
+        Assert.False(cache.TryGetValue(factory, out _));
+
+        var firstGeometry = GeoJsonGeometryConverter.ReadGeometry(
+            """{"type":"Point","coordinates":[1,2]}""",
+            factory);
+        Assert.Equal(3857, firstGeometry.SRID);
+        Assert.True(cache.TryGetValue(factory, out var firstOptions));
+
+        _ = GeoJsonGeometryConverter.ReadGeometry(
+            """{"type":"Point","coordinates":[3,4]}""",
+            factory);
+
+        Assert.True(cache.TryGetValue(factory, out var secondOptions));
+        Assert.Same(firstOptions, secondOptions);
     }
 
     [Fact]

--- a/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
+++ b/tests/Honua.Sdk.Offline.Tests/OfflineSyncEngineTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Honua.Sdk.Abstractions.Features;
 using Honua.Sdk.Offline.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace Honua.Sdk.Offline.Tests;
 
@@ -199,18 +200,21 @@ public sealed class OfflineSyncEngineTests
         // auto-pagination safety limit is hit. The pull must capture this as a
         // non-retryable per-source failure (and a terminal Failed state) instead of
         // letting it escape and abort every remaining source.
+        var error = new InvalidOperationException(
+            "Auto-pagination safety limit reached (100 pages).");
         var queryClient = new FakeQueryClient
         {
-            PagesError = new InvalidOperationException(
-                "Auto-pagination safety limit reached (100 pages)."),
+            PagesError = error,
         };
         var store = new FakeOfflineStore();
+        var logger = new FakeLogger<OfflineSyncEngine>();
         var engine = CreateEngine(
             queryClient,
             new FakeEditClient(),
             store,
             new FakeChangeJournal(),
-            stateStore: store);
+            stateStore: store,
+            logger: logger);
 
         var result = await engine.PullAsync(CreateManifest());
 
@@ -218,8 +222,19 @@ public sealed class OfflineSyncEngineTests
         Assert.Equal("parks", failure.SourceId);
         Assert.False(failure.Retryable);
         Assert.Contains("safety limit", failure.Reason, StringComparison.Ordinal);
-        Assert.Contains(store.States, state =>
-            state.SourceId == "parks" && state.Phase == OfflineSyncPhase.Failed);
+        Assert.Contains("System.InvalidOperationException", failure.Reason, StringComparison.Ordinal);
+        Assert.Contains(nameof(FakeQueryClient.QueryPagesAsync), failure.Reason, StringComparison.Ordinal);
+
+        var failedState = Assert.Single(
+            store.States,
+            state => state.SourceId == "parks" && state.Phase == OfflineSyncPhase.Failed);
+        Assert.Equal(failure.Reason, failedState.LastError);
+
+        var logEntry = Assert.Single(logger.Entries, entry => entry.EventId.Id == 1013);
+        Assert.Equal(LogLevel.Error, logEntry.Level);
+        Assert.Same(error, logEntry.Exception);
+        Assert.Contains("field-area-1", logEntry.Message, StringComparison.Ordinal);
+        Assert.Contains("parks", logEntry.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -246,6 +261,40 @@ public sealed class OfflineSyncEngineTests
         Assert.Equal(OfflineSyncPhase.Failed, store.States[^1].Phase);
     }
 
+    [Fact]
+    public async Task SyncAsync_UnhandledPushException_LogsAndStoresExceptionDiagnostics()
+    {
+        var error = new InvalidOperationException("edit service failed unexpectedly");
+        var editClient = new FakeEditClient
+        {
+            ApplyError = error,
+        };
+        var store = new FakeOfflineStore();
+        var logger = new FakeLogger<OfflineSyncEngine>();
+        var engine = CreateEngine(
+            new FakeQueryClient(),
+            editClient,
+            store,
+            new FakeChangeJournal([CreateOperation(OfflineEditOperationKind.Add)]),
+            stateStore: store,
+            logger: logger);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() => engine.SyncAsync(CreateManifest()));
+
+        Assert.Same(error, thrown);
+        var failedState = Assert.Single(
+            store.States,
+            state => state.SourceId is null && state.Phase == OfflineSyncPhase.Failed);
+        Assert.Contains("System.InvalidOperationException", failedState.LastError, StringComparison.Ordinal);
+        Assert.Contains(nameof(FakeEditClient.ApplyEditsAsync), failedState.LastError, StringComparison.Ordinal);
+
+        var logEntry = Assert.Single(logger.Entries, entry => entry.EventId.Id == 1006);
+        Assert.Equal(LogLevel.Error, logEntry.Level);
+        Assert.Same(error, logEntry.Exception);
+        Assert.Contains("field-area-1", logEntry.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(OfflineSyncPhase.Pushing), logEntry.Message, StringComparison.Ordinal);
+    }
+
     private static OfflineSyncEngine CreateEngine(
         FakeQueryClient queryClient,
         FakeEditClient editClient,
@@ -253,7 +302,8 @@ public sealed class OfflineSyncEngineTests
         FakeChangeJournal journal,
         FakeConflictStore? conflictStore = null,
         OfflineSyncEngineOptions? options = null,
-        IOfflineSyncStateStore? stateStore = null)
+        IOfflineSyncStateStore? stateStore = null,
+        ILogger<OfflineSyncEngine>? logger = null)
         => new(
             queryClient,
             editClient,
@@ -262,7 +312,8 @@ public sealed class OfflineSyncEngineTests
             store,
             options,
             stateStore,
-            conflictStore);
+            conflictStore,
+            logger);
 
     private static OfflinePackageManifest CreateManifest()
         => new()
@@ -385,8 +436,15 @@ public sealed class OfflineSyncEngineTests
 
         public List<FeatureEditRequest> Requests { get; } = [];
 
+        public Exception? ApplyError { get; init; }
+
         public Task<FeatureEditResponse> ApplyEditsAsync(FeatureEditRequest request, CancellationToken cancellationToken = default)
         {
+            if (ApplyError is not null)
+            {
+                throw ApplyError;
+            }
+
             Requests.Add(request);
             return Task.FromResult(Responses.Dequeue());
         }
@@ -522,4 +580,29 @@ public sealed class OfflineSyncEngineTests
         public Task ResolveConflictAsync(string operationId, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
+
+    private sealed class FakeLogger<T> : ILogger<T>
+    {
+        public List<FakeLogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            Entries.Add(new FakeLogEntry(logLevel, eventId, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record FakeLogEntry(LogLevel Level, EventId EventId, string Message, Exception? Exception);
 }


### PR DESCRIPTION
## Summary
- Integrate the completed issue #196 Allstar workflow hardening branch.
- Integrate issue #254 audit-backlog slices for Admin/catalog, GeoServices, Offline, and Geometry.
- Add a workflow lint fix so the new actionlint validation gate passes in this combined branch.

## Validation
- PyYAML parse over .github/**/*.yml
- digest-pinned Docker actionlint
- dotnet test tests/Honua.Sdk.Admin.Tests/Honua.Sdk.Admin.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.GeoServices.Tests/Honua.Sdk.GeoServices.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj --configuration Release
- dotnet test tests/Honua.Sdk.Geometry.Tests/Honua.Sdk.Geometry.Tests.csproj --configuration Release
- dotnet build Honua.Sdk.sln --configuration Release /p:TreatWarningsAsErrors=true
- dotnet test Honua.Sdk.sln --configuration Release --no-build

Closes #196
Closes #254