### PR TITLE
feat(cli): add support-safe doctor bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,9 @@ jobs:
 
   dotnet-sdk:
     # Matrix replacement for the 13 previously-duplicated dotnet-<package>-sdk
-    # jobs. Each matrix leg builds one shipped SDK package (13 sub-packages plus
-    # the Honua.Sdk meta) under strict release flags and, when present, runs its
-    # dedicated test project. The strict flag set
+    # jobs. Each matrix leg builds one shipped SDK package (13 sub-packages,
+    # the Honua.Sdk meta, plus the separate CLI tool) under strict release
+    # flags and, when present, runs its dedicated test project. The strict flag set
     # (TreatWarningsAsErrors=true / EnforceCodeStyleInBuild=true / Release) is
     # preserved verbatim. fail-fast is disabled so one package's failure does
     # not mask the others -- we want to see every red leg in a single run.
@@ -298,6 +298,11 @@ jobs:
             src: src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj
             tests:
               - tests/Honua.Sdk.ConsoleShare.Tests/Honua.Sdk.ConsoleShare.Tests.csproj
+          # Schema-pinned support-safe `honua doctor` .NET tool.
+          - label: Cli
+            src: src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj
+            tests:
+              - tests/Honua.Sdk.Cli.Tests/Honua.Sdk.Cli.Tests.csproj
           # Umbrella meta package -- builds Honua.Sdk and runs the AddHonua DI
           # smoke test that exercises the umbrella's registration surface.
           - label: Meta

--- a/.github/workflows/publish-dotnet-sdk.yml
+++ b/.github/workflows/publish-dotnet-sdk.yml
@@ -69,6 +69,7 @@ jobs:
             "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
             "src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj"
             "src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj"
+            "src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj"
             "src/Honua.Sdk/Honua.Sdk.csproj"
           )
 
@@ -127,6 +128,7 @@ jobs:
             "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
             "src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj"
             "src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj"
+            "src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj"
             "src/Honua.Sdk/Honua.Sdk.csproj"
           )
 
@@ -153,6 +155,7 @@ jobs:
             "tests/Honua.Sdk.Offline.Tests/Honua.Sdk.Offline.Tests.csproj"
             "tests/Honua.Sdk.Studio.Tests/Honua.Sdk.Studio.Tests.csproj"
             "tests/Honua.Sdk.ConsoleShare.Tests/Honua.Sdk.ConsoleShare.Tests.csproj"
+            "tests/Honua.Sdk.Cli.Tests/Honua.Sdk.Cli.Tests.csproj"
             "tests/Honua.Sdk.MetaSmoke.Tests/Honua.Sdk.MetaSmoke.Tests.csproj"
           )
 
@@ -216,6 +219,7 @@ jobs:
             "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
             "src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj"
             "src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj"
+            "src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj"
             "src/Honua.Sdk/Honua.Sdk.csproj"
           )
 
@@ -254,6 +258,7 @@ jobs:
             "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
             "src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj"
             "src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj"
+            "src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj"
             "src/Honua.Sdk/Honua.Sdk.csproj"
           )
 
@@ -284,6 +289,7 @@ jobs:
             "src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj"
             "src/Honua.Sdk.Studio/Honua.Sdk.Studio.csproj"
             "src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj"
+            "src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj"
             "src/Honua.Sdk/Honua.Sdk.csproj"
           )
 

--- a/Honua.Sdk.sln
+++ b/Honua.Sdk.sln
@@ -96,11 +96,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfflineConflictConsole", "examples\OfflineConflictConsole\OfflineConflictConsole.csproj", "{08FAB285-9461-48CF-A3C2-763D470BF544}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FieldFormConsole", "examples\FieldFormConsole\FieldFormConsole.csproj", "{1B913296-7F44-425E-8EEB-51C1E9967F9A}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.ConsoleShare", "src\Honua.Sdk.ConsoleShare\Honua.Sdk.ConsoleShare.csproj", "{2A710C6A-B656-4803-A3D0-A38FE81E21B7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.ConsoleShare.Tests", "tests\Honua.Sdk.ConsoleShare.Tests\Honua.Sdk.ConsoleShare.Tests.csproj", "{68A8457E-4830-45F3-A0BA-C68F706201B4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Conformance.Tests", "tests\Honua.Sdk.Conformance.Tests\Honua.Sdk.Conformance.Tests.csproj", "{11481936-9CF4-444A-A1A7-B7E56C118278}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Cli", "src\Honua.Sdk.Cli\Honua.Sdk.Cli.csproj", "{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honua.Sdk.Cli.Tests", "tests\Honua.Sdk.Cli.Tests\Honua.Sdk.Cli.Tests.csproj", "{9E5F4FBD-2100-486E-A13D-50771F11B489}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -676,6 +681,30 @@ Global
 		{11481936-9CF4-444A-A1A7-B7E56C118278}.Release|x64.Build.0 = Release|Any CPU
 		{11481936-9CF4-444A-A1A7-B7E56C118278}.Release|x86.ActiveCfg = Release|Any CPU
 		{11481936-9CF4-444A-A1A7-B7E56C118278}.Release|x86.Build.0 = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|x64.Build.0 = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Debug|x86.Build.0 = Debug|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|x64.ActiveCfg = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|x64.Build.0 = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|x86.ActiveCfg = Release|Any CPU
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E}.Release|x86.Build.0 = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|x64.Build.0 = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E5F4FBD-2100-486E-A13D-50771F11B489}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -728,5 +757,7 @@ Global
 		{2A710C6A-B656-4803-A3D0-A38FE81E21B7} = {2F8F8F8F-8F8F-8F8F-8F8F-8F8F8F8F8F8F}
 		{68A8457E-4830-45F3-A0BA-C68F706201B4} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 		{11481936-9CF4-444A-A1A7-B7E56C118278} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
+		{DB369D5C-9C66-4C4A-9A0C-9E33F478D98E} = {2F8F8F8F-8F8F-8F8F-8F8F-8F8F8F8F8F8F}
+		{9E5F4FBD-2100-486E-A13D-50771F11B489} = {3F9F9F9F-9F9F-9F9F-9F9F-9F9F9F9F9F9F}
 	EndGlobalSection
 EndGlobal

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@
 | `Honua.Sdk.Scenes` | Scene metadata, endpoint resolution, and offline scene package contracts |
 | `Honua.Sdk.OgcFeatures` | OGC API Features read/query client plus WFS 2.0 read surface (GetCapabilities, GetFeature, DescribeFeatureType) |
 | `Honua.Sdk.Catalogs` | OGC API Records + STAC catalog client (landing pages, conformance, collections, item / record search and paging) |
+| `Honua.Sdk.Cli` | Global .NET tool providing the support-safe, schema-pinned `honua doctor` diagnostic emitter and read-only replay |
 
 ## Prerequisites
 
@@ -70,6 +71,13 @@ dotnet add package Honua.Sdk.OgcFeatures
 # Metadata / catalog clients
 dotnet add package Honua.Sdk.Scenes
 dotnet add package Honua.Sdk.Catalogs
+```
+
+Install the CLI as a .NET tool rather than an application dependency:
+
+```bash
+dotnet tool install --global Honua.Sdk.Cli
+honua doctor --help
 ```
 
 All SDK packages share one package version from `Directory.Build.props`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ real-time feature stream contracts.
 
 > **New here? Pick your path:**
 > - Just want to call the server in 5 minutes → [docs/quickstart.md](docs/quickstart.md)
-> - Want a map of the 14 packages before you choose → [docs/architecture.md](docs/architecture.md)
+> - Want a map of the client packages and CLI tool → [docs/architecture.md](docs/architecture.md)
 > - Want to browse the public docs → [docs/README.md](docs/README.md)
 > - Want to install pre-release packages → [INSTALL.md](INSTALL.md)
 > - Hit a problem → [docs/troubleshooting.md](docs/troubleshooting.md)
@@ -38,6 +38,7 @@ Current SDK capabilities are summarized in [docs/features/README.md](docs/featur
 | **Honua.Sdk.Scenes** | Scene metadata client -- list/detail/resolve scene endpoints plus offline scene package contracts |
 | **Honua.Sdk.OgcFeatures** | OGC API Features and WFS 2.0 read/query client -- landing page, conformance, collections, queryables, items, plus WFS GetCapabilities / GetFeature (GeoJSON) / DescribeFeatureType |
 | **Honua.Sdk.Catalogs** | OGC API Records + STAC catalog client -- landing pages, conformance, collections, item / record pages, GET/POST search with paging, raw JSON |
+| **Honua.Sdk.Cli** | `honua doctor` .NET tool -- schema-pinned sanitized diagnostic bundles, anonymous capability probe, and bounded read-only replay |
 | *Geocoding* (in Admin) | Forward/reverse geocoding and autocomplete via `IHonuaGeocodingClient` |
 
 Browser and WebAssembly consumers should start with
@@ -73,6 +74,16 @@ dotnet add package Honua.Sdk.Catalogs
 ```
 
 </details>
+
+Install the support-safe diagnostics tool separately:
+
+```bash
+dotnet tool install --global Honua.Sdk.Cli
+honua doctor --help
+```
+
+See [Sanitized diagnostic bundles](docs/diagnostic-bundles.md) for capture,
+consent, privacy, and replay guidance.
 
 Prerelease / dry-run builds are also available from
 [GitHub Packages](INSTALL.md#install-from-github-packages).
@@ -186,6 +197,7 @@ src/
   Honua.Sdk.Spec/                Spec workspace validate/plan/apply/artifact client package
   Honua.Sdk.Studio/              Console Studio analysis-report read client package
   Honua.Sdk.ConsoleShare/        Console Share access/public-link/embed-token, export/traffic, and open-data (DCAT/STAC) client package
+  Honua.Sdk.Cli/                 `honua doctor` support-safe diagnostic .NET tool
   Honua.Sdk.Field/               Field form, validation, and workflow contracts
   Honua.Sdk.GeoServices/         GeoServices FeatureServer + routing client package
   Honua.Sdk.Scenes/              Scene metadata and offline package contract client

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ An index of the public documentation that ships alongside the
 
 ## Get started
 
-- [Architecture overview](architecture.md) — a one-page map of the 14 packages (meta plus 13 sub-packages), how they compose, and which one to depend on.
+- [Architecture overview](architecture.md) — a one-page map of the client packages and separate CLI tool, how they compose, and which one to use.
 - [Quickstart](quickstart.md) — build a console app that talks gRPC + REST in 5 minutes.
 - [API reference](api-reference.md) — how to browse the full XML-doc API surface (IDE hover, local DocFX site, or GitHub source).
 - [INSTALL.md](../INSTALL.md) — NuGet, GitHub Packages, version policy, server compatibility baseline.
@@ -15,6 +15,7 @@ An index of the public documentation that ships alongside the
 - [Console client contracts](console-client-contracts.md) — Blazor Web and MAUI host contract map, route guards, environment profiles, Studio reports/artifacts, native mTLS state, and fixtures.
 - [Browser / WASM support](browser-wasm-support.md) — supported surface, gRPC-Web, host-side constraints.
 - [Troubleshooting](troubleshooting.md) — concrete failure modes and fixes for configuration, auth, retry, CORS, compatibility, Catalog/Records/STAC/Scenes, and offline sync.
+- [Sanitized diagnostic bundles](diagnostic-bundles.md) — `honua doctor` capture, consent, schema provenance, privacy boundary, and read-only replay.
 
 ## Capability guides
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,7 @@ per-package `AddHonua*` extensions remain available unchanged.
 | Define / validate field forms, run record workflows | `Honua.Sdk.Field` |
 | Write a library that's agnostic to transport | `Honua.Sdk.Abstractions` only |
 | Model Console shells, route guards, environment profiles, and mTLS state | `Honua.Sdk.Abstractions` |
+| Emit a sanitized support bundle or perform bounded read-only replay | Install the separate `Honua.Sdk.Cli` .NET tool and run `honua doctor` |
 
 ## How clients compose
 

--- a/docs/diagnostic-bundles.md
+++ b/docs/diagnostic-bundles.md
@@ -1,0 +1,113 @@
+# Sanitized diagnostic bundles (`honua doctor`)
+
+`honua doctor` creates a local, bounded support artifact and never uploads it
+automatically. The command uses the canonical
+[`diagnostic-bundle.v1` JSON Schema](https://honua.io/schemas/diagnostic-bundle.v1.json),
+mirrored byte-for-byte under `schemas/` and pinned to:
+
+- support source commit `0c990fbe8f519a00a57e26dab21cbb8f80d559ea`;
+- 6,494 bytes; and
+- SHA-256 `4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9`.
+
+The public provenance record is
+[`diagnostic-bundle.v1.provenance.json`](https://honua.io/schemas/diagnostic-bundle.v1.provenance.json).
+The .NET test lane runs the complete language-neutral support conformance
+corpus and fails if the embedded schema, provenance, manifest, or emitted wire
+shape drifts.
+
+## Install and capture
+
+```bash
+dotnet tool install --global Honua.Sdk.Cli
+```
+
+Capture the last failing HTTP exchange in a local JSON file. The input may
+contain raw values because it is read only into memory and is never copied to
+the output:
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "url": "https://server.example/api/v1/services/parcels?token=secret",
+    "headers": {
+      "authorization": "Bearer secret",
+      "x-request-id": "request-1"
+    }
+  },
+  "response": {
+    "status": 500,
+    "mediaType": "application/json",
+    "headers": { "content-type": "application/json" },
+    "body": { "error": "failed", "apiKey": "secret" }
+  }
+}
+```
+
+Then explicitly choose the classification and both consent values:
+
+```bash
+honua doctor \
+  --exchange ./failure.json \
+  --classification customer-data \
+  --redaction-acknowledged=true \
+  --share-with-support=false \
+  --output ./diagnostic-bundle.json \
+  --json
+```
+
+Add `--base-url https://server.example/honua` to attempt an anonymous,
+credential-free capability probe. The configured base path is preserved and a
+probe failure becomes a sanitized envelope without removing the supplied
+failing exchange.
+
+Review the local artifact before changing `--share-with-support=true` and
+submitting it to support intake. Output is owner-readable/writable only on
+platforms that support Unix file permissions. The process summary includes the
+SDK version, runtime, target framework, probe outcome, and schema provenance;
+those operational fields are not added to the strict v1 bundle because the
+canonical schema does not permit them.
+
+## Privacy boundary
+
+The emitter:
+
+- drops authorization, proxy authorization, cookies, API keys, signatures,
+  tokens, and every non-allowlisted header;
+- removes URL origin and user information, drops sensitive query parameters,
+  placeholders all remaining query values, and placeholders unknown path
+  segments;
+- recursively redacts sensitive JSON keys and free-text credentials, provider
+  tokens, AWS keys, JWTs, email addresses, and URL-encoded variants;
+- rejects optional bundle identifiers and consent identities containing
+  credential-shaped or personal material;
+- hashes original in-memory body bytes but persists only a redacted preview,
+  original byte count, SHA-256, and truncation/redaction flags; and
+- refuses bodies above 25 MiB, probe responses above 256 KiB, previews above
+  8 KiB, and bundles above 50 envelopes.
+
+Absent optional properties are omitted rather than serialized as `null`. No raw
+body, credential, cookie, configured secret, origin, or customer payload is
+written to stdout, stderr, the final artifact, telemetry, or snapshots.
+
+## Read-only replay
+
+Replay one sanitized exchange against a separately configured server:
+
+```bash
+honua doctor \
+  --replay ./diagnostic-bundle.json \
+  --base-url https://server.example \
+  --output ./diagnostic-replay.json \
+  --timeout-ms 10000 \
+  --json
+```
+
+Replay validates the entire input before network access, verifies the schema
+pin and body hashes, sends no captured headers or query values, omits
+credentials, and permits only one bounded `GET` or `HEAD`. It refuses mutation,
+subscriptions, job submission, uploads, traversal, placeholder path segments,
+non-HTTPS remote origins, unsafe headers, credential-bearing artifacts, hash
+drift, malformed schemas, over-budget responses, timeout, and cancellation.
+The result is a new schema-valid sanitized bundle; replay never modifies its
+input.

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,6 +22,7 @@ The publish workflow builds and packs:
 - `Honua.Sdk.Catalogs`
 - `Honua.Sdk.Offline`
 - `Honua.Sdk.ConsoleShare`
+- `Honua.Sdk.Cli` (.NET tool package)
 - `Honua.Sdk`
 
 ## Release Flow
@@ -93,6 +94,7 @@ for project in \
   src/Honua.Sdk.Catalogs/Honua.Sdk.Catalogs.csproj \
   src/Honua.Sdk.Offline/Honua.Sdk.Offline.csproj \
   src/Honua.Sdk.ConsoleShare/Honua.Sdk.ConsoleShare.csproj \
+  src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj \
   src/Honua.Sdk/Honua.Sdk.csproj
 do
   dotnet pack "$project" --configuration Release -o ./nupkgs

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -12,6 +12,8 @@
       href: console-client-contracts.md
     - name: Troubleshooting
       href: troubleshooting.md
+    - name: Sanitized diagnostic bundles
+      href: diagnostic-bundles.md
     - name: Browser / WASM
       href: browser-wasm-support.md
 - name: API reference

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,12 @@
+# Diagnostic bundle contract mirror
+
+The files in this directory mirror Honua Support's canonical public
+`diagnostic-bundle.v1` schema, provenance, and language-neutral conformance
+corpus byte-for-byte. The source of truth remains `honua-io/honua-support` at
+the commit and SHA-256 recorded in
+`diagnostic-bundle.v1.provenance.json`.
+
+`Honua.Sdk.Cli` embeds the exact schema bytes and refuses to emit a bundle when
+the byte pin or instance validation fails. The CLI test lane executes every
+valid and invalid corpus case so contract drift fails before publishing the
+tool.

--- a/schemas/diagnostic-bundle.v1.conformance/invalid/additional-property.json
+++ b/schemas/diagnostic-bundle.v1.conformance/invalid/additional-property.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready",
+      "rawResponse": "raw response bytes are forbidden"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/invalid/missing-consent.json
+++ b/schemas/diagnostic-bundle.v1.conformance/invalid/missing-consent.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/invalid/optional-null.json
+++ b/schemas/diagnostic-bundle.v1.conformance/invalid/optional-null.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "bundleId": null,
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/invalid/status-out-of-range.json
+++ b/schemas/diagnostic-bundle.v1.conformance/invalid/status-out-of-range.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready",
+      "statusCode": 600
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/invalid/wrong-version.json
+++ b/schemas/diagnostic-bundle.v1.conformance/invalid/wrong-version.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "2.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/manifest.json
+++ b/schemas/diagnostic-bundle.v1.conformance/manifest.json
@@ -1,0 +1,48 @@
+{
+  "suiteVersion": "1.0",
+  "schemaId": "https://honua.io/schemas/diagnostic-bundle.v1.json",
+  "schemaVersion": "1.0",
+  "schemaSha256": "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9",
+  "cases": [
+    {
+      "id": "minimal-valid",
+      "path": "valid/minimal.json",
+      "valid": true
+    },
+    {
+      "id": "sanitized-exchange-valid",
+      "path": "valid/sanitized-exchange.json",
+      "valid": true
+    },
+    {
+      "id": "missing-consent-invalid",
+      "path": "invalid/missing-consent.json",
+      "valid": false,
+      "expectedErrorContains": "missing required property 'consent'"
+    },
+    {
+      "id": "wrong-version-invalid",
+      "path": "invalid/wrong-version.json",
+      "valid": false,
+      "expectedErrorContains": "value must equal the constant"
+    },
+    {
+      "id": "additional-property-invalid",
+      "path": "invalid/additional-property.json",
+      "valid": false,
+      "expectedErrorContains": "unexpected property 'rawResponse'"
+    },
+    {
+      "id": "optional-null-invalid",
+      "path": "invalid/optional-null.json",
+      "valid": false,
+      "expectedErrorContains": "expected type 'string'"
+    },
+    {
+      "id": "status-out-of-range-invalid",
+      "path": "invalid/status-out-of-range.json",
+      "valid": false,
+      "expectedErrorContains": "exceeds maximum 599"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/valid/minimal.json
+++ b/schemas/diagnostic-bundle.v1.conformance/valid/minimal.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/rest/services/{service}/FeatureServer/{layer}/query"
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.conformance/valid/sanitized-exchange.json
+++ b/schemas/diagnostic-bundle.v1.conformance/valid/sanitized-exchange.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0",
+  "bundleId": "doctor-01J00000000000000000000000",
+  "contentClassification": "customer-data",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true,
+    "grantedBy": "customer-operator"
+  },
+  "envelopes": [
+    {
+      "method": "POST",
+      "normalizedPath": "/api/v1/tickets/{ticketId}/diagnostics",
+      "statusCode": 400,
+      "mediaType": "application/problem+json",
+      "correlationId": "corr-redacted-01",
+      "traceId": "0123456789abcdef0123456789abcdef",
+      "capturedAt": "2026-07-11T12:00:00Z",
+      "requestHeaders": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "responseHeaders": [
+        {
+          "name": "Content-Type",
+          "value": "application/problem+json"
+        }
+      ],
+      "requestBody": {
+        "preview": "{\"query\":\"[REDACTED]\"}",
+        "contentSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "originalByteSize": 128,
+        "redactionApplied": true,
+        "truncated": false
+      },
+      "responseBody": {
+        "preview": "{\"error\":\"validation failed\"}",
+        "contentSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "originalByteSize": 38,
+        "redactionApplied": false,
+        "truncated": false
+      }
+    }
+  ]
+}

--- a/schemas/diagnostic-bundle.v1.json
+++ b/schemas/diagnostic-bundle.v1.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://honua.io/schemas/diagnostic-bundle.v1.json",
+  "title": "Honua Sanitized Diagnostic Bundle (v1)",
+  "description": "Canonical, sanitized evidence contract for SDK/client interop tickets (honua-support#41). A diagnostic bundle NEVER carries raw request/response bytes. Each captured HTTP exchange is a sanitized envelope: HTTP method, a normalized path (path parameters and query values placeholdered), status code, media type, correlation/trace ids, an allowlist of safe headers ONLY, and redacted + truncated body previews. For each body, the ORIGINAL byte size and a content hash are recorded alongside a redaction-applied flag so integrity is verifiable without the bytes. The bundle carries explicit content-classification and consent fields. Intake VALIDATES submissions against this schema and enforces every string-length, array-count, and body-size bound below; violations are rejected with a 400. This is the canonical artifact SDK emitters and the console must conform to.",
+  "type": "object",
+  "required": ["schemaVersion", "contentClassification", "consent", "envelopes"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "description": "Contract version. Bump only on breaking changes; additive fields keep v1.",
+      "type": "string",
+      "const": "1.0"
+    },
+    "bundleId": {
+      "description": "Optional client-assigned id for the bundle. The server assigns its own id on intake.",
+      "type": "string",
+      "maxLength": 64
+    },
+    "contentClassification": {
+      "description": "Declared sensitivity of the captured content, after client-side redaction.",
+      "type": "string",
+      "enum": ["unknown", "public", "internal", "customer-data", "secret-suspected"]
+    },
+    "consent": {
+      "description": "Explicit consent to share the sanitized bundle with Honua support.",
+      "type": "object",
+      "required": ["redactionAcknowledged", "shareWithSupport"],
+      "additionalProperties": false,
+      "properties": {
+        "redactionAcknowledged": {
+          "description": "The submitter acknowledges the bundle was redacted and carries no raw secrets.",
+          "type": "boolean"
+        },
+        "shareWithSupport": {
+          "description": "The submitter consents to sharing the sanitized bundle with Honua support.",
+          "type": "boolean"
+        },
+        "grantedBy": {
+          "description": "Optional identity of the human/automation that granted consent.",
+          "type": "string",
+          "maxLength": 256
+        }
+      }
+    },
+    "envelopes": {
+      "description": "Sanitized HTTP exchanges. At least one; capped to bound bundle size.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "required": ["method", "normalizedPath"],
+        "additionalProperties": false,
+        "properties": {
+          "method": {
+            "description": "HTTP method (e.g. GET, POST).",
+            "type": "string",
+            "maxLength": 16
+          },
+          "normalizedPath": {
+            "description": "Request path with path parameters and query values placeholdered (e.g. /api/v1/tickets/{id}?status={value}).",
+            "type": "string",
+            "maxLength": 2048
+          },
+          "statusCode": {
+            "description": "HTTP status code, when the exchange produced a response.",
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "mediaType": {
+            "description": "Response media type (e.g. application/json).",
+            "type": "string",
+            "maxLength": 256
+          },
+          "correlationId": {
+            "description": "Correlation id linking the exchange to server logs.",
+            "type": "string",
+            "maxLength": 200
+          },
+          "traceId": {
+            "description": "Distributed-trace id for the exchange.",
+            "type": "string",
+            "maxLength": 200
+          },
+          "capturedAt": {
+            "description": "When the exchange was captured (ISO-8601).",
+            "type": "string",
+            "maxLength": 40
+          },
+          "requestHeaders": {
+            "description": "Allowlisted, non-secret request headers ONLY. Authorization, Cookie, and any header not on the server allowlist are never present.",
+            "type": "array",
+            "maxItems": 32,
+            "items": { "$ref": "#/$defs/header" }
+          },
+          "responseHeaders": {
+            "description": "Allowlisted, non-secret response headers ONLY. Set-Cookie and any header not on the server allowlist are never present.",
+            "type": "array",
+            "maxItems": 32,
+            "items": { "$ref": "#/$defs/header" }
+          },
+          "requestBody": { "$ref": "#/$defs/bodyPreview" },
+          "responseBody": { "$ref": "#/$defs/bodyPreview" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "header": {
+      "type": "object",
+      "required": ["name", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "maxLength": 128 },
+        "value": { "type": "string", "maxLength": 2048 }
+      }
+    },
+    "bodyPreview": {
+      "description": "A redacted, truncated preview of a body plus integrity metadata for the ORIGINAL bytes. The raw bytes are never included.",
+      "type": "object",
+      "required": ["originalByteSize", "redactionApplied", "truncated"],
+      "additionalProperties": false,
+      "properties": {
+        "preview": {
+          "description": "Redacted, truncated text preview of the body.",
+          "type": "string",
+          "maxLength": 8192
+        },
+        "contentSha256": {
+          "description": "Lowercase hex SHA-256 of the ORIGINAL (pre-redaction) body bytes.",
+          "type": "string",
+          "maxLength": 64
+        },
+        "originalByteSize": {
+          "description": "Size in bytes of the ORIGINAL body before truncation/redaction.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 26214400
+        },
+        "redactionApplied": {
+          "description": "True when redaction removed content from the preview.",
+          "type": "boolean"
+        },
+        "truncated": {
+          "description": "True when the preview is shorter than the original body.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/schemas/diagnostic-bundle.v1.provenance.json
+++ b/schemas/diagnostic-bundle.v1.provenance.json
@@ -1,0 +1,9 @@
+{
+  "schema": "honua.public-schema-provenance.v1",
+  "sourceRepository": "honua-io/honua-support",
+  "sourcePath": "schemas/diagnostic-bundle.v1.json",
+  "sourceCommit": "0c990fbe8f519a00a57e26dab21cbb8f80d559ea",
+  "sha256": "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9",
+  "bytes": 6494,
+  "canonicalUrl": "https://honua.io/schemas/diagnostic-bundle.v1.json"
+}

--- a/src/Honua.Sdk.Cli/DiagnosticDoctor.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticDoctor.cs
@@ -1,0 +1,210 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Sdk.Cli;
+
+internal static class DiagnosticDoctor
+{
+    internal const int MaxInputBytes = 30 * 1024 * 1024;
+    internal const int MaxProbeBytes = 256 * 1024;
+
+    internal static DiagnosticExchangeInput ReadCapturedExchange(string path)
+    {
+        FileInfo file = new(path);
+        if (!file.Exists || file.Length > MaxInputBytes)
+            throw new CliArgumentException("Diagnostic input could not be read or exceeds 30 MiB.");
+
+        byte[] bytes;
+        try
+        {
+            bytes = File.ReadAllBytes(file.FullName);
+        }
+        catch (IOException)
+        {
+            throw new CliArgumentException("Diagnostic input could not be read.");
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(bytes);
+            JsonElement root = document.RootElement;
+            if (!root.TryGetProperty("request", out JsonElement request)
+                || !request.TryGetProperty("method", out JsonElement methodElement)
+                || methodElement.ValueKind != JsonValueKind.String
+                || !request.TryGetProperty("url", out JsonElement urlElement)
+                || urlElement.ValueKind != JsonValueKind.String)
+            {
+                throw new CliArgumentException("Captured exchange requires request.method and request.url strings.");
+            }
+
+            root.TryGetProperty("response", out JsonElement response);
+            return new DiagnosticExchangeInput(
+                methodElement.GetString()!,
+                urlElement.GetString()!,
+                ReadStatus(response),
+                ReadString(response, "mediaType"),
+                ReadString(root, "correlationId"),
+                ReadString(root, "traceId"),
+                ReadString(root, "capturedAt"),
+                ReadHeaders(request, "headers"),
+                ReadHeaders(response, "headers"),
+                ReadBody(request),
+                ReadBody(response));
+        }
+        catch (JsonException)
+        {
+            throw new CliArgumentException("Diagnostic input is not valid JSON.");
+        }
+    }
+
+    internal static async Task<DiagnosticExchangeInput> ProbeCapabilitiesAsync(
+        Uri baseUri,
+        HttpClient client,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        Uri target = AppendPath(baseUri, "/api/v1/services?limit=1");
+        using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+        try
+        {
+            using HttpRequestMessage request = new(HttpMethod.Get, target);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/problem+json"));
+            using HttpResponseMessage response = await client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                timeoutSource.Token).ConfigureAwait(false);
+            byte[] body = await ReadBoundedBodyAsync(response, MaxProbeBytes, timeoutSource.Token).ConfigureAwait(false);
+            return new DiagnosticExchangeInput(
+                "GET",
+                target.AbsoluteUri,
+                (int)response.StatusCode,
+                response.Content.Headers.ContentType?.MediaType,
+                FirstHeader(response, "x-correlation-id", "x-request-id"),
+                FirstHeader(response, "traceparent"),
+                DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+                ResponseHeaders: ReadHeaders(response),
+                ResponseBody: body);
+        }
+        catch (Exception exception) when (exception is HttpRequestException or IOException or OperationCanceledException or DiagnosticSafetyException)
+        {
+            return new DiagnosticExchangeInput(
+                "GET",
+                target.AbsoluteUri,
+                CapturedAt: DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+                ResponseHeaders: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["content-type"] = "application/problem+json"
+                },
+                ResponseBody: Encoding.UTF8.GetBytes("{\"error\":\"capability-probe-failed\"}"));
+        }
+    }
+
+    internal static async Task<byte[]> ReadBoundedBodyAsync(
+        HttpResponseMessage response,
+        int maximumBytes,
+        CancellationToken cancellationToken)
+    {
+        if (response.Content.Headers.ContentLength > maximumBytes)
+            throw new DiagnosticSafetyException("response-over-budget", "Diagnostic response exceeds the byte budget.");
+
+        Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (responseStream.ConfigureAwait(false))
+        {
+            using MemoryStream output = new();
+            byte[] buffer = new byte[8192];
+            while (true)
+            {
+                int read = await responseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+                if (output.Length + read > maximumBytes)
+                    throw new DiagnosticSafetyException("response-over-budget", "Diagnostic response exceeds the byte budget.");
+                await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            }
+            return output.ToArray();
+        }
+    }
+
+    internal static IReadOnlyDictionary<string, string> ReadHeaders(HttpResponseMessage response)
+    {
+        Dictionary<string, string> result = new(StringComparer.OrdinalIgnoreCase);
+        AddHeaders(result, response.Headers);
+        AddHeaders(result, response.Content.Headers);
+        return result;
+    }
+
+    internal static string? FirstHeader(HttpResponseMessage response, params string[] names)
+    {
+        foreach (string name in names)
+        {
+            if (response.Headers.TryGetValues(name, out IEnumerable<string>? values))
+                return values.FirstOrDefault();
+        }
+        return null;
+    }
+
+    private static Uri AppendPath(Uri baseUri, string suffix)
+    {
+        string basePath = baseUri.AbsolutePath == "/" ? string.Empty : baseUri.AbsolutePath.TrimEnd('/');
+        return new Uri(baseUri.GetLeftPart(UriPartial.Authority) + basePath + suffix);
+    }
+
+    private static void AddHeaders(Dictionary<string, string> destination, HttpHeaders headers)
+    {
+        foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
+            destination[header.Key] = string.Join(",", header.Value);
+    }
+
+    private static int? ReadStatus(JsonElement response)
+    {
+        if (response.ValueKind != JsonValueKind.Object)
+            return null;
+        foreach (string name in new[] { "statusCode", "status" })
+        {
+            if (response.TryGetProperty(name, out JsonElement status) && status.TryGetInt32(out int value))
+                return value;
+        }
+        return null;
+    }
+
+    private static string? ReadString(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object
+            && element.TryGetProperty(name, out JsonElement value)
+            && value.ValueKind == JsonValueKind.String
+                ? value.GetString()
+                : null;
+
+    private static Dictionary<string, string>? ReadHeaders(JsonElement element, string name)
+    {
+        if (element.ValueKind != JsonValueKind.Object
+            || !element.TryGetProperty(name, out JsonElement headers)
+            || headers.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        Dictionary<string, string> result = new(StringComparer.OrdinalIgnoreCase);
+        foreach (JsonProperty header in headers.EnumerateObject())
+        {
+            if (header.Value.ValueKind == JsonValueKind.String)
+                result[header.Name] = header.Value.GetString() ?? string.Empty;
+            else if (header.Value.ValueKind == JsonValueKind.Array)
+                result[header.Name] = string.Join(",", header.Value.EnumerateArray()
+                    .Where(value => value.ValueKind == JsonValueKind.String)
+                    .Select(value => value.GetString()));
+        }
+        return result;
+    }
+
+    private static byte[]? ReadBody(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty("body", out JsonElement body))
+            return null;
+        return body.ValueKind == JsonValueKind.String
+            ? Encoding.UTF8.GetBytes(body.GetString() ?? string.Empty)
+            : Encoding.UTF8.GetBytes(body.GetRawText());
+    }
+}

--- a/src/Honua.Sdk.Cli/DiagnosticModels.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticModels.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Honua.Sdk.Cli;
+
+internal sealed record DiagnosticBundle(
+    [property: JsonPropertyName("schemaVersion")] string SchemaVersion,
+    [property: JsonPropertyName("contentClassification")] string ContentClassification,
+    [property: JsonPropertyName("consent")] DiagnosticConsent Consent,
+    [property: JsonPropertyName("envelopes")] IReadOnlyList<DiagnosticEnvelope> Envelopes,
+    [property: JsonPropertyName("bundleId")] string? BundleId = null);
+
+internal sealed record DiagnosticConsent(
+    [property: JsonPropertyName("redactionAcknowledged")] bool RedactionAcknowledged,
+    [property: JsonPropertyName("shareWithSupport")] bool ShareWithSupport,
+    [property: JsonPropertyName("grantedBy")] string? GrantedBy = null);
+
+internal sealed record DiagnosticEnvelope(
+    [property: JsonPropertyName("method")] string Method,
+    [property: JsonPropertyName("normalizedPath")] string NormalizedPath,
+    [property: JsonPropertyName("statusCode")] int? StatusCode = null,
+    [property: JsonPropertyName("mediaType")] string? MediaType = null,
+    [property: JsonPropertyName("correlationId")] string? CorrelationId = null,
+    [property: JsonPropertyName("traceId")] string? TraceId = null,
+    [property: JsonPropertyName("capturedAt")] string? CapturedAt = null,
+    [property: JsonPropertyName("requestHeaders")] IReadOnlyList<DiagnosticHeader>? RequestHeaders = null,
+    [property: JsonPropertyName("responseHeaders")] IReadOnlyList<DiagnosticHeader>? ResponseHeaders = null,
+    [property: JsonPropertyName("requestBody")] DiagnosticBodyPreview? RequestBody = null,
+    [property: JsonPropertyName("responseBody")] DiagnosticBodyPreview? ResponseBody = null);
+
+internal sealed record DiagnosticHeader(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("value")] string Value);
+
+internal sealed record DiagnosticBodyPreview(
+    [property: JsonPropertyName("originalByteSize")] long OriginalByteSize,
+    [property: JsonPropertyName("redactionApplied")] bool RedactionApplied,
+    [property: JsonPropertyName("truncated")] bool Truncated,
+    [property: JsonPropertyName("preview")] string? Preview = null,
+    [property: JsonPropertyName("contentSha256")] string? ContentSha256 = null);
+
+internal sealed record DiagnosticExchangeInput(
+    string Method,
+    string Url,
+    int? StatusCode = null,
+    string? MediaType = null,
+    string? CorrelationId = null,
+    string? TraceId = null,
+    string? CapturedAt = null,
+    IReadOnlyDictionary<string, string>? RequestHeaders = null,
+    IReadOnlyDictionary<string, string>? ResponseHeaders = null,
+    byte[]? RequestBody = null,
+    byte[]? ResponseBody = null);
+
+internal static class DiagnosticJson
+{
+    internal static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+}

--- a/src/Honua.Sdk.Cli/DiagnosticReplay.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticReplay.cs
@@ -1,0 +1,190 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Honua.Sdk.Cli;
+
+internal static partial class DiagnosticReplay
+{
+    private static readonly HashSet<string> SafeHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "accept", "content-length", "content-type", "traceparent", "x-correlation-id", "x-request-id"
+    };
+
+    internal static DiagnosticBundle ReadAndValidateBundle(string path)
+    {
+        FileInfo file = new(path);
+        if (!file.Exists || file.Length > 30L * 1024 * 1024)
+            throw new CliArgumentException("Replay bundle could not be read or exceeds 30 MiB.");
+
+        byte[] bytes;
+        try
+        {
+            bytes = File.ReadAllBytes(file.FullName);
+        }
+        catch (IOException)
+        {
+            throw new CliArgumentException("Replay bundle could not be read.");
+        }
+
+        using JsonDocument document = ParseJson(bytes, "Replay bundle is not valid JSON.");
+        DiagnosticSchema.Instance.AssertValid(document.RootElement);
+        DiagnosticBundle bundle = JsonSerializer.Deserialize<DiagnosticBundle>(document.RootElement, DiagnosticJson.Options)
+            ?? throw new DiagnosticSafetyException("invalid-bundle", "Replay bundle did not contain an object.");
+        AssertArtifactSafe(bundle, bytes);
+        return bundle;
+    }
+
+    internal static async Task<DiagnosticBundle> ReplayAsync(
+        DiagnosticBundle bundle,
+        Uri baseUri,
+        HttpClient client,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        DiagnosticEnvelope source = bundle.Envelopes[^1];
+        string method = source.Method.ToUpperInvariant();
+        if (method is not ("GET" or "HEAD"))
+            throw new DiagnosticSafetyException("unsafe-method", "Replay permits only GET and HEAD exchanges.");
+
+        string path = GetReplayPath(source.NormalizedPath);
+        Uri target = BuildTarget(baseUri, path);
+        using CancellationTokenSource timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+        using HttpRequestMessage request = new(new HttpMethod(method), target);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/problem+json"));
+
+        using HttpResponseMessage response = await client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            timeoutSource.Token).ConfigureAwait(false);
+        byte[]? responseBody = method == "HEAD"
+            ? null
+            : await DiagnosticDoctor.ReadBoundedBodyAsync(response, DiagnosticSanitizer.MaxBodyBytes, timeoutSource.Token)
+                .ConfigureAwait(false);
+
+        DiagnosticExchangeInput replay = new(
+            method,
+            target.AbsoluteUri,
+            (int)response.StatusCode,
+            response.Content.Headers.ContentType?.MediaType,
+            DiagnosticDoctor.FirstHeader(response, "x-correlation-id", "x-request-id"),
+            DiagnosticDoctor.FirstHeader(response, "traceparent"),
+            DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
+            ResponseHeaders: DiagnosticDoctor.ReadHeaders(response),
+            ResponseBody: responseBody);
+
+        return DiagnosticSanitizer.CreateBundle(
+            bundle.ContentClassification,
+            bundle.Consent,
+            [replay]);
+    }
+
+    internal static Uri ValidateBaseUri(string value)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            || uri.UserInfo.Length > 0
+            || !string.IsNullOrEmpty(uri.Query)
+            || !string.IsNullOrEmpty(uri.Fragment))
+        {
+            throw new CliArgumentException("Base URL must be credential-free and contain no query or fragment.");
+        }
+
+        bool localHttp = uri.Scheme == Uri.UriSchemeHttp
+            && (uri.IsLoopback || uri.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase));
+        if (uri.Scheme != Uri.UriSchemeHttps && !localHttp)
+            throw new CliArgumentException("Base URL must use HTTPS (localhost HTTP is allowed).");
+        return uri;
+    }
+
+    private static void AssertArtifactSafe(DiagnosticBundle bundle, byte[] bytes)
+    {
+        DiagnosticSanitizer.AssertSafeMetadata(bundle.BundleId, 64, "unsafe-bundle-id", "Diagnostic bundle id");
+        DiagnosticSanitizer.AssertSafeMetadata(bundle.Consent.GrantedBy, 256, "unsafe-granted-by", "Diagnostic consent identity");
+        string artifact = Encoding.UTF8.GetString(bytes);
+        if (CredentialMaterial().IsMatch(artifact))
+            throw new DiagnosticSafetyException("credential-bearing-artifact", "Replay artifact contains credential material.");
+
+        foreach (DiagnosticEnvelope envelope in bundle.Envelopes)
+        {
+            foreach (DiagnosticHeader header in (envelope.RequestHeaders ?? []).Concat(envelope.ResponseHeaders ?? []))
+            {
+                if (!SafeHeaders.Contains(header.Name))
+                    throw new DiagnosticSafetyException("unsafe-header", "Replay artifact contains a non-allowlisted header.");
+            }
+            VerifyBody(envelope.RequestBody);
+            VerifyBody(envelope.ResponseBody);
+        }
+    }
+
+    private static void VerifyBody(DiagnosticBodyPreview? body)
+    {
+        if (body is null)
+            return;
+        if (body.ContentSha256 is null || !LowercaseSha256().IsMatch(body.ContentSha256))
+            throw new DiagnosticSafetyException("hash-drift", "Replay requires a lowercase SHA-256 for every captured body.");
+        if (body.RedactionApplied || body.Truncated)
+            return;
+
+        byte[] preview = Encoding.UTF8.GetBytes(body.Preview ?? string.Empty);
+        string digest = Convert.ToHexStringLower(SHA256.HashData(preview));
+        if (preview.LongLength != body.OriginalByteSize || !digest.Equals(body.ContentSha256, StringComparison.Ordinal))
+            throw new DiagnosticSafetyException("hash-drift", "Captured body preview no longer matches its integrity metadata.");
+    }
+
+    private static string GetReplayPath(string normalizedPath)
+    {
+        if (normalizedPath.Length > 2048
+            || !normalizedPath.StartsWith('/')
+            || normalizedPath.StartsWith("//", StringComparison.Ordinal)
+            || normalizedPath.Contains('\\', StringComparison.Ordinal)
+            || normalizedPath.Any(character => character is <= '\u001f' or '\u007f'))
+        {
+            throw new DiagnosticSafetyException("unsafe-path", "Replay path is malformed.");
+        }
+
+        string path = normalizedPath.Split('?', 2)[0];
+        if (path.Contains('{', StringComparison.Ordinal) || path.Contains('}', StringComparison.Ordinal))
+            throw new DiagnosticSafetyException("unsafe-path", "Replay refuses placeholder path segments.");
+
+        string decoded = Uri.UnescapeDataString(path);
+        if (decoded.Split('/').Any(segment => segment is "." or "..") || ForbiddenPath().IsMatch(decoded))
+            throw new DiagnosticSafetyException("unsafe-path", "Replay path is mutation-, subscription-, or traversal-capable.");
+        return path;
+    }
+
+    private static Uri BuildTarget(Uri baseUri, string path)
+    {
+        string basePath = baseUri.AbsolutePath == "/" ? string.Empty : baseUri.AbsolutePath.TrimEnd('/');
+        bool alreadyPrefixed = basePath.Length > 0
+            && (path.Equals(basePath, StringComparison.Ordinal) || path.StartsWith(basePath + "/", StringComparison.Ordinal));
+        Uri target = new(baseUri.GetLeftPart(UriPartial.Authority) + (alreadyPrefixed ? path : basePath + path));
+        if (!target.GetLeftPart(UriPartial.Authority).Equals(baseUri.GetLeftPart(UriPartial.Authority), StringComparison.OrdinalIgnoreCase))
+            throw new DiagnosticSafetyException("unsafe-origin", "Replay target escaped the configured server origin.");
+        return target;
+    }
+
+    private static JsonDocument ParseJson(byte[] bytes, string error)
+    {
+        try
+        {
+            return JsonDocument.Parse(bytes);
+        }
+        catch (JsonException)
+        {
+            throw new CliArgumentException(error);
+        }
+    }
+
+    [GeneratedRegex("(?:\\bBearer\\s+|\\bBasic\\s+|AKIA[0-9A-Z]{16}|[?&](?:api[-_]?key|signature|token)=)", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex CredentialMaterial();
+
+    [GeneratedRegex("^[a-f0-9]{64}$", RegexOptions.None, 100)]
+    private static partial Regex LowercaseSha256();
+
+    [GeneratedRegex("(?:^|/)(?:applyedits|attachments|delete|edit|jobs|mutate|publish|stream|subscribe|update|upload)(?:/|$)", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex ForbiddenPath();
+}

--- a/src/Honua.Sdk.Cli/DiagnosticSafetyException.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticSafetyException.cs
@@ -1,0 +1,26 @@
+namespace Honua.Sdk.Cli;
+
+internal sealed class DiagnosticSafetyException : Exception
+{
+    public DiagnosticSafetyException()
+    {
+    }
+
+    public DiagnosticSafetyException(string message)
+        : base(message)
+    {
+    }
+
+    public DiagnosticSafetyException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public DiagnosticSafetyException(string code, string message)
+        : base(message)
+    {
+        Code = code;
+    }
+
+    internal string? Code { get; }
+}

--- a/src/Honua.Sdk.Cli/DiagnosticSanitizer.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticSanitizer.cs
@@ -1,0 +1,368 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Honua.Sdk.Cli;
+
+internal static partial class DiagnosticSanitizer
+{
+    internal const int MaxBodyBytes = 25 * 1024 * 1024;
+    internal const int MaxEnvelopes = 50;
+    internal const int DefaultPreviewBytes = 4096;
+    internal const int MaxPreviewBytes = 8192;
+
+    private static readonly HashSet<string> Classifications = new(StringComparer.Ordinal)
+    {
+        "unknown", "public", "internal", "customer-data", "secret-suspected"
+    };
+
+    private static readonly HashSet<string> SafeHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "accept", "content-length", "content-type", "traceparent", "x-correlation-id", "x-request-id"
+    };
+
+    private static readonly HashSet<string> SafePathSegments = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "api", "capabilities", "collections", "conformance", "features", "featureserver", "health",
+        "healthz", "honua", "items", "layers", "mapserver", "maps", "ogc", "query", "readiness",
+        "ready", "records", "search", "services", "stac", "tiles", "v1", "v2"
+    };
+
+    private static readonly HashSet<string> SafeQueryNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "bbox", "collections", "datetime", "f", "fields", "filter", "format", "limit", "offset",
+        "outfields", "q", "resultoffset", "resultrecordcount", "where"
+    };
+
+    internal static DiagnosticBundle CreateBundle(
+        string classification,
+        DiagnosticConsent consent,
+        IReadOnlyList<DiagnosticExchangeInput> exchanges,
+        string? bundleId = null,
+        int previewBytes = DefaultPreviewBytes)
+    {
+        if (!Classifications.Contains(classification))
+            throw new DiagnosticSafetyException("invalid-classification", "Diagnostic classification is not supported.");
+        if (previewBytes is < 1 or > MaxPreviewBytes)
+            throw new DiagnosticSafetyException("invalid-preview-budget", "Diagnostic preview bytes must be between 1 and 8192.");
+        if (exchanges.Count is < 1 or > MaxEnvelopes)
+            throw new DiagnosticSafetyException("invalid-envelope-count", "Diagnostic bundle requires between 1 and 50 exchanges.");
+
+        AssertSafeMetadata(bundleId, 64, "unsafe-bundle-id", "Diagnostic bundle id");
+        AssertSafeMetadata(consent.GrantedBy, 256, "unsafe-granted-by", "Diagnostic consent identity");
+
+        DiagnosticBundle bundle = new(
+            "1.0",
+            classification,
+            consent,
+            exchanges.Select(exchange => SanitizeExchange(exchange, previewBytes)).ToArray(),
+            bundleId);
+        using JsonDocument document = JsonSerializer.SerializeToDocument(bundle, DiagnosticJson.Options);
+        DiagnosticSchema.Instance.AssertValid(document.RootElement);
+        return bundle;
+    }
+
+    internal static DiagnosticEnvelope SanitizeExchange(DiagnosticExchangeInput input, int previewBytes)
+    {
+        string method = input.Method.Trim().ToUpperInvariant();
+        if (method.Length is < 1 or > 16 || !method.All(character => character is >= 'A' and <= 'Z'))
+            throw new DiagnosticSafetyException("invalid-method", "Diagnostic HTTP method is invalid.");
+        if (input.StatusCode is < 100 or > 599)
+            throw new DiagnosticSafetyException("invalid-status", "Diagnostic status code must be between 100 and 599.");
+
+        string? mediaType = SanitizeMediaType(input.MediaType);
+        IReadOnlyList<DiagnosticHeader>? requestHeaders = SanitizeHeaders(input.RequestHeaders);
+        IReadOnlyList<DiagnosticHeader>? responseHeaders = SanitizeHeaders(input.ResponseHeaders);
+        string? requestMediaType = requestHeaders?.FirstOrDefault(header =>
+            header.Name.Equals("content-type", StringComparison.OrdinalIgnoreCase))?.Value;
+
+        return new DiagnosticEnvelope(
+            method,
+            NormalizePath(input.Url),
+            input.StatusCode,
+            mediaType,
+            SanitizeBoundedText(input.CorrelationId, 200),
+            SanitizeBoundedText(input.TraceId, 200),
+            NormalizeTimestamp(input.CapturedAt),
+            requestHeaders,
+            responseHeaders,
+            SanitizeBody(input.RequestBody, requestMediaType, previewBytes),
+            SanitizeBody(input.ResponseBody, mediaType, previewBytes));
+    }
+
+    internal static IReadOnlyList<DiagnosticHeader>? SanitizeHeaders(IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is null)
+            return null;
+
+        DiagnosticHeader[] sanitized = headers
+            .Where(header => SafeHeaders.Contains(header.Key))
+            .Select(header => new DiagnosticHeader(
+#pragma warning disable CA1308 // HTTP field names are conventionally normalized to lowercase on the wire.
+                header.Key.ToLowerInvariant(),
+#pragma warning restore CA1308
+                header.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase)
+                    ? SanitizeMediaType(header.Value) ?? "application/octet-stream"
+                    : TruncateText(RedactText(header.Value), 2048)))
+            .OrderBy(header => header.Name, StringComparer.Ordinal)
+            .Take(32)
+            .ToArray();
+        return sanitized.Length == 0 ? null : sanitized;
+    }
+
+    internal static DiagnosticBodyPreview? SanitizeBody(byte[]? body, string? mediaType, int previewBytes)
+    {
+        if (body is null)
+            return null;
+        if (body.Length > MaxBodyBytes)
+            throw new DiagnosticSafetyException("body-over-budget", "Diagnostic body exceeds the 25 MiB intake ceiling.");
+
+        string digest = Convert.ToHexStringLower(SHA256.HashData(body));
+        int scanLength = Math.Min(body.Length, previewBytes * 8);
+        string decoded;
+        try
+        {
+            decoded = new UTF8Encoding(false, true).GetString(body, 0, scanLength);
+        }
+        catch (DecoderFallbackException)
+        {
+            return new DiagnosticBodyPreview(body.Length, true, true, "[BINARY_BODY_OMITTED]", digest);
+        }
+
+        string sanitized = LooksLikeJson(decoded, mediaType) ? RedactJsonOrText(decoded) : RedactText(decoded);
+        string preview = TruncateUtf8(sanitized, previewBytes);
+        bool truncated = body.Length > scanLength || Encoding.UTF8.GetByteCount(sanitized) > previewBytes;
+        return new DiagnosticBodyPreview(
+            body.Length,
+            !string.Equals(sanitized, decoded, StringComparison.Ordinal),
+            truncated,
+            preview,
+            digest);
+    }
+
+    internal static string NormalizePath(string input)
+    {
+        string rawPath = input.Split('?', '#')[0];
+        if (input.Length > 8192
+            || input.Contains('\\', StringComparison.Ordinal)
+            || HasControl(input)
+            || TraversalSegment().IsMatch(rawPath))
+            throw new DiagnosticSafetyException("unsafe-url", "Diagnostic URL is malformed or over budget.");
+        if (!Uri.TryCreate(input, UriKind.Absolute, out Uri? uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new DiagnosticSafetyException("unsafe-url", "Diagnostic URL must be an absolute HTTP or HTTPS URL.");
+        }
+
+        string[] segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        List<string> normalizedSegments = [];
+        foreach (string encodedSegment in segments)
+        {
+            string segment;
+            try
+            {
+                segment = Uri.UnescapeDataString(encodedSegment);
+            }
+            catch (UriFormatException)
+            {
+                throw new DiagnosticSafetyException("unsafe-path", "Diagnostic URL contains invalid path encoding.");
+            }
+            if (segment is "." or ".." || segment.Contains('\\', StringComparison.Ordinal) || HasControl(segment))
+                throw new DiagnosticSafetyException("unsafe-path", "Diagnostic URL contains an unsafe path segment.");
+            normalizedSegments.Add(SafePathSegments.Contains(segment) ? Uri.EscapeDataString(segment) : "{value}");
+        }
+
+        List<string> query = [];
+        string rawQuery = uri.Query.TrimStart('?');
+        foreach (string pair in rawQuery.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            string rawName = pair.Split('=', 2)[0];
+            string name = Uri.UnescapeDataString(rawName.Replace("+", " ", StringComparison.Ordinal));
+            if (SensitiveName().IsMatch(name))
+                continue;
+            query.Add($"{(SafeQueryNames.Contains(name) ? Uri.EscapeDataString(name) : "{parameter}")}={{value}}");
+        }
+        query.Sort(StringComparer.Ordinal);
+
+        string path = "/" + string.Join('/', normalizedSegments);
+        string result = query.Count == 0 ? path : $"{path}?{string.Join('&', query)}";
+        if (result.Length > 2048)
+            throw new DiagnosticSafetyException("path-over-budget", "Normalized diagnostic path exceeds the schema limit.");
+        return result;
+    }
+
+    internal static string RedactText(string input)
+    {
+        string value = DecodeForRedaction(input);
+        value = Authorization().Replace(value, "[REDACTED_AUTH]");
+        value = AwsAccessKey().Replace(value, "[REDACTED_AWS_KEY]");
+        value = ProviderToken().Replace(value, "[REDACTED_PROVIDER_TOKEN]");
+        value = Jwt().Replace(value, "[REDACTED_JWT]");
+        value = NamedSecret().Replace(value, "$1=[REDACTED]");
+        value = Email().Replace(value, "[REDACTED_EMAIL]");
+        return HighEntropy().Replace(value, "[REDACTED_TOKEN]");
+    }
+
+    internal static void AssertSafeMetadata(string? value, int maxLength, string code, string label)
+    {
+        if (value is null)
+            return;
+        if (value.Length > maxLength || HasControl(value) || !string.Equals(RedactText(value), value, StringComparison.Ordinal))
+            throw new DiagnosticSafetyException(code, $"{label} must not contain credentials or personal data.");
+    }
+
+    private static string? SanitizeMediaType(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        string mediaType = value.Split(';', 2)[0].Trim();
+        return SanitizeBoundedText(mediaType, 256);
+    }
+
+    private static string? NormalizeTimestamp(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || !DateTimeOffset.TryParse(value, out DateTimeOffset timestamp))
+            return null;
+        return timestamp.ToUniversalTime().ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string? SanitizeBoundedText(string? value, int length)
+        => string.IsNullOrWhiteSpace(value) ? null : TruncateText(RedactText(value), length);
+
+    private static string RedactJsonOrText(string decoded)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(decoded);
+            using MemoryStream output = new();
+            using (Utf8JsonWriter writer = new(output, new JsonWriterOptions { Encoder = JavaScriptEncoder.Default }))
+                WriteRedactedJson(writer, document.RootElement, 0, new Counter());
+            return Encoding.UTF8.GetString(output.ToArray());
+        }
+        catch (JsonException)
+        {
+            return RedactText(decoded);
+        }
+    }
+
+    private static void WriteRedactedJson(Utf8JsonWriter writer, JsonElement element, int depth, Counter counter)
+    {
+        counter.Value++;
+        if (depth > 16 || counter.Value > 4096)
+        {
+            writer.WriteStringValue("[REDACTED_COMPLEX_VALUE]");
+            return;
+        }
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                int propertyIndex = 0;
+                foreach (JsonProperty property in element.EnumerateObject().Take(256))
+                {
+                    propertyIndex++;
+                    bool sensitive = SensitiveName().IsMatch(property.Name)
+                        || !string.Equals(RedactText(property.Name), property.Name, StringComparison.Ordinal);
+                    writer.WritePropertyName(sensitive ? $"[REDACTED_KEY_{propertyIndex}]" : property.Name);
+                    if (sensitive)
+                        writer.WriteStringValue("[REDACTED]");
+                    else
+                        WriteRedactedJson(writer, property.Value, depth + 1, counter);
+                }
+                writer.WriteEndObject();
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (JsonElement item in element.EnumerateArray().Take(256))
+                    WriteRedactedJson(writer, item, depth + 1, counter);
+                writer.WriteEndArray();
+                break;
+            case JsonValueKind.String:
+                writer.WriteStringValue(RedactText(element.GetString() ?? string.Empty));
+                break;
+            default:
+                element.WriteTo(writer);
+                break;
+        }
+    }
+
+    private static bool LooksLikeJson(string decoded, string? mediaType)
+    {
+        string trimmed = decoded.TrimStart();
+        return mediaType?.Contains("json", StringComparison.OrdinalIgnoreCase) == true
+            || trimmed.StartsWith('{')
+            || trimmed.StartsWith('[');
+    }
+
+    private static string DecodeForRedaction(string input)
+    {
+        string value = input;
+        for (int pass = 0; pass < 2 && PercentEncoding().IsMatch(value); pass++)
+        {
+            try
+            {
+                value = Uri.UnescapeDataString(value);
+            }
+            catch (UriFormatException)
+            {
+                break;
+            }
+        }
+        return value;
+    }
+
+    private static bool HasControl(string value) => value.Any(character => character is <= '\u001f' or '\u007f');
+
+    private static string TruncateText(string value, int maximumCharacters)
+        => value.Length <= maximumCharacters ? value : value[..maximumCharacters];
+
+    private static string TruncateUtf8(string value, int maximumBytes)
+    {
+        if (Encoding.UTF8.GetByteCount(value) <= maximumBytes)
+            return value;
+        int length = Math.Min(value.Length, maximumBytes);
+        while (length > 0 && Encoding.UTF8.GetByteCount(value.AsSpan(0, length)) > maximumBytes)
+            length--;
+        if (length > 0 && char.IsHighSurrogate(value[length - 1]))
+            length--;
+        return value[..length];
+    }
+
+    private sealed class Counter
+    {
+        internal int Value { get; set; }
+    }
+
+    [GeneratedRegex("(?:api[-_]?key|authorization|cookie|credential|jwt|pass(?:word)?|proxy[-_]?authorization|secret|session|set[-_]?cookie|sig(?:nature)?|token)", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex SensitiveName();
+
+    [GeneratedRegex("\\b(?:Bearer|Basic)\\s+[A-Za-z0-9._~+/=-]+", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex Authorization();
+
+    [GeneratedRegex("\\bAKIA[0-9A-Z]{16}\\b", RegexOptions.None, 100)]
+    private static partial Regex AwsAccessKey();
+
+    [GeneratedRegex("\\b(?:sk_[A-Za-z0-9_-]{8,}|(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{8,}|gh[pousr]_[A-Za-z0-9_-]{8,}|xox[baprs]-[A-Za-z0-9-]{8,}|AIza[0-9A-Za-z_-]{20,}|glpat-[A-Za-z0-9_-]{10,})\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex ProviderToken();
+
+    [GeneratedRegex("\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\b", RegexOptions.None, 100)]
+    private static partial Regex Jwt();
+
+    [GeneratedRegex("\\b(access[-_]?key|api[-_]?key|authorization|aws[-_]?secret[-_]?access[-_]?key|bearer|client[-_]?secret|cookie|credential|pass(?:word)?|proxy[-_]?authorization|pwd|secret|session|set[-_]?cookie|signature|token)\\s*[:=]\\s*(?:\"[^\"]*\"|'[^']*'|[^\\s&,;}]*)", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex NamedSecret();
+
+    [GeneratedRegex("\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex Email();
+
+    [GeneratedRegex("\\b[A-Za-z0-9_+/=]{32,}\\b", RegexOptions.None, 100)]
+    private static partial Regex HighEntropy();
+
+    [GeneratedRegex("%[0-9a-f]{2}", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex PercentEncoding();
+
+    [GeneratedRegex("(?:^|/)(?:(?:%2e|\\.){1,2})(?:/|$)", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex TraversalSegment();
+}

--- a/src/Honua.Sdk.Cli/DiagnosticSchema.cs
+++ b/src/Honua.Sdk.Cli/DiagnosticSchema.cs
@@ -1,0 +1,217 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Sdk.Cli;
+
+internal sealed class DiagnosticSchema
+{
+    internal const string ResourceName = "Honua.Sdk.Cli.Schemas.diagnostic-bundle.v1.json";
+    internal const string CanonicalUrl = "https://honua.io/schemas/diagnostic-bundle.v1.json";
+    internal const string SourceCommit = "0c990fbe8f519a00a57e26dab21cbb8f80d559ea";
+    internal const string Sha256 = "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9";
+    internal const int ByteCount = 6494;
+
+    private const int MaxErrors = 50;
+    private readonly JsonDocument _schema;
+    private readonly JsonElement _root;
+
+    internal static DiagnosticSchema Instance { get; } = new();
+
+    private DiagnosticSchema()
+    {
+        byte[] bytes = LoadCanonicalBytes();
+        VerifyCanonicalBytes(bytes);
+        _schema = JsonDocument.Parse(bytes);
+        _root = _schema.RootElement;
+    }
+
+    internal static byte[] LoadCanonicalBytes()
+    {
+        using Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException($"Embedded diagnostic schema '{ResourceName}' was not found.");
+        using MemoryStream buffer = new();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+
+    internal static void VerifyCanonicalBytes(ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.Length != ByteCount)
+            throw new InvalidOperationException("Embedded diagnostic schema byte count does not match canonical provenance.");
+
+        string digest = Convert.ToHexStringLower(SHA256.HashData(bytes));
+        if (!string.Equals(digest, Sha256, StringComparison.Ordinal))
+            throw new InvalidOperationException("Embedded diagnostic schema SHA-256 does not match canonical provenance.");
+    }
+
+    internal IReadOnlyList<string> Validate(JsonElement instance)
+    {
+        List<string> errors = [];
+        ValidateNode(_root, instance, "$", errors);
+        return errors;
+    }
+
+    internal void AssertValid(JsonElement instance)
+    {
+        IReadOnlyList<string> errors = Validate(instance);
+        if (errors.Count > 0)
+            throw new DiagnosticSafetyException("schema-validation", "Diagnostic bundle failed pinned v1 schema validation.");
+    }
+
+    private void ValidateNode(JsonElement schema, JsonElement instance, string path, List<string> errors)
+    {
+        if (errors.Count >= MaxErrors)
+            return;
+
+        if (schema.ValueKind == JsonValueKind.Object && schema.TryGetProperty("$ref", out JsonElement reference))
+        {
+            ValidateNode(ResolveReference(reference.GetString()), instance, path, errors);
+            return;
+        }
+
+        string? type = schema.TryGetProperty("type", out JsonElement typeElement) ? typeElement.GetString() : null;
+        if (type is not null && !MatchesType(type, instance))
+        {
+            errors.Add($"{path}: expected type '{type}' but found '{instance.ValueKind}'.");
+            return;
+        }
+
+        if (schema.TryGetProperty("const", out JsonElement constant) && !JsonElement.DeepEquals(constant, instance))
+            errors.Add($"{path}: value must equal the constant '{constant.GetRawText()}'.");
+
+        if (schema.TryGetProperty("enum", out JsonElement choices)
+            && choices.ValueKind == JsonValueKind.Array
+            && !choices.EnumerateArray().Any(choice => JsonElement.DeepEquals(choice, instance)))
+        {
+            errors.Add($"{path}: value is not one of the allowed values.");
+        }
+
+        switch (instance.ValueKind)
+        {
+            case JsonValueKind.String:
+                ValidateString(schema, instance, path, errors);
+                break;
+            case JsonValueKind.Number:
+                ValidateNumber(schema, instance, path, errors);
+                break;
+            case JsonValueKind.Array:
+                ValidateArray(schema, instance, path, errors);
+                break;
+            case JsonValueKind.Object:
+                ValidateObject(schema, instance, path, errors);
+                break;
+        }
+    }
+
+    private static void ValidateString(JsonElement schema, JsonElement instance, string path, List<string> errors)
+    {
+        int length = (instance.GetString() ?? string.Empty).EnumerateRunes().Count();
+        if (schema.TryGetProperty("maxLength", out JsonElement maximum) && length > maximum.GetInt32())
+            errors.Add($"{path}: string length {length} exceeds maxLength {maximum.GetInt32()}.");
+        if (schema.TryGetProperty("minLength", out JsonElement minimum) && length < minimum.GetInt32())
+            errors.Add($"{path}: string length {length} is below minLength {minimum.GetInt32()}.");
+    }
+
+    private static void ValidateNumber(JsonElement schema, JsonElement instance, string path, List<string> errors)
+    {
+        if (schema.TryGetProperty("type", out JsonElement type)
+            && type.GetString() == "integer"
+            && !IsIntegral(instance))
+        {
+            errors.Add($"{path}: expected an integer.");
+            return;
+        }
+
+        double value = instance.GetDouble();
+        if (schema.TryGetProperty("minimum", out JsonElement minimum) && value < minimum.GetDouble())
+            errors.Add($"{path}: value {value} is below minimum {minimum.GetDouble()}.");
+        if (schema.TryGetProperty("maximum", out JsonElement maximum) && value > maximum.GetDouble())
+            errors.Add($"{path}: value {value} exceeds maximum {maximum.GetDouble()}.");
+    }
+
+    private static bool IsIntegral(JsonElement instance)
+    {
+        if (instance.TryGetInt64(out _))
+            return true;
+        return instance.TryGetDouble(out double value)
+            && !double.IsInfinity(value)
+            && value == Math.Floor(value);
+    }
+
+    private void ValidateArray(JsonElement schema, JsonElement instance, string path, List<string> errors)
+    {
+        int count = instance.GetArrayLength();
+        if (schema.TryGetProperty("maxItems", out JsonElement maximum) && count > maximum.GetInt32())
+            errors.Add($"{path}: array length {count} exceeds maxItems {maximum.GetInt32()}.");
+        if (schema.TryGetProperty("minItems", out JsonElement minimum) && count < minimum.GetInt32())
+            errors.Add($"{path}: array length {count} is below minItems {minimum.GetInt32()}.");
+
+        if (!schema.TryGetProperty("items", out JsonElement itemSchema))
+            return;
+
+        int index = 0;
+        foreach (JsonElement item in instance.EnumerateArray())
+        {
+            ValidateNode(itemSchema, item, $"{path}[{index}]", errors);
+            index++;
+        }
+    }
+
+    private void ValidateObject(JsonElement schema, JsonElement instance, string path, List<string> errors)
+    {
+        bool hasProperties = schema.TryGetProperty("properties", out JsonElement properties);
+        if (schema.TryGetProperty("required", out JsonElement required))
+        {
+            foreach (JsonElement requiredName in required.EnumerateArray())
+            {
+                string name = requiredName.GetString() ?? string.Empty;
+                if (!instance.TryGetProperty(name, out _))
+                    errors.Add($"{path}: missing required property '{name}'.");
+            }
+        }
+
+        bool allowAdditional = !schema.TryGetProperty("additionalProperties", out JsonElement additional)
+            || additional.ValueKind != JsonValueKind.False;
+        foreach (JsonProperty property in instance.EnumerateObject())
+        {
+            if (!hasProperties || !properties.TryGetProperty(property.Name, out JsonElement propertySchema))
+            {
+                if (!allowAdditional)
+                    errors.Add($"{path}: unexpected property '{property.Name}'.");
+                continue;
+            }
+
+            ValidateNode(propertySchema, property.Value, $"{path}.{property.Name}", errors);
+        }
+    }
+
+    private JsonElement ResolveReference(string? pointer)
+    {
+        if (string.IsNullOrEmpty(pointer) || !pointer.StartsWith("#/", StringComparison.Ordinal))
+            throw new InvalidOperationException("Canonical diagnostic schema contains an unsupported reference.");
+
+        JsonElement current = _root;
+        foreach (string rawSegment in pointer[2..].Split('/'))
+        {
+            string segment = rawSegment.Replace("~1", "/", StringComparison.Ordinal)
+                .Replace("~0", "~", StringComparison.Ordinal);
+            if (!current.TryGetProperty(segment, out JsonElement next))
+                throw new InvalidOperationException("Canonical diagnostic schema contains an unresolved reference.");
+            current = next;
+        }
+        return current;
+    }
+
+    private static bool MatchesType(string type, JsonElement instance) => type switch
+    {
+        "object" => instance.ValueKind == JsonValueKind.Object,
+        "array" => instance.ValueKind == JsonValueKind.Array,
+        "string" => instance.ValueKind == JsonValueKind.String,
+        "boolean" => instance.ValueKind is JsonValueKind.True or JsonValueKind.False,
+        "integer" => instance.ValueKind == JsonValueKind.Number,
+        "number" => instance.ValueKind == JsonValueKind.Number,
+        _ => true
+    };
+}

--- a/src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj
+++ b/src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>Honua.Sdk.Cli</PackageId>
+    <Description>Support-safe Honua command-line diagnostics and schema-pinned read-only replay.</Description>
+    <RootNamespace>Honua.Sdk.Cli</RootNamespace>
+    <Authors>Honua</Authors>
+    <Copyright>Copyright (c) Honua</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/honua-io/honua-sdk-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/honua-io/honua-sdk-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>honua;diagnostics;support;cli;dotnet-tool</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>honua</ToolCommandName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\schemas\diagnostic-bundle.v1.json">
+      <Link>Schemas\diagnostic-bundle.v1.json</Link>
+      <LogicalName>Honua.Sdk.Cli.Schemas.diagnostic-bundle.v1.json</LogicalName>
+    </EmbeddedResource>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Honua.Sdk.Cli.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Honua.Sdk.Cli/HonuaCli.cs
+++ b/src/Honua.Sdk.Cli/HonuaCli.cs
@@ -1,0 +1,323 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace Honua.Sdk.Cli;
+
+internal sealed class CliArgumentException : Exception
+{
+    public CliArgumentException()
+    {
+    }
+
+    public CliArgumentException(string message)
+        : base(message)
+    {
+    }
+
+    public CliArgumentException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+internal static class HonuaCli
+{
+    internal static async Task<int> RunAsync(string[] args)
+    {
+        using SocketsHttpHandler handler = new()
+        {
+            AllowAutoRedirect = false,
+            UseCookies = false,
+            AutomaticDecompression = System.Net.DecompressionMethods.None
+        };
+        using HttpClient client = new(handler) { Timeout = Timeout.InfiniteTimeSpan };
+        return await RunAsync(args, Console.Out, Console.Error, client, CancellationToken.None).ConfigureAwait(false);
+    }
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        TextWriter output,
+        TextWriter error,
+        HttpClient client,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (args.Length == 0 || args[0] is "--help" or "-h")
+            {
+                await output.WriteLineAsync(Usage()).ConfigureAwait(false);
+                return args.Length == 0 ? 2 : 0;
+            }
+            if (!args[0].Equals("doctor", StringComparison.Ordinal))
+                throw new CliArgumentException("Unknown command. Only 'honua doctor' is supported.");
+
+            Dictionary<string, string> options = ParseOptions(args[1..]);
+            if (options.ContainsKey("help"))
+            {
+                await output.WriteLineAsync(Usage()).ConfigureAwait(false);
+                return 0;
+            }
+
+            string destination = Require(options, "output", "honua doctor requires --output <bundle.json>.");
+            int timeoutMilliseconds = ReadInteger(options, "timeout-ms", 10_000, 1, 30_000);
+            int previewBytes = ReadInteger(
+                options,
+                "preview-bytes",
+                DiagnosticSanitizer.DefaultPreviewBytes,
+                1,
+                DiagnosticSanitizer.MaxPreviewBytes);
+            TimeSpan timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+            string? replayPath = Get(options, "replay");
+
+            DiagnosticBundle bundle;
+            string outcome;
+            bool capabilityProbe;
+            if (replayPath is not null)
+            {
+                RejectPresent(options, "exchange", "classification", "redaction-acknowledged", "share-with-support", "granted-by", "bundle-id");
+                string baseValue = Get(options, "base-url")
+                    ?? Environment.GetEnvironmentVariable("HONUA_BASE_URL")
+                    ?? throw new CliArgumentException("Replay requires --base-url or HONUA_BASE_URL.");
+                Uri baseUri = DiagnosticReplay.ValidateBaseUri(baseValue);
+                DiagnosticBundle source = DiagnosticReplay.ReadAndValidateBundle(replayPath);
+                bundle = await DiagnosticReplay.ReplayAsync(
+                    source,
+                    baseUri,
+                    client,
+                    timeout,
+                    cancellationToken).ConfigureAwait(false);
+                outcome = "replayed";
+                capabilityProbe = false;
+            }
+            else
+            {
+                string classification = Require(
+                    options,
+                    "classification",
+                    "honua doctor requires --classification <value>.");
+                DiagnosticConsent consent = new(
+                    ReadExplicitBoolean(options, "redaction-acknowledged"),
+                    ReadExplicitBoolean(options, "share-with-support"),
+                    Get(options, "granted-by"));
+                List<DiagnosticExchangeInput> exchanges = [];
+                string? baseValue = Get(options, "base-url") ?? Environment.GetEnvironmentVariable("HONUA_BASE_URL");
+                capabilityProbe = baseValue is not null;
+                if (baseValue is not null)
+                {
+                    Uri baseUri = DiagnosticReplay.ValidateBaseUri(baseValue);
+                    exchanges.Add(await DiagnosticDoctor.ProbeCapabilitiesAsync(
+                        baseUri,
+                        client,
+                        timeout,
+                        cancellationToken).ConfigureAwait(false));
+                }
+
+                string? exchangePath = Get(options, "exchange");
+                if (exchangePath is not null)
+                    exchanges.Add(DiagnosticDoctor.ReadCapturedExchange(exchangePath));
+                if (exchanges.Count == 0)
+                    throw new CliArgumentException("honua doctor requires --base-url/HONUA_BASE_URL or --exchange <captured.json>.");
+
+                bundle = DiagnosticSanitizer.CreateBundle(
+                    classification,
+                    consent,
+                    exchanges,
+                    Get(options, "bundle-id"),
+                    previewBytes);
+                outcome = "emitted";
+            }
+
+            WriteValidatedBundle(destination, bundle);
+            await WriteSummaryAsync(output, options.ContainsKey("json"), outcome, bundle.Envelopes.Count, capabilityProbe)
+                .ConfigureAwait(false);
+            return 0;
+        }
+        catch (CliArgumentException exception)
+        {
+            await error.WriteLineAsync(exception.Message).ConfigureAwait(false);
+            return 2;
+        }
+        catch (Exception exception) when (exception is DiagnosticSafetyException
+            or HttpRequestException
+            or IOException
+            or UnauthorizedAccessException
+            or OperationCanceledException
+            or JsonException)
+        {
+            await error.WriteLineAsync("honua doctor failed safely; no diagnostic artifact was written.").ConfigureAwait(false);
+            return 1;
+        }
+#pragma warning disable CA1031 // CLI safety boundary: never leak an unexpected exception or raw input to process streams.
+        catch (Exception)
+        {
+            await error.WriteLineAsync("honua doctor failed safely; no diagnostic artifact was written.").ConfigureAwait(false);
+            return 1;
+        }
+#pragma warning restore CA1031
+    }
+
+    internal static void WriteValidatedBundle(string path, DiagnosticBundle bundle)
+    {
+        byte[] serialized = JsonSerializer.SerializeToUtf8Bytes(bundle, DiagnosticJson.Options);
+        using (JsonDocument document = JsonDocument.Parse(serialized))
+            DiagnosticSchema.Instance.AssertValid(document.RootElement);
+
+        string destination = Path.GetFullPath(path);
+        string? directory = Path.GetDirectoryName(destination);
+        if (directory is null)
+            throw new IOException("Diagnostic output directory could not be resolved.");
+        Directory.CreateDirectory(directory);
+        string temporary = Path.Combine(directory, $".{Path.GetFileName(destination)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            using (FileStream stream = new(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(serialized);
+                stream.WriteByte((byte)'\n');
+                stream.Flush(flushToDisk: true);
+            }
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(temporary, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.Move(temporary, destination, overwrite: true);
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(destination, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        finally
+        {
+            if (File.Exists(temporary))
+                File.Delete(temporary);
+        }
+    }
+
+    private static Dictionary<string, string> ParseOptions(string[] args)
+    {
+        Dictionary<string, string> options = new(StringComparer.Ordinal);
+        for (int index = 0; index < args.Length; index++)
+        {
+            string argument = args[index];
+            if (!argument.StartsWith("--", StringComparison.Ordinal))
+                throw new CliArgumentException("honua doctor does not accept positional arguments.");
+            string token = argument[2..];
+            int equals = token.IndexOf('=', StringComparison.Ordinal);
+            string name = equals >= 0 ? token[..equals] : token;
+            string value;
+            if (name is "json" or "help")
+            {
+                value = "true";
+                if (equals >= 0)
+                    throw new CliArgumentException($"--{name} does not accept a value.");
+            }
+            else if (equals >= 0)
+            {
+                value = token[(equals + 1)..];
+            }
+            else
+            {
+                if (++index >= args.Length || args[index].StartsWith("--", StringComparison.Ordinal))
+                    throw new CliArgumentException($"--{name} requires a value.");
+                value = args[index];
+            }
+
+            if (!KnownOptions.Contains(name))
+                throw new CliArgumentException("honua doctor received an unknown option.");
+            if (!options.TryAdd(name, value))
+                throw new CliArgumentException($"--{name} may be specified only once.");
+        }
+        return options;
+    }
+
+    private static readonly HashSet<string> KnownOptions = new(StringComparer.Ordinal)
+    {
+        "base-url", "bundle-id", "classification", "exchange", "granted-by", "help", "json", "output",
+        "preview-bytes", "redaction-acknowledged", "replay", "share-with-support", "timeout-ms"
+    };
+
+    private static string Require(Dictionary<string, string> options, string name, string message)
+        => Get(options, name) ?? throw new CliArgumentException(message);
+
+    private static string? Get(Dictionary<string, string> options, string name)
+        => options.TryGetValue(name, out string? value) && !string.IsNullOrWhiteSpace(value) ? value : null;
+
+    private static bool ReadExplicitBoolean(Dictionary<string, string> options, string name)
+    {
+        string value = Require(options, name, $"--{name} must be explicitly true or false.");
+        return value switch
+        {
+            "true" => true,
+            "false" => false,
+            _ => throw new CliArgumentException($"--{name} must be explicitly true or false.")
+        };
+    }
+
+    private static int ReadInteger(
+        Dictionary<string, string> options,
+        string name,
+        int defaultValue,
+        int minimum,
+        int maximum)
+    {
+        string? value = Get(options, name);
+        if (value is null)
+            return defaultValue;
+        if (!int.TryParse(value, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out int parsed)
+            || parsed < minimum
+            || parsed > maximum)
+        {
+            throw new CliArgumentException($"--{name} is outside the supported range.");
+        }
+        return parsed;
+    }
+
+    private static void RejectPresent(Dictionary<string, string> options, params string[] names)
+    {
+        if (names.Any(options.ContainsKey))
+            throw new CliArgumentException("Replay options cannot be combined with capture options.");
+    }
+
+    private static async Task WriteSummaryAsync(
+        TextWriter output,
+        bool json,
+        string outcome,
+        int envelopeCount,
+        bool capabilityProbe)
+    {
+        string version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        if (!json)
+        {
+            await output.WriteLineAsync($"doctorOutcome={outcome}").ConfigureAwait(false);
+            await output.WriteLineAsync("output=written").ConfigureAwait(false);
+            await output.WriteLineAsync($"schema={DiagnosticSchema.CanonicalUrl}").ConfigureAwait(false);
+            await output.WriteLineAsync($"schemaSha256={DiagnosticSchema.Sha256}").ConfigureAwait(false);
+            return;
+        }
+
+        var summary = new
+        {
+            format = "honua.doctor-result.v1",
+            outcome,
+            outputWritten = true,
+            envelopeCount,
+            capabilityProbe = capabilityProbe ? "attempted" : "not-configured",
+            runtime = new { framework = RuntimeInformation.FrameworkDescription, target = "net10.0", os = RuntimeInformation.OSDescription },
+            sdk = new { package = "Honua.Sdk.Cli", version },
+            schema = DiagnosticSchema.CanonicalUrl,
+            schemaSha256 = DiagnosticSchema.Sha256,
+            uploaded = false
+        };
+        await output.WriteLineAsync(JsonSerializer.Serialize(summary, DiagnosticJson.Options)).ConfigureAwait(false);
+    }
+
+    private static string Usage() => """
+        Usage:
+          honua doctor --exchange <capture.json> --classification <value>
+            --redaction-acknowledged=<true|false> --share-with-support=<true|false>
+            --output <bundle.json> [--base-url <url>] [--json]
+
+          honua doctor --replay <bundle.json> --base-url <url>
+            --output <replay.json> [--json]
+
+        The command validates against the pinned support v1 schema and never uploads automatically.
+        """;
+}

--- a/src/Honua.Sdk.Cli/Program.cs
+++ b/src/Honua.Sdk.Cli/Program.cs
@@ -1,0 +1,3 @@
+using Honua.Sdk.Cli;
+
+return await HonuaCli.RunAsync(args).ConfigureAwait(false);

--- a/src/Honua.Sdk.Cli/README.md
+++ b/src/Honua.Sdk.Cli/README.md
@@ -1,0 +1,14 @@
+# Honua .NET CLI
+
+Install the tool, then use `honua doctor` to create a local, sanitized support
+bundle:
+
+```bash
+dotnet tool install --global Honua.Sdk.Cli
+honua doctor --exchange failure.json --classification customer-data \
+  --redaction-acknowledged=true --share-with-support=false \
+  --output diagnostic-bundle.json
+```
+
+See the repository's [diagnostic bundle guide](../../docs/diagnostic-bundles.md)
+for the privacy boundary, capability probe, and read-only replay contract.

--- a/tests/Honua.Sdk.Cli.Tests/DiagnosticConformanceTests.cs
+++ b/tests/Honua.Sdk.Cli.Tests/DiagnosticConformanceTests.cs
@@ -1,0 +1,103 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Honua.Sdk.Cli;
+
+namespace Honua.Sdk.Cli.Tests;
+
+public sealed class DiagnosticConformanceTests
+{
+    [Fact]
+    public void CanonicalArtifacts_MatchPinnedProvenanceAndEmbeddedSchema()
+    {
+        string root = FindRepositoryRoot();
+        byte[] schema = File.ReadAllBytes(Path.Combine(root, "schemas", "diagnostic-bundle.v1.json"));
+        byte[] embedded = DiagnosticSchema.LoadCanonicalBytes();
+        Assert.Equal(6494, schema.Length);
+        Assert.Equal(DiagnosticSchema.Sha256, Convert.ToHexStringLower(SHA256.HashData(schema)));
+        Assert.Equal(schema, embedded);
+
+        using JsonDocument provenance = JsonDocument.Parse(File.ReadAllBytes(
+            Path.Combine(root, "schemas", "diagnostic-bundle.v1.provenance.json")));
+        Assert.Equal(DiagnosticSchema.SourceCommit, provenance.RootElement.GetProperty("sourceCommit").GetString());
+        Assert.Equal(DiagnosticSchema.Sha256, provenance.RootElement.GetProperty("sha256").GetString());
+        Assert.Equal(DiagnosticSchema.ByteCount, provenance.RootElement.GetProperty("bytes").GetInt32());
+        Assert.Equal(DiagnosticSchema.CanonicalUrl, provenance.RootElement.GetProperty("canonicalUrl").GetString());
+    }
+
+    [Fact]
+    public void MergedConformanceCorpus_AcceptsAndRejectsEveryDeclaredCase()
+    {
+        string corpus = Path.Combine(FindRepositoryRoot(), "schemas", "diagnostic-bundle.v1.conformance");
+        Dictionary<string, string> canonicalHashes = new(StringComparer.Ordinal)
+        {
+            ["manifest.json"] = "b27dd139ea4f2617cd094fc23b28c880e12777d57eef01430cd00493adbdaae9",
+            ["valid/minimal.json"] = "933a2b5babde8a63c72142d0cb30692ff0b7546b4c1a2c9db1ae96736125141d",
+            ["valid/sanitized-exchange.json"] = "e3e10b0a2ef12ce46bf351f3523e4dd46ed12d53e614ecf08d8b2596733b0e66",
+            ["invalid/additional-property.json"] = "49565f95e85b050a1c325a59f3c2927f10e5549698be2972fc74d050dea2d718",
+            ["invalid/missing-consent.json"] = "dd8af980bc23cb18f2c4442b23fe7b13ec28f0d1df8d2a3e97c5390765ad9061",
+            ["invalid/optional-null.json"] = "df2592a2d1d5660b1c8dba330e09fc8c95b2a03fb7a7a89d589f80e4f50ed0c0",
+            ["invalid/status-out-of-range.json"] = "777a5e21014188ee6f8e1708bc339e5c71fa9c785a795f5da5951c6c2089913a",
+            ["invalid/wrong-version.json"] = "fd3d04e99667f22275747e7d0fa42868dfb3a325e50f58ebcad3ed9634849e8f"
+        };
+        foreach (KeyValuePair<string, string> artifact in canonicalHashes)
+        {
+            string digest = Convert.ToHexStringLower(SHA256.HashData(File.ReadAllBytes(Path.Combine(corpus, artifact.Key))));
+            Assert.Equal(artifact.Value, digest);
+        }
+
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllBytes(Path.Combine(corpus, "manifest.json")));
+        Assert.Equal(DiagnosticSchema.CanonicalUrl, manifest.RootElement.GetProperty("schemaId").GetString());
+        Assert.Equal(DiagnosticSchema.Sha256, manifest.RootElement.GetProperty("schemaSha256").GetString());
+
+        foreach (JsonElement testCase in manifest.RootElement.GetProperty("cases").EnumerateArray())
+        {
+            string path = testCase.GetProperty("path").GetString()!;
+            bool expectedValid = testCase.GetProperty("valid").GetBoolean();
+            using JsonDocument instance = JsonDocument.Parse(File.ReadAllBytes(Path.Combine(corpus, path)));
+            IReadOnlyList<string> errors = DiagnosticSchema.Instance.Validate(instance.RootElement);
+            Assert.Equal(expectedValid, errors.Count == 0);
+            if (!expectedValid)
+            {
+                string expected = testCase.GetProperty("expectedErrorContains").GetString()!;
+                Assert.Contains(errors, error => error.Contains(expected, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+    }
+
+    [Fact]
+    public void OutputValidation_RejectsOptionalNullBeforeCreatingFile()
+    {
+        using TemporaryDirectory temporary = new();
+        string output = Path.Combine(temporary.Path, "invalid.json");
+        DiagnosticBundle invalid = new(
+            "1.0",
+            "internal",
+            new DiagnosticConsent(true, false),
+            [new DiagnosticEnvelope("GET", "/healthz/ready")],
+            BundleId: null);
+
+        // Null is normally omitted by the serializer. Deliberately validate the canonical
+        // invalid corpus instance to prove the gate fails before any writer can accept it.
+        using JsonDocument nullInstance = JsonDocument.Parse("""
+            {"schemaVersion":"1.0","bundleId":null,"contentClassification":"internal","consent":{"redactionAcknowledged":true,"shareWithSupport":false},"envelopes":[{"method":"GET","normalizedPath":"/healthz/ready"}]}
+            """);
+        Assert.NotEmpty(DiagnosticSchema.Instance.Validate(nullInstance.RootElement));
+
+        HonuaCli.WriteValidatedBundle(output, invalid);
+        string serialized = File.ReadAllText(output);
+        Assert.DoesNotContain(": null", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"bundleId\"", serialized, StringComparison.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Honua.Sdk.sln")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not find repository root.");
+    }
+}

--- a/tests/Honua.Sdk.Cli.Tests/DoctorCommandTests.cs
+++ b/tests/Honua.Sdk.Cli.Tests/DoctorCommandTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Honua.Sdk.Cli;
+
+namespace Honua.Sdk.Cli.Tests;
+
+public sealed class DoctorCommandTests
+{
+    [Fact]
+    public async Task Doctor_RawExchange_EmitsSchemaValidBundleWithoutSecretsOrNulls()
+    {
+        using TemporaryDirectory temporary = new();
+        string capture = Path.Combine(temporary.Path, "capture.json");
+        string output = Path.Combine(temporary.Path, "bundle.json");
+        File.WriteAllText(capture, """
+            {
+              "request": {
+                "method": "GET",
+                "url": "https://alice:password@example.test/api/items/123456?token=raw-query-token",
+                "headers": {
+                  "authorization": "Bearer raw-auth",
+                  "cookie": "raw-cookie",
+                  "x-request-id": "req-1"
+                }
+              },
+              "response": {
+                "status": 500,
+                "mediaType": "application/json",
+                "headers": { "content-type": "application/json; boundary=raw-boundary-secret", "set-cookie": "raw-set-cookie" },
+                "body": { "message": "failed for person@example.test", "apiKey": "raw-api-key" }
+              }
+            }
+            """);
+        using HttpClient client = new(new RecordingHandler(_ => throw new InvalidOperationException()));
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+
+        int exitCode = await HonuaCli.RunAsync(
+            [
+                "doctor", "--exchange", capture, "--classification", "customer-data",
+                "--redaction-acknowledged=true", "--share-with-support=false",
+                "--output", output, "--json"
+            ],
+            stdout,
+            stderr,
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr.ToString());
+        string artifact = File.ReadAllText(output);
+        using JsonDocument document = JsonDocument.Parse(artifact);
+        Assert.Empty(DiagnosticSchema.Instance.Validate(document.RootElement));
+        Assert.False(document.RootElement.GetProperty("consent").GetProperty("shareWithSupport").GetBoolean());
+        Assert.DoesNotContain(": null", artifact, StringComparison.Ordinal);
+        foreach (string secret in new[]
+        {
+            "raw-query-token", "raw-auth", "raw-cookie", "raw-set-cookie", "raw-boundary-secret",
+            "raw-api-key", "person@example.test"
+        })
+        {
+            Assert.DoesNotContain(secret, artifact, StringComparison.Ordinal);
+            Assert.DoesNotContain(secret, stdout.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain(secret, stderr.ToString(), StringComparison.Ordinal);
+        }
+
+        JsonElement envelope = document.RootElement.GetProperty("envelopes")[0];
+        Assert.Equal("/api/items/{value}", envelope.GetProperty("normalizedPath").GetString());
+        Assert.Equal("req-1", envelope.GetProperty("requestHeaders")[0].GetProperty("value").GetString());
+        Assert.Equal(64, envelope.GetProperty("responseBody").GetProperty("contentSha256").GetString()!.Length);
+    }
+
+    [Theory]
+    [InlineData("https://example.test/a/../admin")]
+    [InlineData("https://example.test/a/%2e%2e/admin")]
+    [InlineData("file:///etc/passwd")]
+    public void Normalizer_TraversalAndNonHttpUrls_AreRejected(string value)
+    {
+        Assert.Throws<DiagnosticSafetyException>(() => DiagnosticSanitizer.NormalizePath(value));
+    }
+
+    [Fact]
+    public async Task Doctor_CapabilityProbe_IsAnonymousBoundedAndPreservesBasePath()
+    {
+        using TemporaryDirectory temporary = new();
+        string output = Path.Combine(temporary.Path, "bundle.json");
+        RecordingHandler handler = new(request =>
+        {
+            Assert.Equal("https://example.test/honua/api/v1/services?limit=1", request.RequestUri!.AbsoluteUri);
+            Assert.Null(request.Headers.Authorization);
+            HttpResponseMessage response = new(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"serverVersion\":\"1.2.3\",\"secret\":\"raw-secret\"}", Encoding.UTF8, "application/json")
+            };
+            response.Headers.Add("x-request-id", "request-1");
+            response.Headers.Add("set-cookie", "raw-cookie");
+            return response;
+        });
+        using HttpClient client = new(handler);
+
+        int exitCode = await HonuaCli.RunAsync(
+            [
+                "doctor", "--base-url", "https://example.test/honua", "--classification", "internal",
+                "--redaction-acknowledged=true", "--share-with-support=false", "--output", output, "--json"
+            ],
+            TextWriter.Null,
+            TextWriter.Null,
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, handler.CallCount);
+        string artifact = File.ReadAllText(output);
+        Assert.DoesNotContain("raw-secret", artifact, StringComparison.Ordinal);
+        Assert.DoesNotContain("raw-cookie", artifact, StringComparison.Ordinal);
+        using JsonDocument document = JsonDocument.Parse(artifact);
+        Assert.Empty(DiagnosticSchema.Instance.Validate(document.RootElement));
+        Assert.Equal("/honua/api/v1/services?limit={value}",
+            document.RootElement.GetProperty("envelopes")[0].GetProperty("normalizedPath").GetString());
+    }
+
+    [Fact]
+    public async Task Doctor_MissingConsent_FailsWithoutArtifactOrSecretEcho()
+    {
+        using TemporaryDirectory temporary = new();
+        string capture = Path.Combine(temporary.Path, "capture.json");
+        string output = Path.Combine(temporary.Path, "bundle.json");
+        File.WriteAllText(capture, "{\"request\":{\"method\":\"GET\",\"url\":\"https://example.test/api?token=raw-secret\"}}");
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        using HttpClient client = new(new RecordingHandler(_ => throw new InvalidOperationException()));
+
+        int exitCode = await HonuaCli.RunAsync(
+            [
+                "doctor", "--exchange", capture, "--classification", "internal",
+                "--redaction-acknowledged=true", "--output", output
+            ],
+            stdout,
+            stderr,
+            client);
+
+        Assert.Equal(2, exitCode);
+        Assert.False(File.Exists(output));
+        Assert.DoesNotContain("raw-secret", stdout.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("raw-secret", stderr.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Replay_Get_StripsQueryAndCapturedHeadersAndEmitsNewValidBundle()
+    {
+        using TemporaryDirectory temporary = new();
+        string source = Path.Combine(temporary.Path, "source.json");
+        string output = Path.Combine(temporary.Path, "replay.json");
+        File.WriteAllText(source, """
+            {
+              "schemaVersion": "1.0",
+              "contentClassification": "public",
+              "consent": { "redactionAcknowledged": true, "shareWithSupport": true },
+              "envelopes": [{ "method": "GET", "normalizedPath": "/api/v1/services?limit={value}" }]
+            }
+            """);
+        RecordingHandler handler = new(request =>
+        {
+            Assert.Equal("https://new.example.test/honua/api/v1/services", request.RequestUri!.AbsoluteUri);
+            Assert.Null(request.Headers.Authorization);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"services\":[]}", Encoding.UTF8, "application/json")
+            };
+        });
+        using HttpClient client = new(handler);
+
+        int exitCode = await HonuaCli.RunAsync(
+            ["doctor", "--replay", source, "--base-url", "https://new.example.test/honua", "--output", output],
+            TextWriter.Null,
+            TextWriter.Null,
+            client);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, handler.CallCount);
+        using JsonDocument replay = JsonDocument.Parse(File.ReadAllBytes(output));
+        Assert.Empty(DiagnosticSchema.Instance.Validate(replay.RootElement));
+    }
+
+    [Fact]
+    public async Task Replay_Mutation_IsRejectedBeforeNetwork()
+    {
+        using TemporaryDirectory temporary = new();
+        string source = Path.Combine(temporary.Path, "source.json");
+        string output = Path.Combine(temporary.Path, "replay.json");
+        File.WriteAllText(source, """
+            {
+              "schemaVersion": "1.0",
+              "contentClassification": "internal",
+              "consent": { "redactionAcknowledged": true, "shareWithSupport": true },
+              "envelopes": [{ "method": "POST", "normalizedPath": "/api/v1/applyEdits" }]
+            }
+            """);
+        RecordingHandler handler = new(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        using HttpClient client = new(handler);
+
+        int exitCode = await HonuaCli.RunAsync(
+            ["doctor", "--replay", source, "--base-url", "https://example.test", "--output", output],
+            TextWriter.Null,
+            TextWriter.Null,
+            client);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, handler.CallCount);
+        Assert.False(File.Exists(output));
+    }
+
+    private sealed class RecordingHandler(Func<HttpRequestMessage, HttpResponseMessage> response) : HttpMessageHandler
+    {
+        internal int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(response(request));
+        }
+    }
+}
+
+internal sealed class TemporaryDirectory : IDisposable
+{
+    internal TemporaryDirectory()
+    {
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "honua-doctor-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path);
+    }
+
+    internal string Path { get; }
+
+    public void Dispose() => Directory.Delete(Path, recursive: true);
+}

--- a/tests/Honua.Sdk.Cli.Tests/GlobalUsings.cs
+++ b/tests/Honua.Sdk.Cli.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Honua.Sdk.Cli.Tests/Honua.Sdk.Cli.Tests.csproj
+++ b/tests/Honua.Sdk.Cli.Tests/Honua.Sdk.Cli.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Honua.Sdk.Cli\Honua.Sdk.Cli.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Add the installable `Honua.Sdk.Cli` .NET tool and its `honua doctor` command for locally emitting sanitized, support-uploadable diagnostic bundles and performing bounded read-only replay.

Fixes #258.
Related to [honua-support#54](https://github.com/honua-io/honua-support/issues/54).

## Contract and provenance

- Mirrors the canonical support v1 schema, provenance record, and merged valid/invalid corpus byte-for-byte.
- Embeds and verifies the published 6,494-byte schema at SHA-256 `4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9`.
- Validates generated and replayed artifacts against the pinned schema before any output write.
- Omits absent optional properties rather than serializing `null`.
- Keeps runtime/SDK/probe context in the machine summary because strict support v1 does not permit those fields in the uploaded bundle.

## Safety behavior

- Requires explicit classification, redaction acknowledgement, and support-sharing consent.
- Drops non-allowlisted headers, authentication, cookies, URL origin/userinfo, sensitive query parameters, and raw query values.
- Redacts sensitive JSON keys, credentials, provider tokens, JWTs, AWS keys, emails, and encoded variants.
- Stores only bounded redacted previews plus original size and SHA-256; raw bodies are never emitted.
- Uses an anonymous, redirect-disabled, 256 KiB-bounded capability probe.
- Replays only one schema-valid `GET`/`HEAD`, strips query values and captured headers, verifies body integrity, and rejects mutation/traversal/unsafe origins before network access.
- Writes local artifacts with owner-only Unix permissions where supported and never uploads automatically.

## Packaging and docs

- Adds the CLI tool and tests to the solution, CI matrix, release build/test/audit/pack/SBOM lists, install docs, architecture map, and DocFX navigation.
- Verifies installation and invocation from the packed `Honua.Sdk.Cli` NuGet artifact.

## Validation

- `dotnet build Honua.Sdk.sln --no-restore --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true`
- `dotnet test Honua.Sdk.sln --configuration Release --no-build --logger "console;verbosity=minimal"`
- `dotnet test tests/Honua.Sdk.Cli.Tests/Honua.Sdk.Cli.Tests.csproj --configuration Release /p:TreatWarningsAsErrors=true /p:EnforceCodeStyleInBuild=true` (11 passed)
- `dotnet pack src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj --configuration Release`
- local `dotnet tool install Honua.Sdk.Cli` from the packed artifact, followed by `honua --help`
- `dotnet list src/Honua.Sdk.Cli/Honua.Sdk.Cli.csproj package --vulnerable --include-transitive`
- repository actionlint workflow validation
- `git diff --check`