### PR TITLE
feat(coverage): sdk-coverage.v1.json per-capability coverage snapshot (#273)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,31 @@ jobs:
       - name: Test CI enforcement helpers
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
+  sdk-coverage:
+    name: SDK Capability Coverage Snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Validate sdk-coverage.v1.json (drift gate)
+        # Regenerates the snapshot in memory from the curated inventory in
+        # scripts/generate-sdk-coverage.py and fails if it differs from the
+        # committed contracts/sdk-coverage.v1.json -- catching both stale
+        # commits and unknown/malformed capability keys. KEY_LIST_URL is
+        # intentionally left unset here so this always validates against the
+        # pinned contracts/fixtures/capability-keys.fixture.json mirror,
+        # matching what's actually committed.
+        run: |
+          python3 scripts/generate-sdk-coverage.py --check --summary "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload sdk-coverage.v1.json artifact
+        if: github.ref == 'refs/heads/trunk' && github.event_name == 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: sdk-coverage-v1
+          path: contracts/sdk-coverage.v1.json
+          if-no-files-found: error
+
   security-audit:
     name: Security Audit (NuGet)
     runs-on: ubuntu-latest

--- a/contracts/fixtures/capability-keys.fixture.json
+++ b/contracts/fixtures/capability-keys.fixture.json
@@ -1,0 +1,1096 @@
+{
+  "schemaVersion": "1.0.0",
+  "generator": "src/Honua.Core/Features/Licensing/Domain/CapabilityKeyCatalog.cs",
+  "trackingIssue": "#2893",
+  "description": "Canonical customer-facing capability key vocabulary (Community + Pro + Enterprise) and its crosswalks to the evidence vocabularies that don't otherwise join: honua-esri-assess's verdict registry, client-interop certification envelopes (client_lane x protocol), the geoservices REST parity index, and geobench benchmark scenarios. Hard Esri lock-ins (Utility Network, Parcel Fabric, Linear Referencing) are intentionally absent from esriAssess below -- see capability-no-go-allowlist.v1.json.",
+  "capabilities": [
+    {
+      "key": "admin.control-plane",
+      "displayName": "Admin Control Plane",
+      "category": "ControlPlane",
+      "edition": "Community",
+      "description": "General administrative CRUD surfaces (connections, metadata, services, tenants, users, roles, configuration) with no dedicated entitlement of their own."
+    },
+    {
+      "key": "ai.agent-operations",
+      "displayName": "Agent Operations (Validation Layer)",
+      "category": "AI",
+      "edition": "Pro",
+      "description": "Agent-initiated changes run through a validation layer \u2014 planned, dry-run, validated, with a pre-change snapshot/backup gate before apply (spec apply, NL grounding mutations, workflow generation, and MCP execute tools)."
+    },
+    {
+      "key": "ai.approval-workflows",
+      "displayName": "Agent Approval Workflows",
+      "category": "AI",
+      "edition": "Enterprise",
+      "description": "Human-in-the-loop approval, policy-scoped agent permissions, and immutable audit for agent-initiated operations."
+    },
+    {
+      "key": "ai.grounding",
+      "displayName": "Spec Grounding Mutations",
+      "category": "AI",
+      "edition": "Pro",
+      "description": "Ground natural-language turns into validated spec mutation plans."
+    },
+    {
+      "key": "ai.mcp-discovery",
+      "displayName": "MCP Discovery & Query",
+      "category": "AI",
+      "edition": "Community",
+      "description": "Discover, search, and query Honua through MCP and the agent read surface without a license."
+    },
+    {
+      "key": "ai.spec-apply",
+      "displayName": "Spec Apply Execution",
+      "category": "AI",
+      "edition": "Pro",
+      "description": "Apply executable specs and submit MCP plan execution jobs from agentic tooling."
+    },
+    {
+      "key": "ai.spec-artifacts",
+      "displayName": "Spec Artifact Retrieval",
+      "category": "AI",
+      "edition": "Community",
+      "description": "Read-only retrieval of executable spec artifacts by content hash. Applying a spec plan remains Pro-gated (ai.spec-apply)."
+    },
+    {
+      "key": "ai.workflow-generation",
+      "displayName": "AI Workflow and Content Generation",
+      "category": "AI",
+      "edition": "Pro",
+      "description": "Generate or refine workflows, maps, apps, forms, reports, dashboards, saved queries, and analysis packages from natural-language prompts."
+    },
+    {
+      "key": "alerts.dwell",
+      "displayName": "Dwell Trigger",
+      "category": "Alerts",
+      "edition": "Enterprise",
+      "description": "Trigger alerts when features remain inside a zone for a configured duration."
+    },
+    {
+      "key": "alerts.enter-exit",
+      "displayName": "Enter/Exit Geofence Triggers",
+      "category": "Alerts",
+      "edition": "Pro",
+      "description": "Trigger alerts when features enter or exit geofence zones."
+    },
+    {
+      "key": "alerts.evaluation",
+      "displayName": "Alert Evaluation Engine",
+      "category": "Alerts",
+      "edition": "Pro",
+      "description": "Background worker for evaluating geofence rules against feature changes."
+    },
+    {
+      "key": "alerts.threshold",
+      "displayName": "Threshold Trigger",
+      "category": "Alerts",
+      "edition": "Enterprise",
+      "description": "Trigger alerts based on attribute threshold conditions."
+    },
+    {
+      "key": "analytics.buffer-aggregate",
+      "displayName": "Buffer Aggregate",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Buffer features by a fixed distance and dissolve or aggregate per group."
+    },
+    {
+      "key": "analytics.clustering",
+      "displayName": "Spatial Clustering",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Server-side DBSCAN and K-Means clustering with optional cluster hulls."
+    },
+    {
+      "key": "analytics.content",
+      "displayName": "Analysis Artifact Content",
+      "category": "Analytics",
+      "edition": "Community",
+      "description": "Store and retrieve spatial-analysis artifacts. The analytics compute operations themselves (clustering, spatial join, etc.) remain Pro-gated."
+    },
+    {
+      "key": "analytics.density",
+      "displayName": "Density Binning",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Hex or square grid density (heatmap) binning over a filtered subset."
+    },
+    {
+      "key": "analytics.line-of-sight",
+      "displayName": "Line of Sight",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Determine terrain visibility between an observer and target over the elevation surface."
+    },
+    {
+      "key": "analytics.reporting",
+      "displayName": "Analysis Reporting",
+      "category": "Analytics",
+      "edition": "Community",
+      "description": "Retrieve generated analysis reports."
+    },
+    {
+      "key": "analytics.slice",
+      "displayName": "Slice/Volumetric Analysis",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Intersect a vertical slice plane with the elevation surface and return cross-section metadata."
+    },
+    {
+      "key": "analytics.spatial-join",
+      "displayName": "Spatial Join",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Cross-layer spatial join with intersects/contains/within/dwithin predicates."
+    },
+    {
+      "key": "analytics.sun-shadow",
+      "displayName": "Sun/Shadow Analysis",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Compute solar position from date/time/location and cast the shadow extent against the elevation surface."
+    },
+    {
+      "key": "analytics.viewshed",
+      "displayName": "Viewshed",
+      "category": "Analytics",
+      "edition": "Pro",
+      "description": "Compute the radially-sampled visible area around an observer over the elevation surface."
+    },
+    {
+      "key": "caching.output-cache",
+      "displayName": "Output Caching",
+      "category": "Caching",
+      "edition": "Pro",
+      "description": "HTTP response caching with tag-based invalidation."
+    },
+    {
+      "key": "caching.redis",
+      "displayName": "Redis Distributed Cache",
+      "category": "Caching",
+      "edition": "Pro",
+      "description": "Redis-backed distributed cache for multi-node deployments."
+    },
+    {
+      "key": "channels.aws-sns",
+      "displayName": "AWS SNS Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Deliver alert notifications via AWS Simple Notification Service."
+    },
+    {
+      "key": "channels.azure-eventgrid",
+      "displayName": "Azure Event Grid Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Deliver alert notifications via Azure Event Grid."
+    },
+    {
+      "key": "channels.digest",
+      "displayName": "Digest Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Aggregate and deliver batched alert summaries."
+    },
+    {
+      "key": "channels.email",
+      "displayName": "Email Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Deliver alert notifications via email."
+    },
+    {
+      "key": "channels.slack",
+      "displayName": "Slack Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Deliver alert notifications to Slack channels."
+    },
+    {
+      "key": "channels.teams",
+      "displayName": "Microsoft Teams Delivery",
+      "category": "Channels",
+      "edition": "Enterprise",
+      "description": "Deliver alert notifications to Microsoft Teams."
+    },
+    {
+      "key": "channels.webhook",
+      "displayName": "Webhook Delivery",
+      "category": "Channels",
+      "edition": "Pro",
+      "description": "Deliver alert notifications via webhook HTTP callbacks."
+    },
+    {
+      "key": "collaboration.map-sessions",
+      "displayName": "Map Collaboration Sessions",
+      "category": "Collaboration",
+      "edition": "Community",
+      "description": "Collaborative saved-map session operations (comments, activity, shared editing coordination)."
+    },
+    {
+      "key": "demo.showcase",
+      "displayName": "Demo Showcase Surfaces",
+      "category": "Demo",
+      "edition": "Community",
+      "description": "Non-sellable demo/showcase endpoints used for product demonstrations."
+    },
+    {
+      "key": "discovery.capability-manifest",
+      "displayName": "Capability Manifest",
+      "category": "Discovery",
+      "edition": "Community",
+      "description": "Advertise the server's capability manifest for SDK/agent discovery (#1186)."
+    },
+    {
+      "key": "dr.backup-automation",
+      "displayName": "Backup Automation",
+      "category": "DisasterRecovery",
+      "edition": "Enterprise",
+      "description": "Scheduled PostgreSQL base backups plus WAL archiving enabling point-in-time recovery."
+    },
+    {
+      "key": "dr.cache-backup",
+      "displayName": "Cache State Backup",
+      "category": "DisasterRecovery",
+      "edition": "Enterprise",
+      "description": "Backup and restore Redis cache state so warm cache contents survive a regional failover."
+    },
+    {
+      "key": "dr.failover",
+      "displayName": "Failover Playbooks",
+      "category": "DisasterRecovery",
+      "edition": "Enterprise",
+      "description": "Active-passive failover playbooks driven by automated health checks against the primary serving surface."
+    },
+    {
+      "key": "dr.rto-rpo-reporting",
+      "displayName": "RTO/RPO Reporting",
+      "category": "DisasterRecovery",
+      "edition": "Enterprise",
+      "description": "Track recovery time and recovery point objectives and report recovery readiness, last successful backup, and restorable point."
+    },
+    {
+      "key": "editing.branch-versioning",
+      "displayName": "Branch Versioning",
+      "category": "Editing",
+      "edition": "Enterprise",
+      "description": "Named gdb versions with isolated edits, reconcile/post back to DEFAULT, and gdbVersion-scoped editing/querying over the GeoServices VersionManagementServer."
+    },
+    {
+      "key": "editing.featureserver-edits",
+      "displayName": "FeatureServer Editing",
+      "category": "Editing",
+      "edition": "Pro",
+      "description": "Create, update, and delete features through the Esri GeoServices FeatureServer write surface \u2014 applyEdits, addFeatures, updateFeatures, deleteFeatures, and calculate."
+    },
+    {
+      "key": "enrichment.datasets",
+      "displayName": "Data Enrichment Datasets",
+      "category": "Enrichment",
+      "edition": "Community",
+      "description": "Register and manage third-party data-enrichment dataset sources."
+    },
+    {
+      "key": "fieldops.forms",
+      "displayName": "Field Collection Forms",
+      "category": "FieldOps",
+      "edition": "Community",
+      "description": "Read and submit online form packages. Disconnected/offline sync is Pro-gated separately by fieldops.offline-sync."
+    },
+    {
+      "key": "fieldops.offline-sync",
+      "displayName": "Offline/Field Sync",
+      "category": "FieldOps",
+      "edition": "Pro",
+      "description": "Use disconnected field sync, form offline policy discovery, GeoServices replica/GeoPackage delta sync, and FieldCollection cursor/change exchange."
+    },
+    {
+      "key": "geocoding.batch",
+      "displayName": "Batch Geocoding",
+      "category": "Geocoding",
+      "edition": "Enterprise",
+      "description": "Geocode multiple addresses in a single request."
+    },
+    {
+      "key": "geocoding.failover",
+      "displayName": "Provider Failover",
+      "category": "Geocoding",
+      "edition": "Pro",
+      "description": "Automatic failover between geocoding providers on error."
+    },
+    {
+      "key": "geocoding.forward",
+      "displayName": "Forward Geocoding",
+      "category": "Geocoding",
+      "edition": "Pro",
+      "description": "Convert addresses to coordinates using configured providers."
+    },
+    {
+      "key": "geocoding.reverse",
+      "displayName": "Reverse Geocoding",
+      "category": "Geocoding",
+      "edition": "Pro",
+      "description": "Convert coordinates to addresses using configured providers."
+    },
+    {
+      "key": "identity.claims-mapping",
+      "displayName": "Claims Mapping",
+      "category": "Identity",
+      "edition": "Enterprise",
+      "description": "Custom claim-to-role mapping and identity governance for OIDC providers."
+    },
+    {
+      "key": "identity.mtls-client-certificate",
+      "displayName": "mTLS Client-Certificate Authentication",
+      "category": "Identity",
+      "edition": "Enterprise",
+      "description": "Native client-certificate (mTLS) authentication: trust profiles, issuer/chain validation with CRL/OCSP revocation, and certificate-to-principal mapping."
+    },
+    {
+      "key": "identity.oidc",
+      "displayName": "OIDC Authentication",
+      "category": "Identity",
+      "edition": "Pro",
+      "description": "Single-provider OpenID Connect authentication with Azure AD, Google, Okta, Auth0, or generic OIDC."
+    },
+    {
+      "key": "identity.oidc-multi-provider",
+      "displayName": "OIDC Multi-Provider SSO",
+      "category": "Identity",
+      "edition": "Enterprise",
+      "description": "Configure multiple OIDC identity providers in one deployment."
+    },
+    {
+      "key": "identity.portal-sharing",
+      "displayName": "ArcGIS Portal Sharing Read Surface",
+      "category": "Identity",
+      "edition": "Community",
+      "description": "Expose the read-only /sharing/rest Portal facade (info, portals/self, search, content/items) so Esri clients can discover Honua content as portal items."
+    },
+    {
+      "key": "identity.portal-token",
+      "displayName": "ArcGIS Portal Token Issuance",
+      "category": "Identity",
+      "edition": "Community",
+      "description": "Expose POST/GET /sharing/rest/generateToken so Esri clients can authenticate against Honua-secured /rest/services."
+    },
+    {
+      "key": "identity.saml",
+      "displayName": "SAML 2.0 Authentication",
+      "category": "Identity",
+      "edition": "Community",
+      "description": "SAML 2.0 service-provider metadata and assertion consumer endpoints."
+    },
+    {
+      "key": "identity.scim",
+      "displayName": "SCIM 2.0 Provisioning",
+      "category": "Identity",
+      "edition": "Community",
+      "description": "User/group provisioning through the SCIM 2.0 protocol surface."
+    },
+    {
+      "key": "import.file",
+      "displayName": "File Import",
+      "category": "Import",
+      "edition": "Community",
+      "description": "Import geospatial data from file uploads (GeoJSON, Shapefile, GeoPackage)."
+    },
+    {
+      "key": "import.geoserver",
+      "displayName": "GeoServer Import",
+      "category": "Import",
+      "edition": "Enterprise",
+      "description": "Import layers from GeoServer REST API."
+    },
+    {
+      "key": "import.geoservices",
+      "displayName": "GeoServices Import",
+      "category": "Import",
+      "edition": "Enterprise",
+      "description": "Import layers from ArcGIS REST services."
+    },
+    {
+      "key": "ops.health",
+      "displayName": "Health Checks",
+      "category": "Ops",
+      "edition": "Community",
+      "description": "Liveness/readiness health-check endpoints."
+    },
+    {
+      "key": "ops.observability",
+      "displayName": "Observability",
+      "category": "Ops",
+      "edition": "Community",
+      "description": "Metrics and monitoring surfaces for operational visibility."
+    },
+    {
+      "key": "plugin.sdk",
+      "displayName": "Plugin/Extension SDK",
+      "category": "Extensibility",
+      "edition": "Enterprise",
+      "description": "Register compile-time, AOT-safe server plugins (custom feature validators and pre/post-edit hooks) discovered and gated at startup."
+    },
+    {
+      "key": "printing.layout-templates",
+      "displayName": "Print Layout Templates",
+      "category": "Printing",
+      "edition": "Pro",
+      "description": "Use full print layout templates beyond MAP_ONLY."
+    },
+    {
+      "key": "printing.pdf-output",
+      "displayName": "PDF Print Output",
+      "category": "Printing",
+      "edition": "Pro",
+      "description": "Export print jobs as PDF files."
+    },
+    {
+      "key": "process.geoprocessing",
+      "displayName": "Geoprocessing Task Execution",
+      "category": "Process",
+      "edition": "Community",
+      "description": "Submit and poll geoprocessing tasks through the Esri GeoServices GPServer surface. Print/export-specific tasks are gated by printing.* entitlement keys."
+    },
+    {
+      "key": "process.ogc-api-processes",
+      "displayName": "OGC API Processes",
+      "category": "Process",
+      "edition": "Community",
+      "description": "Submit and poll jobs through OGC API - Processes."
+    },
+    {
+      "key": "raster.cloud-cog-serving",
+      "displayName": "COG Serving",
+      "category": "Raster",
+      "edition": "Pro",
+      "description": "Serve COG files directly from S3/Azure via HTTP range requests."
+    },
+    {
+      "key": "raster.cloud-storage-config",
+      "displayName": "Cloud Storage Configuration",
+      "category": "Raster",
+      "edition": "Pro",
+      "description": "Configure cloud storage connections for direct raster serving."
+    },
+    {
+      "key": "raster.multidim-coverage",
+      "displayName": "Multidimensional Coverage (NetCDF/HDF5/Zarr)",
+      "category": "Raster",
+      "edition": "Pro",
+      "description": "Register and serve cloud-hosted NetCDF4/HDF5/Zarr datacubes as multidimensional coverages (OGC API Coverages / WCS / ImageServer multidimensional)."
+    },
+    {
+      "key": "raster.temporal-mosaic",
+      "displayName": "Temporal Raster Mosaic",
+      "category": "Raster",
+      "edition": "Pro",
+      "description": "Select raster mosaics by acquisition timestamp for time-series imagery."
+    },
+    {
+      "key": "raster.terrain-rgb",
+      "displayName": "Terrain-RGB Tiles",
+      "category": "Raster",
+      "edition": "Community",
+      "description": "Serve Terrain-RGB encoded elevation tiles."
+    },
+    {
+      "key": "routing.solve",
+      "displayName": "Network Routing",
+      "category": "Routing",
+      "edition": "Pro",
+      "description": "Solve multi-stop routes with the configured routing engine (MCP honua_solve_route and future gated surfaces)."
+    },
+    {
+      "key": "scene.bim-ingest",
+      "displayName": "CityGML/BIM Scene Ingest",
+      "category": "Scene",
+      "edition": "Enterprise",
+      "description": "Ingest CityGML building models into a servable Building Scene Layer 3D Tiles tileset with per-feature discipline / sub-layer semantics."
+    },
+    {
+      "key": "scene.catalog",
+      "displayName": "Scene Catalog",
+      "category": "Scene",
+      "edition": "Community",
+      "description": "Discover published 3D scene layers through the scene catalog surface."
+    },
+    {
+      "key": "scene.pointcloud-ingest",
+      "displayName": "Point Cloud Scene Ingest",
+      "category": "Scene",
+      "edition": "Enterprise",
+      "description": "Ingest LAS point clouds into a servable 3D Tiles point tileset preserving per-point classification, intensity, and RGB."
+    },
+    {
+      "key": "serve.3d-tiles-scene",
+      "displayName": "3D Tiles Scene Serving",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve published 3D Tiles scene layers through the SceneServer surface. Scene ingest (CityGML/point cloud) is Enterprise-gated separately."
+    },
+    {
+      "key": "serve.elevation",
+      "displayName": "Elevation Query",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query elevation profile and point-value surfaces. Sun/shadow, slice, line-of-sight, and viewshed analytics are Pro-gated separately."
+    },
+    {
+      "key": "serve.geoservices-featureserver",
+      "displayName": "FeatureServer Query",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query and read features through the Esri GeoServices FeatureServer surface (query, metadata, related records, domains, shared templates)."
+    },
+    {
+      "key": "serve.geoservices-geocodeserver",
+      "displayName": "GeocodeServer Discovery",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Discover GeocodeServer service and layer metadata. Forward/reverse/batch geocode execution is gated by the geocoding.* entitlement keys."
+    },
+    {
+      "key": "serve.geoservices-geometry-service",
+      "displayName": "Geometry Service",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Server-side geometry operations (project, buffer, simplify, union, and related utilities) through the Esri GeometryServer surface."
+    },
+    {
+      "key": "serve.geoservices-imageserver",
+      "displayName": "ImageServer",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve raster imagery and coverage metadata through the Esri GeoServices ImageServer surface."
+    },
+    {
+      "key": "serve.geoservices-mapserver",
+      "displayName": "MapServer",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve map images, identify, and export through the Esri GeoServices MapServer surface."
+    },
+    {
+      "key": "serve.geoservices-root",
+      "displayName": "GeoServices REST Root",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Discover the GeoServices REST catalog root and service-directory info."
+    },
+    {
+      "key": "serve.geoservices-vectortileserver",
+      "displayName": "VectorTileServer",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve Esri vector tile services through the GeoServices VectorTileServer surface."
+    },
+    {
+      "key": "serve.i3s-scene",
+      "displayName": "I3S Scene Serving",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve published I3S scene layers Esri clients consume directly."
+    },
+    {
+      "key": "serve.odata",
+      "displayName": "OData v4",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query and edit features through the OData v4 protocol surface."
+    },
+    {
+      "key": "serve.ogc-api-coverages",
+      "displayName": "OGC API Coverages",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve coverage data through OGC API - Coverages."
+    },
+    {
+      "key": "serve.ogc-api-edr",
+      "displayName": "OGC API - EDR",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query environmental data resources through OGC API - Environmental Data Retrieval."
+    },
+    {
+      "key": "serve.ogc-api-features",
+      "displayName": "OGC API Features",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Read and query collections/items through OGC API - Features. Mutation is Community via the shared edit pipeline (distinct from the Pro FeatureServer write gate)."
+    },
+    {
+      "key": "serve.ogc-api-maps",
+      "displayName": "OGC API Maps",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Render maps through OGC API - Maps."
+    },
+    {
+      "key": "serve.ogc-api-records",
+      "displayName": "OGC API Records",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Search and retrieve catalog records through OGC API - Records."
+    },
+    {
+      "key": "serve.ogc-api-tiles",
+      "displayName": "OGC API Tiles",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve vector and raster tiles through OGC API - Tiles."
+    },
+    {
+      "key": "serve.sensorthings",
+      "displayName": "OGC SensorThings API",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query sensor observation data through OGC SensorThings API v1.1."
+    },
+    {
+      "key": "serve.stac",
+      "displayName": "STAC API",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Search and browse spatiotemporal asset catalogs through the STAC API."
+    },
+    {
+      "key": "serve.vector-tiles",
+      "displayName": "Vector Tiles (MVT/TileJSON/PMTiles)",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve Mapbox Vector Tiles, TileJSON descriptors, and PMTiles archives."
+    },
+    {
+      "key": "serve.wcs",
+      "displayName": "WCS 2.0.1",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve coverage data through WCS 2.0.1."
+    },
+    {
+      "key": "serve.wfs",
+      "displayName": "WFS 2.0",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Query and read features through WFS 2.0."
+    },
+    {
+      "key": "serve.wms",
+      "displayName": "WMS 1.3",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve map images through WMS 1.3 (GetMap, GetFeatureInfo, GetCapabilities)."
+    },
+    {
+      "key": "serve.wmts",
+      "displayName": "WMTS 1.0",
+      "category": "Serve",
+      "edition": "Community",
+      "description": "Serve pre-rendered tile pyramids through WMTS 1.0."
+    },
+    {
+      "key": "staticmap.high-dpi",
+      "displayName": "High-DPI Static Maps",
+      "category": "StaticMap",
+      "edition": "Pro",
+      "description": "Render static map images at 150 and 300 DPI."
+    },
+    {
+      "key": "staticmap.large-dimensions",
+      "displayName": "Large Static Maps",
+      "category": "StaticMap",
+      "edition": "Pro",
+      "description": "Render static map images up to 4096x4096 pixels."
+    },
+    {
+      "key": "staticmap.rich-overlays",
+      "displayName": "Rich Static Map Overlays",
+      "category": "StaticMap",
+      "edition": "Pro",
+      "description": "Render up to 100 markers and 500 path vertices on static maps."
+    },
+    {
+      "key": "streaming.feature-subscriptions",
+      "displayName": "Real-Time Feature Streams",
+      "category": "Streaming",
+      "edition": "Pro",
+      "description": "Subscribe to WebSocket and SSE feature-change streams with filters and replay cursors."
+    },
+    {
+      "key": "styling.auto-suggest",
+      "displayName": "Auto-Cartographic Styling",
+      "category": "Styling",
+      "edition": "Pro",
+      "description": "Style suggestions based on field analysis and classification."
+    },
+    {
+      "key": "styling.defaults",
+      "displayName": "Smart Style Defaults",
+      "category": "Styling",
+      "edition": "Community",
+      "description": "Enhanced geometry-aware default styles for published layers."
+    },
+    {
+      "key": "styling.ogc-api-styles",
+      "displayName": "OGC API Styles",
+      "category": "Styling",
+      "edition": "Community",
+      "description": "Read and manage styles through OGC API - Styles (Part 1)."
+    },
+    {
+      "key": "temporal.animation-api",
+      "displayName": "Animation API Contract",
+      "category": "Temporal",
+      "edition": "Pro",
+      "description": "Capability flag for SDK/admin TimeSlider and playback integration."
+    },
+    {
+      "key": "temporal.extent-discovery",
+      "displayName": "Temporal Extent Discovery",
+      "category": "Temporal",
+      "edition": "Community",
+      "description": "Expose timeInfo, dedicated extent endpoint, and OGC time dimension metadata for time-aware layers."
+    },
+    {
+      "key": "temporal.filtering",
+      "displayName": "Temporal Query Filtering",
+      "category": "Temporal",
+      "edition": "Community",
+      "description": "Filter feature queries by a bounded or open-ended time range."
+    },
+    {
+      "key": "temporal.histogram",
+      "displayName": "Temporal Histogram (Date Bins)",
+      "category": "Temporal",
+      "edition": "Pro",
+      "description": "Count features per time bucket using calendar or fixed bins for animation frame planning."
+    },
+    {
+      "key": "temporal.time-series-tiles",
+      "displayName": "Time-Series Tile Filtering",
+      "category": "Temporal",
+      "edition": "Pro",
+      "description": "Filter vector tile requests to a bounded time range via the time parameter."
+    }
+  ],
+  "crosswalks": {
+    "esriAssess": [
+      {
+        "assessKey": "web-map",
+        "capability": "identity.portal-sharing",
+        "note": "Web Map/Web Scene portal items are discovered through the Portal Sharing facade."
+      },
+      {
+        "assessKey": "feature-service",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "assessKey": "map-service",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "assessKey": "vector-tiles",
+        "capability": "serve.geoservices-vectortileserver"
+      },
+      {
+        "assessKey": "editing",
+        "capability": "editing.featureserver-edits"
+      },
+      {
+        "assessKey": "image-service",
+        "capability": "serve.geoservices-imageserver"
+      },
+      {
+        "assessKey": "scene-service",
+        "capability": "serve.i3s-scene",
+        "note": "Esri SceneServer/Scene Layer Package fidelity maps to Honua's I3S scene serving; 3D Tiles (serve.3d-tiles-scene) is the OGC-native alternative."
+      },
+      {
+        "assessKey": "survey123",
+        "capability": "fieldops.forms",
+        "note": "Form-logic re-authoring boundary; submissions migrate as feature data, the Survey123 form runtime does not."
+      },
+      {
+        "assessKey": "dashboards-apps",
+        "capability": "collaboration.map-sessions",
+        "note": "Best-fit approximation only: dashboards/configurable apps have no direct Honua analog and are rebuilt on Honua app surfaces per the assess registry's own boundary text."
+      },
+      {
+        "assessKey": "geocoding",
+        "capability": "geocoding.forward",
+        "note": "Represents the geocoding.* key family (forward/reverse/batch/failover)."
+      },
+      {
+        "assessKey": "geoprocessing",
+        "capability": "process.geoprocessing"
+      }
+    ],
+    "interop": [
+      {
+        "clientLane": "js",
+        "protocol": "featureserver",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "mapserver",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "ogc-features",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "ogc-maps",
+        "capability": "serve.ogc-api-maps"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "mvt",
+        "capability": "serve.vector-tiles"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "wfs",
+        "capability": "serve.wfs"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "wms",
+        "capability": "serve.wms"
+      },
+      {
+        "clientLane": "js",
+        "protocol": "wmts",
+        "capability": "serve.wmts"
+      },
+      {
+        "clientLane": "js-cesium",
+        "protocol": "wms",
+        "capability": "serve.wms"
+      },
+      {
+        "clientLane": "js-cesium",
+        "protocol": "wmts",
+        "capability": "serve.wmts"
+      },
+      {
+        "clientLane": "js-cesium",
+        "protocol": "ogc-tiles",
+        "capability": "serve.ogc-api-tiles"
+      },
+      {
+        "clientLane": "js-cesium",
+        "protocol": "ogc-maps",
+        "capability": "serve.ogc-api-maps"
+      },
+      {
+        "clientLane": "desktop-qgis",
+        "protocol": "ogc-features",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "clientLane": "desktop-qgis",
+        "protocol": "wfs",
+        "capability": "serve.wfs"
+      },
+      {
+        "clientLane": "desktop-qgis",
+        "protocol": "wms",
+        "capability": "serve.wms"
+      },
+      {
+        "clientLane": "desktop-qgis",
+        "protocol": "wmts",
+        "capability": "serve.wmts"
+      },
+      {
+        "clientLane": "desktop-arcgis",
+        "protocol": "featureserver",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "clientLane": "desktop-arcgis",
+        "protocol": "mapserver",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "clientLane": "arcgis-stub",
+        "protocol": "featureserver",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "clientLane": "arcgis-stub",
+        "protocol": "mapserver",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "clientLane": "cli",
+        "protocol": "featureserver",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "clientLane": "cli",
+        "protocol": "ogc-features",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "clientLane": "cli",
+        "protocol": "wfs",
+        "capability": "serve.wfs"
+      },
+      {
+        "clientLane": "cli",
+        "protocol": "odata",
+        "capability": "serve.odata"
+      },
+      {
+        "clientLane": "cli",
+        "protocol": "admin-api",
+        "capability": "admin.control-plane"
+      },
+      {
+        "clientLane": "ci-desktop",
+        "protocol": "featureserver",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "clientLane": "ci-desktop",
+        "protocol": "ogc-features",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "clientLane": "ci-desktop",
+        "protocol": "mapserver",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "clientLane": "ci-bi",
+        "protocol": "odata",
+        "capability": "serve.odata"
+      },
+      {
+        "clientLane": "bi-powerbi",
+        "protocol": "odata",
+        "capability": "serve.odata"
+      },
+      {
+        "clientLane": "bi-excel",
+        "protocol": "odata",
+        "capability": "serve.odata"
+      }
+    ],
+    "esriCompatMatrix": [
+      {
+        "serviceId": "feature-server",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "serviceId": "map-server",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "serviceId": "image-server",
+        "capability": "serve.geoservices-imageserver"
+      },
+      {
+        "serviceId": "vector-tile-server",
+        "capability": "serve.geoservices-vectortileserver"
+      },
+      {
+        "serviceId": "geometry-service",
+        "capability": "serve.geoservices-geometry-service"
+      },
+      {
+        "serviceId": "gp-server",
+        "capability": "process.geoprocessing"
+      },
+      {
+        "serviceId": "geocode-server",
+        "capability": "serve.geoservices-geocodeserver"
+      },
+      {
+        "serviceId": "na-server",
+        "capability": "routing.solve"
+      },
+      {
+        "serviceId": "version-management-server",
+        "capability": "editing.branch-versioning"
+      },
+      {
+        "serviceId": "geoservices-catalog",
+        "capability": "serve.geoservices-root"
+      },
+      {
+        "serviceId": "portal-sharing",
+        "capability": "identity.portal-sharing"
+      }
+    ],
+    "geobench": [
+      {
+        "scenario": "attribute-filter",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "scenario": "spatial-bbox",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "scenario": "concurrent",
+        "capability": "serve.ogc-api-features"
+      },
+      {
+        "scenario": "wfs-getfeature",
+        "capability": "serve.wfs"
+      },
+      {
+        "scenario": "wfs-filtered",
+        "capability": "serve.wfs"
+      },
+      {
+        "scenario": "wms-getmap",
+        "capability": "serve.wms"
+      },
+      {
+        "scenario": "wms-reprojection",
+        "capability": "serve.wms"
+      },
+      {
+        "scenario": "wms-getfeatureinfo",
+        "capability": "serve.wms"
+      },
+      {
+        "scenario": "wms-filtered",
+        "capability": "serve.wms"
+      },
+      {
+        "scenario": "wmts",
+        "capability": "serve.wmts"
+      },
+      {
+        "scenario": "wcs",
+        "capability": "serve.wcs"
+      },
+      {
+        "scenario": "geoservices-query",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "scenario": "geoservices-query-diagnostics",
+        "capability": "serve.geoservices-featureserver"
+      },
+      {
+        "scenario": "geoservices-export",
+        "capability": "serve.geoservices-mapserver"
+      },
+      {
+        "scenario": "geoservices-identify",
+        "capability": "serve.geoservices-mapserver"
+      }
+    ]
+  }
+}

--- a/contracts/sdk-coverage.v1.json
+++ b/contracts/sdk-coverage.v1.json
@@ -1,0 +1,383 @@
+{
+  "schemaVersion": "1.0.0",
+  "generator": "scripts/generate-sdk-coverage.py",
+  "trackingIssue": "#273",
+  "sourceRepository": "honua-io/honua-sdk-dotnet",
+  "description": "Per-capability coverage snapshot for the cross-repo capability matrix (honua-io/honua-server#2892). Each entry maps a canonical capability key (consumed, never copied, from honua-server#2893's published capability-keys.v1.json) to what this SDK's source actually implements. Capabilities this SDK does not touch are absent from 'coverage' -- never padded.",
+  "sdkAvailability": {
+    "status": "source-preview",
+    "publishedVersion": null,
+    "note": "Honua.Sdk.* ships as a source preview only; no NuGet package has published yet (see honua-site data/sdk-availability.v1.json, productArea \"sdk-dotnet\"). Every coverage entry's sinceVersion is the literal marker \"unreleased\" -- repo tags such as dotnet-sdk-v1.5.0 are pre-publish release-please source tags, not registry releases, and are never used here."
+  },
+  "capabilityKeyList": {
+    "canonicalUrl": "https://raw.githubusercontent.com/honua-io/honua-server/trunk/docs/gis/data/capability-keys.v1.json",
+    "resolvedFrom": "contracts/fixtures/capability-keys.fixture.json (pinned mirror -- see KEY_LIST_URL)",
+    "keyCount": 110
+  },
+  "coverage": [
+    {
+      "key": "admin.control-plane",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminConnectionsClient",
+        "Honua.Sdk.Admin.IHonuaAdminServicesClient",
+        "Honua.Sdk.Admin.IHonuaAdminUsersClient",
+        "Honua.Sdk.Admin.IHonuaAdminRolesClient",
+        "Honua.Sdk.Admin.IHonuaAdminConfigClient",
+        "Honua.Sdk.Admin.IHonuaAdminMetadataClient"
+      ]
+    },
+    {
+      "key": "ai.spec-apply",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Spec.IHonuaSpecClient.ApplyAsync",
+        "Honua.Sdk.Spec.IHonuaSpecClient.CancelAsync"
+      ]
+    },
+    {
+      "key": "ai.spec-artifacts",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Spec.IHonuaSpecClient.GetArtifactAsync"
+      ]
+    },
+    {
+      "key": "alerts.dwell",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminAlertsClient"
+      ],
+      "note": "Same generic AlertRuleRequest.TriggerType/Channels passthrough as alerts.threshold; no dwell-duration-specific typed fields or client-side dwell evaluation ships in this SDK."
+    },
+    {
+      "key": "alerts.enter-exit",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminAlertsClient"
+      ],
+      "note": "Alert-zone CRUD (ListAlertZonesAsync/CreateAlertZoneAsync/etc.) plus generic rule CRUD supports configuring enter/exit zones, but TriggerType remains an opaque string -- the SDK has no typed enter-exit request shape or client-side geofence evaluation for alerting."
+    },
+    {
+      "key": "alerts.threshold",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminAlertsClient"
+      ],
+      "note": "Generic alert-rule CRUD (CreateAlertRuleAsync/UpdateAlertRuleAsync) passes AlertRuleRequest.TriggerType and Channels through as opaque strings. The SDK ships no typed threshold-specific request/response shape and does not validate threshold semantics client-side."
+    },
+    {
+      "key": "analytics.reporting",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Studio.IHonuaStudioReportsClient.GetReportAsync",
+        "Honua.Sdk.Studio.IHonuaStudioReportsClient.RenderReportAsync"
+      ],
+      "note": "Read/render only: retrieves and renders (Markdown/HTML) a structured analysis report for an already-completed job. The SDK does not submit or configure the analytics/report-generating job itself -- that goes through the generic IHonuaProcessesClient/IHonuaProcessGrpcClient job submission, not a typed analytics wrapper."
+    },
+    {
+      "key": "discovery.capability-manifest",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Studio.Capabilities.IHonuaCapabilityManifestClient.GetManifestAsync"
+      ]
+    },
+    {
+      "key": "editing.featureserver-edits",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.GeoServices.FeatureServer.IHonuaFeatureServerEditClient.ApplyEditsAsync"
+      ]
+    },
+    {
+      "key": "enrichment.datasets",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Abstractions.Data.IHonuaEnrichmentDataClient"
+      ],
+      "note": "Honua.Sdk.Abstractions ships IHonuaEnrichmentDataClient as a provider-neutral contract (GetEnrichmentMetadataAsync/EnrichAsync), but this SDK contains no concrete HTTP-backed implementation of it -- no HonuaEnrichmentDataClient class exists in src/ yet."
+    },
+    {
+      "key": "fieldops.forms",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Field.Forms.FormValidator",
+        "Honua.Sdk.Field.Forms.FieldFormSchemaMapper",
+        "Honua.Sdk.Field.Forms.CalculatedFieldEvaluator",
+        "Honua.Sdk.Field.Records.RecordWorkflow",
+        "Honua.Sdk.Field.Records.DuplicateDetector"
+      ]
+    },
+    {
+      "key": "fieldops.offline-sync",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Offline.OfflineSyncEngine",
+        "Honua.Sdk.Offline.OfflineDownloadPlanner",
+        "Honua.Sdk.Offline.ReplicaSyncClient"
+      ]
+    },
+    {
+      "key": "geocoding.batch",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.BatchGeocodeAsync",
+        "Honua.Sdk.Admin.Geocoding.IHonuaBatchGeocodingClient.BatchGeocodeDetailedAsync"
+      ]
+    },
+    {
+      "key": "geocoding.forward",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.ForwardGeocodeAsync"
+      ]
+    },
+    {
+      "key": "geocoding.reverse",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.ReverseGeocodeAsync"
+      ]
+    },
+    {
+      "key": "identity.oidc",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminIdentityClient.CreateOidcProviderAsync",
+        "Honua.Sdk.Admin.IHonuaAdminIdentityClient.TestOidcProviderAsync"
+      ]
+    },
+    {
+      "key": "identity.oidc-multi-provider",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminIdentityClient.ListOidcProvidersAsync",
+        "Honua.Sdk.Admin.IHonuaAdminIdentityClient.GetIdentityProvidersAsync"
+      ]
+    },
+    {
+      "key": "identity.portal-sharing",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.UpdateAccessAsync",
+        "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.CreatePublicLinkAsync"
+      ]
+    },
+    {
+      "key": "identity.portal-token",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.CreateEmbedTokenAsync",
+        "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.RevokeEmbedTokenAsync"
+      ]
+    },
+    {
+      "key": "import.geoserver",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.HonuaAdminMigrationClientExtensions.ScanMigrationSourceAsync"
+      ],
+      "note": "Covers migration-source scanning and inventory/manifest/parity-evidence/readiness-attestation generation only (sourceKind: \"geoserver\"), producing MigrationSourceInventoryArtifact / MigrationManifestArtifact / MigrationParityEvidenceArtifact / MigrationReadinessAttestation. The SDK has no apply/cutover call that loads a scanned GeoServer source's data or config into Honua."
+    },
+    {
+      "key": "import.geoservices",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.HonuaAdminMigrationClientExtensions.ScanMigrationSourceAsync"
+      ],
+      "note": "Same as import.geoserver: scan/manifest/parity-evidence/readiness-attestation generation only (sourceKind: \"geoservices\"), no apply/execute call."
+    },
+    {
+      "key": "ops.observability",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.IHonuaAdminObservabilityClient"
+      ]
+    },
+    {
+      "key": "plugin.sdk",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Abstractions.Plugins.HonuaPluginManifest"
+      ]
+    },
+    {
+      "key": "process.geoprocessing",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Processes.IHonuaProcessesClient.SubmitJobAsync",
+        "Honua.Sdk.Grpc.IHonuaProcessGrpcClient.SubmitJobAsync"
+      ],
+      "note": "Generic job submission/poll/cancel by processId works against any registered geoprocessing tool -- this is also the only path this SDK offers for GP-backed analytics.* operations; it has no typed per-tool wrappers. IHonuaProcessGrpcClient's own doc comments flag that its synchronous ExecutePlanAsync/ExecutePlanStreamAsync methods may return Unimplemented on current Honua Server deployments -- the reliable path is async submit-then-poll."
+    },
+    {
+      "key": "process.ogc-api-processes",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Processes.IHonuaProcessesClient"
+      ]
+    },
+    {
+      "key": "routing.solve",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.GeoServices.Routing.HonuaRoutingClient"
+      ]
+    },
+    {
+      "key": "scene.catalog",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Scenes.HonuaSceneClient.ListScenesAsync"
+      ]
+    },
+    {
+      "key": "serve.3d-tiles-scene",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Scenes.HonuaSceneClient"
+      ],
+      "note": "The scene client discovers and resolves a scene's 3D Tiles endpoint URL and capability tag (HonuaSceneCapabilities.ThreeDimensionalTiles); it does not parse or serve the 3D Tiles/Cesium tileset protocol itself. Renderer/display code is explicitly out of scope for this SDK (see AGENTS.md 'Does Not Belong Here')."
+    },
+    {
+      "key": "serve.elevation",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Abstractions.Data.IHonuaElevationDataClient"
+      ],
+      "note": "Same contract-only situation as enrichment.datasets: IHonuaElevationDataClient (SampleElevationAsync) is a shipped abstraction with no concrete implementing class in this SDK yet."
+    },
+    {
+      "key": "serve.geoservices-featureserver",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.GeoServices.FeatureServer.HonuaFeatureServerClient"
+      ]
+    },
+    {
+      "key": "serve.geoservices-geocodeserver",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient"
+      ]
+    },
+    {
+      "key": "serve.geoservices-geometry-service",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.GeoServices.GeometryServer.HonuaGeometryServerClient"
+      ]
+    },
+    {
+      "key": "serve.geoservices-imageserver",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.GeoServices.ImageServer.HonuaImageServerClient",
+        "Honua.Sdk.GeoServices.ImageServer.HonuaImageServerRasterDataClient"
+      ]
+    },
+    {
+      "key": "serve.i3s-scene",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Scenes.HonuaSceneClient"
+      ],
+      "note": "Same as serve.3d-tiles-scene: the scene client resolves the I3S endpoint URL and capability tag (HonuaSceneCapabilities.I3s) only; it does not parse or serve the I3S scene-layer protocol itself."
+    },
+    {
+      "key": "serve.ogc-api-features",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.OgcFeatures.HonuaOgcFeaturesClient",
+        "Honua.Sdk.OgcFeatures.IHonuaOgcFeaturesEditClient",
+        "Honua.Sdk.OgcFeatures.IHonuaOgcFeaturesPatchClient"
+      ]
+    },
+    {
+      "key": "serve.ogc-api-records",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Catalogs.Records.HonuaOgcRecordsClient"
+      ]
+    },
+    {
+      "key": "serve.stac",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Catalogs.Stac.HonuaStacClient"
+      ]
+    },
+    {
+      "key": "serve.wfs",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.OgcFeatures.Wfs.IHonuaWfsClient"
+      ],
+      "note": "WFS 2.0 read/query only (GetCapabilitiesAsync, DescribeFeatureTypeAsync, GetFeaturesAsync, hits-only count, auto-paging). No WFS-T Transaction (insert/update/delete) support ships in this SDK."
+    },
+    {
+      "key": "streaming.feature-subscriptions",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.Abstractions.Features.IHonuaFeatureStreamClient.SubscribeAsync",
+        "Honua.Sdk.Admin.IHonuaAdminStreamingOperationsClient"
+      ]
+    },
+    {
+      "key": "styling.defaults",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.ListStylesAsync"
+      ],
+      "note": "Read-only: the OgcStylesList.Default field surfaces which style is the server-declared default. The SDK has no call to designate or change the default style."
+    },
+    {
+      "key": "styling.ogc-api-styles",
+      "status": "covered",
+      "sinceVersion": "unreleased",
+      "entrypoints": [
+        "Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient"
+      ]
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ An index of the public documentation that ships alongside the
 - [Plugin contracts](plugin-contracts.md) — host-neutral plugin manifests, permissions, compatibility.
 - [Metadata catalog parity](metadata-catalog-parity.md) — Catalog vs OGC API Records vs STAC surface comparison.
 - [Capability feature map](features/README.md) — current capability snapshot per protocol.
+- [Capability coverage snapshot](capability-coverage.md) — `sdk-coverage.v1.json` schema, generation, and CI drift gate for the cross-repo capability matrix.
 
 ## Operations
 

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -1,0 +1,139 @@
+# Capability coverage snapshot (`sdk-coverage.v1.json`)
+
+This SDK publishes a per-capability coverage snapshot,
+[`contracts/sdk-coverage.v1.json`](../contracts/sdk-coverage.v1.json), for the
+cross-repo capability matrix (honua-io/honua-server#2892). It is this SDK's
+answer to "which canonical capabilities does the .NET SDK's source actually
+implement, and how completely" -- generated from the SDK's own source, not
+hand-guessed, and validated in CI against the published key list.
+
+## Consume, never copy
+
+The 110-key canonical capability vocabulary is owned by
+[honua-io/honua-server#2893](https://github.com/honua-io/honua-server) and
+published at `docs/gis/data/capability-keys.v1.json` (schema documented in
+that repo's `docs/gis/capability-keys-schema.md`). This SDK never redefines
+that vocabulary; `scripts/generate-sdk-coverage.py` only references keys from
+it, and fails the build if a mapped key does not actually exist in the
+resolved list.
+
+Key-list resolution order (same pattern used by honua-samples and
+honua-esri-assess):
+
+1. **`KEY_LIST_URL` env var**, if set to an `http(s)` URL -- fetched at run
+   time. This is the one-line swap point if CI ever needs to pin a different
+   ref of the published list.
+2. **`contracts/fixtures/capability-keys.fixture.json`** -- a pinned,
+   byte-for-byte mirror of the published file, committed so CI and offline
+   runs never depend on network access. Refresh it by re-downloading
+   <https://raw.githubusercontent.com/honua-io/honua-server/trunk/docs/gis/data/capability-keys.v1.json>
+   over the existing file; nothing else needs to change.
+
+## Schema
+
+```jsonc
+{
+  "schemaVersion": "1.0.0",
+  "generator": "scripts/generate-sdk-coverage.py",
+  "trackingIssue": "#273",
+  "sourceRepository": "honua-io/honua-sdk-dotnet",
+  "description": "...",
+  "sdkAvailability": {
+    "status": "source-preview",       // this SDK has no published NuGet package yet
+    "publishedVersion": null,
+    "note": "..."
+  },
+  "capabilityKeyList": {
+    "canonicalUrl": "https://raw.githubusercontent.com/honua-io/honua-server/trunk/docs/gis/data/capability-keys.v1.json",
+    "resolvedFrom": "contracts/fixtures/capability-keys.fixture.json (pinned mirror -- see KEY_LIST_URL)",
+    "keyCount": 110
+  },
+  "coverage": [
+    {
+      "key": "serve.geoservices-featureserver",
+      "status": "covered",            // "covered" | "partial"
+      "sinceVersion": "unreleased",
+      "entrypoints": ["Honua.Sdk.GeoServices.FeatureServer.HonuaFeatureServerClient"]
+    },
+    {
+      "key": "serve.wfs",
+      "status": "partial",
+      "sinceVersion": "unreleased",
+      "entrypoints": ["Honua.Sdk.OgcFeatures.Wfs.IHonuaWfsClient"],
+      "note": "WFS 2.0 read/query only; no WFS-T Transaction support ships in this SDK."
+    }
+  ]
+}
+```
+
+Field semantics:
+
+- **`status`**: `covered` (the SDK implements the full capability as this SDK
+  understands it) or `partial` (the SDK implements part of it). There is no
+  `none` status in the emitted file -- a capability this SDK does not touch is
+  **omitted from `coverage` entirely**. The generator refuses to emit a
+  literal `"none"` entry (see `_validate_entries` in the generator script);
+  padding the list with `none` rows would misrepresent silence as a
+  deliberate, reviewed judgment.
+- **`note`** (partial only, required and enforced by the generator): says
+  concretely where SDK coverage stops -- e.g. "read-only", "no Transaction
+  support", "contract-only, no concrete implementation ships yet". A `partial`
+  entry with an empty or missing note fails validation. A `covered` entry must
+  **not** carry a `note` (if there's a caveat worth writing down, the entry is
+  `partial` by definition).
+- **`sinceVersion`**: always the literal string `"unreleased"`. This SDK ships
+  as a **source preview** -- no `Honua.Sdk.*` NuGet package has published yet
+  (see honua-site's `data/sdk-availability.v1.json`, `productArea:
+  "sdk-dotnet"`, `availability: "Source preview"`, `publishedVersion: null`).
+  Repo tags such as `dotnet-sdk-v1.5.0` are pre-publish `release-please`
+  source tags, not registry releases, and must never be used as a
+  `sinceVersion` value -- that would imply a version boundary that does not
+  exist for anyone installing from a registry today. When a package first
+  publishes, real per-capability `sinceVersion` values become meaningful and
+  this doc (and the generator) should be updated together.
+- **`entrypoints`**: fully-qualified public type and/or method names that
+  provide the coverage -- always a real symbol in `src/`, never a paraphrase.
+
+## Generating and validating
+
+```bash
+# Regenerate contracts/sdk-coverage.v1.json from the curated inventory in
+# scripts/generate-sdk-coverage.py:
+python3 scripts/generate-sdk-coverage.py
+
+# Drift gate: fails if the committed file doesn't match what the generator
+# would produce right now (unknown keys, missing partial notes, and stale
+# content all fail this):
+python3 scripts/generate-sdk-coverage.py --check
+```
+
+CI runs the `--check` form (see `.github/workflows/ci.yml`, job
+`sdk-coverage`) on every push and pull request, and additionally uploads
+`contracts/sdk-coverage.v1.json` as a build artifact on `trunk` pushes so
+honua-evidence (honua-io/honua-evidence#1) can pull the latest snapshot.
+`scripts/tests/test_sdk_coverage.py` unit-tests the validation rules
+(unknown-key rejection, partial-requires-note, no-note-on-covered, duplicate
+keys) plus an end-to-end `--check` smoke test, and runs as part of the
+`workflow-validation` job's existing
+`python3 -m unittest discover -s scripts/tests -p 'test_*.py'` step.
+
+## Updating the inventory
+
+When SDK source gains, loses, or changes the shape of coverage for a
+capability:
+
+1. Edit the `COVERAGE_ENTRIES` list in `scripts/generate-sdk-coverage.py` --
+   point `entrypoints` at the real public symbol(s), and add/update a `note`
+   if the status is (or becomes) `partial`.
+2. Run `python3 scripts/generate-sdk-coverage.py` to regenerate
+   `contracts/sdk-coverage.v1.json`.
+3. Commit both files together. CI's drift gate fails a PR that changes
+   coverage-relevant source without regenerating the snapshot.
+
+## Known gaps
+
+- **honua-evidence ingestion is not yet proven end-to-end.** This issue
+  (honua-io/honua-server#2892 tracking the family; honua-io/honua-evidence#1
+  for the consumer) ships the producer side -- the validated, drift-gated,
+  CI-published snapshot -- but a live aggregate run pulling this SDK's
+  artifact into honua-evidence has not been executed as part of this change.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -42,6 +42,8 @@
       href: plugin-contracts.md
     - name: Metadata catalog parity
       href: metadata-catalog-parity.md
+    - name: Capability coverage snapshot
+      href: capability-coverage.md
 - name: Operations
   items:
     - name: Release

--- a/scripts/generate-sdk-coverage.py
+++ b/scripts/generate-sdk-coverage.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Generate and validate contracts/sdk-coverage.v1.json (issue #273).
+
+This is the .NET SDK's producer snapshot for the cross-repo capability
+matrix: for every canonical capability key this SDK's source actually
+implements, it records a coverage status (``covered`` or ``partial``),
+a ``sinceVersion`` marker, and entrypoint references (the public
+type/method that provides the coverage). Capabilities this SDK does not
+touch are omitted entirely -- never padded with an invented ``covered`` or
+``partial`` entry.
+
+Consume-never-copy
+-------------------
+The canonical 110-key capability vocabulary is published by
+honua-io/honua-server (honua-io/honua-server#2893) at
+``docs/gis/data/capability-keys.v1.json``. This script never redefines that
+vocabulary -- it only *references* keys from it (and fails loudly if a
+mapped key does not exist in the resolved canonical list). Key resolution
+order:
+
+  1. ``KEY_LIST_URL`` env var, if set to an http(s) URL -- fetched at run
+     time. This is the one-line swap point once the published artifact
+     moves or CI wants to pin a specific ref.
+  2. ``contracts/fixtures/capability-keys.fixture.json`` -- a pinned,
+     byte-for-byte mirror of the published file, committed in this repo so
+     CI and offline runs do not depend on network access. Refresh it by
+     re-downloading the canonical URL below; nothing else needs to change.
+
+Canonical URL (also the ``KEY_LIST_URL`` default a caller would set):
+  https://raw.githubusercontent.com/honua-io/honua-server/trunk/docs/gis/data/capability-keys.v1.json
+
+Partial-requires-a-note
+------------------------
+Every entry with ``status: partial`` must carry a non-empty ``note`` that
+says, in concrete terms, where SDK coverage stops. This is enforced by
+``_validate_entries`` below, not just convention -- a partial entry with no
+note fails the build.
+
+Usage
+-----
+  python3 scripts/generate-sdk-coverage.py            # (re)writes contracts/sdk-coverage.v1.json
+  python3 scripts/generate-sdk-coverage.py --check     # drift gate: fails if committed file is stale
+  python3 scripts/generate-sdk-coverage.py --summary <path>   # also append a GitHub step summary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = ROOT / "contracts" / "sdk-coverage.v1.json"
+FIXTURE_PATH = ROOT / "contracts" / "fixtures" / "capability-keys.fixture.json"
+CANONICAL_URL = (
+    "https://raw.githubusercontent.com/honua-io/honua-server/trunk/"
+    "docs/gis/data/capability-keys.v1.json"
+)
+TRACKING_ISSUE = "#273"
+SOURCE_REPOSITORY = "honua-io/honua-sdk-dotnet"
+
+# This SDK ships as a source preview only: no NuGet package has published yet
+# (see honua-site data/sdk-availability.v1.json, productArea "sdk-dotnet",
+# availability "Source preview", publishedVersion null). Every coverage entry
+# below therefore carries the literal marker "unreleased" rather than a
+# fabricated version number -- repo tags such as dotnet-sdk-v1.5.0 are
+# pre-publish release-please source tags, not registry releases, and must not
+# be used here to imply availability that does not exist yet.
+UNRELEASED = "unreleased"
+
+VALID_STATUSES = frozenset({"covered", "partial"})
+
+# ---------------------------------------------------------------------------
+# The inventory: canonical capability key -> what this SDK's source actually
+# implements. Add an entry only when you can point at a real public type or
+# member; remove an entry the moment the mapped surface is deleted or
+# renamed. Never add a "none" entry -- an untouched capability is simply
+# absent from this list.
+# ---------------------------------------------------------------------------
+COVERAGE_ENTRIES: list[dict[str, Any]] = [
+    {
+        "key": "admin.control-plane",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Admin.IHonuaAdminConnectionsClient",
+            "Honua.Sdk.Admin.IHonuaAdminServicesClient",
+            "Honua.Sdk.Admin.IHonuaAdminUsersClient",
+            "Honua.Sdk.Admin.IHonuaAdminRolesClient",
+            "Honua.Sdk.Admin.IHonuaAdminConfigClient",
+            "Honua.Sdk.Admin.IHonuaAdminMetadataClient",
+        ],
+    },
+    {
+        "key": "ai.spec-apply",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Spec.IHonuaSpecClient.ApplyAsync",
+            "Honua.Sdk.Spec.IHonuaSpecClient.CancelAsync",
+        ],
+    },
+    {
+        "key": "ai.spec-artifacts",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Spec.IHonuaSpecClient.GetArtifactAsync"],
+    },
+    {
+        "key": "discovery.capability-manifest",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Studio.Capabilities.IHonuaCapabilityManifestClient.GetManifestAsync",
+        ],
+    },
+    {
+        "key": "editing.featureserver-edits",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.GeoServices.FeatureServer.IHonuaFeatureServerEditClient.ApplyEditsAsync",
+        ],
+    },
+    {
+        "key": "fieldops.forms",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Field.Forms.FormValidator",
+            "Honua.Sdk.Field.Forms.FieldFormSchemaMapper",
+            "Honua.Sdk.Field.Forms.CalculatedFieldEvaluator",
+            "Honua.Sdk.Field.Records.RecordWorkflow",
+            "Honua.Sdk.Field.Records.DuplicateDetector",
+        ],
+    },
+    {
+        "key": "fieldops.offline-sync",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Offline.OfflineSyncEngine",
+            "Honua.Sdk.Offline.OfflineDownloadPlanner",
+            "Honua.Sdk.Offline.ReplicaSyncClient",
+        ],
+    },
+    {
+        "key": "geocoding.batch",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.BatchGeocodeAsync",
+            "Honua.Sdk.Admin.Geocoding.IHonuaBatchGeocodingClient.BatchGeocodeDetailedAsync",
+        ],
+    },
+    {
+        "key": "geocoding.forward",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.ForwardGeocodeAsync"],
+    },
+    {
+        "key": "geocoding.reverse",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient.ReverseGeocodeAsync"],
+    },
+    {
+        "key": "identity.oidc",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Admin.IHonuaAdminIdentityClient.CreateOidcProviderAsync",
+            "Honua.Sdk.Admin.IHonuaAdminIdentityClient.TestOidcProviderAsync",
+        ],
+    },
+    {
+        "key": "identity.oidc-multi-provider",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Admin.IHonuaAdminIdentityClient.ListOidcProvidersAsync",
+            "Honua.Sdk.Admin.IHonuaAdminIdentityClient.GetIdentityProvidersAsync",
+        ],
+    },
+    {
+        "key": "identity.portal-sharing",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.UpdateAccessAsync",
+            "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.CreatePublicLinkAsync",
+        ],
+    },
+    {
+        "key": "identity.portal-token",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.CreateEmbedTokenAsync",
+            "Honua.Sdk.ConsoleShare.IHonuaConsoleShareClient.RevokeEmbedTokenAsync",
+        ],
+    },
+    {
+        "key": "ops.observability",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Admin.IHonuaAdminObservabilityClient"],
+    },
+    {
+        "key": "plugin.sdk",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Abstractions.Plugins.HonuaPluginManifest"],
+    },
+    {
+        "key": "process.ogc-api-processes",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Processes.IHonuaProcessesClient"],
+    },
+    {
+        "key": "routing.solve",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.GeoServices.Routing.HonuaRoutingClient"],
+    },
+    {
+        "key": "scene.catalog",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Scenes.HonuaSceneClient.ListScenesAsync"],
+    },
+    {
+        "key": "serve.geoservices-featureserver",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.GeoServices.FeatureServer.HonuaFeatureServerClient"],
+    },
+    {
+        "key": "serve.geoservices-geocodeserver",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Admin.Geocoding.IHonuaGeocodingClient"],
+    },
+    {
+        "key": "serve.geoservices-geometry-service",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.GeoServices.GeometryServer.HonuaGeometryServerClient"],
+    },
+    {
+        "key": "serve.geoservices-imageserver",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.GeoServices.ImageServer.HonuaImageServerClient",
+            "Honua.Sdk.GeoServices.ImageServer.HonuaImageServerRasterDataClient",
+        ],
+    },
+    {
+        "key": "serve.ogc-api-features",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.OgcFeatures.HonuaOgcFeaturesClient",
+            "Honua.Sdk.OgcFeatures.IHonuaOgcFeaturesEditClient",
+            "Honua.Sdk.OgcFeatures.IHonuaOgcFeaturesPatchClient",
+        ],
+    },
+    {
+        "key": "serve.ogc-api-records",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Catalogs.Records.HonuaOgcRecordsClient"],
+    },
+    {
+        "key": "serve.stac",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.Catalogs.Stac.HonuaStacClient"],
+    },
+    {
+        "key": "streaming.feature-subscriptions",
+        "status": "covered",
+        "entrypoints": [
+            "Honua.Sdk.Abstractions.Features.IHonuaFeatureStreamClient.SubscribeAsync",
+            "Honua.Sdk.Admin.IHonuaAdminStreamingOperationsClient",
+        ],
+    },
+    {
+        "key": "styling.ogc-api-styles",
+        "status": "covered",
+        "entrypoints": ["Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient"],
+    },
+    {
+        "key": "alerts.threshold",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Admin.IHonuaAdminAlertsClient"],
+        "note": (
+            "Generic alert-rule CRUD (CreateAlertRuleAsync/UpdateAlertRuleAsync) "
+            "passes AlertRuleRequest.TriggerType and Channels through as opaque "
+            "strings. The SDK ships no typed threshold-specific request/response "
+            "shape and does not validate threshold semantics client-side."
+        ),
+    },
+    {
+        "key": "alerts.dwell",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Admin.IHonuaAdminAlertsClient"],
+        "note": (
+            "Same generic AlertRuleRequest.TriggerType/Channels passthrough as "
+            "alerts.threshold; no dwell-duration-specific typed fields or "
+            "client-side dwell evaluation ships in this SDK."
+        ),
+    },
+    {
+        "key": "alerts.enter-exit",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Admin.IHonuaAdminAlertsClient"],
+        "note": (
+            "Alert-zone CRUD (ListAlertZonesAsync/CreateAlertZoneAsync/etc.) plus "
+            "generic rule CRUD supports configuring enter/exit zones, but "
+            "TriggerType remains an opaque string -- the SDK has no typed "
+            "enter-exit request shape or client-side geofence evaluation for "
+            "alerting."
+        ),
+    },
+    {
+        "key": "analytics.reporting",
+        "status": "partial",
+        "entrypoints": [
+            "Honua.Sdk.Studio.IHonuaStudioReportsClient.GetReportAsync",
+            "Honua.Sdk.Studio.IHonuaStudioReportsClient.RenderReportAsync",
+        ],
+        "note": (
+            "Read/render only: retrieves and renders (Markdown/HTML) a structured "
+            "analysis report for an already-completed job. The SDK does not submit "
+            "or configure the analytics/report-generating job itself -- that goes "
+            "through the generic IHonuaProcessesClient/IHonuaProcessGrpcClient job "
+            "submission, not a typed analytics wrapper."
+        ),
+    },
+    {
+        "key": "enrichment.datasets",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Abstractions.Data.IHonuaEnrichmentDataClient"],
+        "note": (
+            "Honua.Sdk.Abstractions ships IHonuaEnrichmentDataClient as a "
+            "provider-neutral contract (GetEnrichmentMetadataAsync/EnrichAsync), "
+            "but this SDK contains no concrete HTTP-backed implementation of it -- "
+            "no HonuaEnrichmentDataClient class exists in src/ yet."
+        ),
+    },
+    {
+        "key": "serve.elevation",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Abstractions.Data.IHonuaElevationDataClient"],
+        "note": (
+            "Same contract-only situation as enrichment.datasets: "
+            "IHonuaElevationDataClient (SampleElevationAsync) is a shipped "
+            "abstraction with no concrete implementing class in this SDK yet."
+        ),
+    },
+    {
+        "key": "serve.wfs",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.OgcFeatures.Wfs.IHonuaWfsClient"],
+        "note": (
+            "WFS 2.0 read/query only (GetCapabilitiesAsync, "
+            "DescribeFeatureTypeAsync, GetFeaturesAsync, hits-only count, "
+            "auto-paging). No WFS-T Transaction (insert/update/delete) support "
+            "ships in this SDK."
+        ),
+    },
+    {
+        "key": "serve.3d-tiles-scene",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Scenes.HonuaSceneClient"],
+        "note": (
+            "The scene client discovers and resolves a scene's 3D Tiles endpoint "
+            "URL and capability tag (HonuaSceneCapabilities.ThreeDimensionalTiles); "
+            "it does not parse or serve the 3D Tiles/Cesium tileset protocol "
+            "itself. Renderer/display code is explicitly out of scope for this SDK "
+            "(see AGENTS.md 'Does Not Belong Here')."
+        ),
+    },
+    {
+        "key": "serve.i3s-scene",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Scenes.HonuaSceneClient"],
+        "note": (
+            "Same as serve.3d-tiles-scene: the scene client resolves the I3S "
+            "endpoint URL and capability tag (HonuaSceneCapabilities.I3s) only; "
+            "it does not parse or serve the I3S scene-layer protocol itself."
+        ),
+    },
+    {
+        "key": "styling.defaults",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.OgcFeatures.Styles.IHonuaOgcStylesClient.ListStylesAsync"],
+        "note": (
+            "Read-only: the OgcStylesList.Default field surfaces which style is "
+            "the server-declared default. The SDK has no call to designate or "
+            "change the default style."
+        ),
+    },
+    {
+        "key": "import.geoserver",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Admin.HonuaAdminMigrationClientExtensions.ScanMigrationSourceAsync"],
+        "note": (
+            "Covers migration-source scanning and inventory/manifest/"
+            "parity-evidence/readiness-attestation generation only "
+            "(sourceKind: \"geoserver\"), producing "
+            "MigrationSourceInventoryArtifact / MigrationManifestArtifact / "
+            "MigrationParityEvidenceArtifact / MigrationReadinessAttestation. The "
+            "SDK has no apply/cutover call that loads a scanned GeoServer "
+            "source's data or config into Honua."
+        ),
+    },
+    {
+        "key": "import.geoservices",
+        "status": "partial",
+        "entrypoints": ["Honua.Sdk.Admin.HonuaAdminMigrationClientExtensions.ScanMigrationSourceAsync"],
+        "note": (
+            "Same as import.geoserver: scan/manifest/parity-evidence/"
+            "readiness-attestation generation only (sourceKind: \"geoservices\"), "
+            "no apply/execute call."
+        ),
+    },
+    {
+        "key": "process.geoprocessing",
+        "status": "partial",
+        "entrypoints": [
+            "Honua.Sdk.Processes.IHonuaProcessesClient.SubmitJobAsync",
+            "Honua.Sdk.Grpc.IHonuaProcessGrpcClient.SubmitJobAsync",
+        ],
+        "note": (
+            "Generic job submission/poll/cancel by processId works against any "
+            "registered geoprocessing tool -- this is also the only path this SDK "
+            "offers for GP-backed analytics.* operations; it has no typed "
+            "per-tool wrappers. IHonuaProcessGrpcClient's own doc comments flag "
+            "that its synchronous ExecutePlanAsync/ExecutePlanStreamAsync methods "
+            "may return Unimplemented on current Honua Server deployments -- the "
+            "reliable path is async submit-then-poll."
+        ),
+    },
+]
+
+
+def _load_canonical_keys() -> tuple[frozenset[str], str]:
+    """Resolves the canonical capability key set and where it came from."""
+
+    url = os.environ.get("KEY_LIST_URL", "").strip()
+    if url:
+        if not url.lower().startswith(("http://", "https://")):
+            raise ValueError(
+                f"KEY_LIST_URL is set to {url!r} but is not an http(s) URL. "
+                "Unset it to fall back to the pinned fixture, or point it at "
+                "the published capability-keys.v1.json."
+            )
+        with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310 (explicit http(s) check above)
+            payload = json.load(response)
+        return _extract_keys(payload), f"KEY_LIST_URL ({url})"
+
+    payload = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+    return (
+        _extract_keys(payload),
+        "contracts/fixtures/capability-keys.fixture.json (pinned mirror -- see KEY_LIST_URL)",
+    )
+
+
+def _extract_keys(payload: Any) -> frozenset[str]:
+    if isinstance(payload, list):
+        return frozenset(payload)
+    if isinstance(payload, dict) and isinstance(payload.get("capabilities"), list):
+        return frozenset(item["key"] for item in payload["capabilities"] if isinstance(item, dict) and "key" in item)
+    if isinstance(payload, dict) and isinstance(payload.get("keys"), list):
+        return frozenset(payload["keys"])
+    raise ValueError(
+        "capability key list must be an array of strings, an object with a "
+        "'keys' array, or the canonical {'capabilities': [{'key': ...}, ...]} shape"
+    )
+
+
+def _validate_entries(entries: list[dict[str, Any]], canonical_keys: frozenset[str]) -> None:
+    seen: set[str] = set()
+    errors: list[str] = []
+
+    for entry in entries:
+        key = entry.get("key")
+        status = entry.get("status")
+        entrypoints = entry.get("entrypoints")
+        note = entry.get("note")
+
+        if not isinstance(key, str) or not key:
+            errors.append(f"entry missing a string 'key': {entry!r}")
+            continue
+
+        if key in seen:
+            errors.append(f"duplicate coverage entry for key {key!r}")
+        seen.add(key)
+
+        if key not in canonical_keys:
+            errors.append(
+                f"unknown capability key {key!r} -- not in the resolved canonical "
+                "key list. Fix the key, or confirm honua-server#2893's published "
+                "list actually contains it before mapping to it."
+            )
+
+        if status not in VALID_STATUSES:
+            errors.append(
+                f"{key!r}: status must be one of {sorted(VALID_STATUSES)}, got {status!r}. "
+                "Untouched capabilities must be omitted entirely, never recorded as 'none'."
+            )
+
+        if not isinstance(entrypoints, list) or not entrypoints or not all(isinstance(e, str) and e for e in entrypoints):
+            errors.append(f"{key!r}: 'entrypoints' must be a non-empty list of non-empty strings")
+
+        if status == "partial" and not (isinstance(note, str) and note.strip()):
+            errors.append(f"{key!r}: status is 'partial' but has no non-empty 'note' saying where coverage stops")
+
+        if status == "covered" and note is not None:
+            errors.append(f"{key!r}: status is 'covered' but carries a 'note' -- notes are reserved for 'partial'")
+
+    if errors:
+        raise ValueError("sdk-coverage.v1.json validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
+
+
+def _build_document(canonical_keys: frozenset[str], key_list_source: str) -> dict[str, Any]:
+    ordered = sorted(COVERAGE_ENTRIES, key=lambda e: e["key"])
+    _validate_entries(ordered, canonical_keys)
+
+    coverage = []
+    for entry in ordered:
+        item: dict[str, Any] = {
+            "key": entry["key"],
+            "status": entry["status"],
+            "sinceVersion": UNRELEASED,
+            "entrypoints": list(entry["entrypoints"]),
+        }
+        if entry["status"] == "partial":
+            item["note"] = entry["note"]
+        coverage.append(item)
+
+    return {
+        "schemaVersion": "1.0.0",
+        "generator": "scripts/generate-sdk-coverage.py",
+        "trackingIssue": TRACKING_ISSUE,
+        "sourceRepository": SOURCE_REPOSITORY,
+        "description": (
+            "Per-capability coverage snapshot for the cross-repo capability "
+            "matrix (honua-io/honua-server#2892). Each entry maps a canonical "
+            "capability key (consumed, never copied, from honua-server#2893's "
+            "published capability-keys.v1.json) to what this SDK's source "
+            "actually implements. Capabilities this SDK does not touch are "
+            "absent from 'coverage' -- never padded."
+        ),
+        "sdkAvailability": {
+            "status": "source-preview",
+            "publishedVersion": None,
+            "note": (
+                "Honua.Sdk.* ships as a source preview only; no NuGet package "
+                "has published yet (see honua-site data/sdk-availability.v1.json, "
+                "productArea \"sdk-dotnet\"). Every coverage entry's "
+                "sinceVersion is the literal marker \"unreleased\" -- repo tags "
+                "such as dotnet-sdk-v1.5.0 are pre-publish release-please "
+                "source tags, not registry releases, and are never used here."
+            ),
+        },
+        "capabilityKeyList": {
+            "canonicalUrl": CANONICAL_URL,
+            "resolvedFrom": key_list_source,
+            "keyCount": len(canonical_keys),
+        },
+        "coverage": coverage,
+    }
+
+
+def _dumps(document: dict[str, Any]) -> str:
+    return json.dumps(document, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if contracts/sdk-coverage.v1.json is missing or stale (drift gate); do not write.",
+    )
+    parser.add_argument(
+        "--summary",
+        type=Path,
+        help="Optional path (e.g. $GITHUB_STEP_SUMMARY) to append a coverage summary to.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        canonical_keys, key_list_source = _load_canonical_keys()
+        document = _build_document(canonical_keys, key_list_source)
+    except (ValueError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return 1
+
+    rendered = _dumps(document)
+    covered = sum(1 for c in document["coverage"] if c["status"] == "covered")
+    partial = sum(1 for c in document["coverage"] if c["status"] == "partial")
+    total_keys = document["capabilityKeyList"]["keyCount"]
+
+    summary_line = (
+        f"sdk-coverage.v1.json: {covered} covered + {partial} partial "
+        f"= {covered + partial}/{total_keys} canonical capability keys touched "
+        f"(source: {key_list_source})."
+    )
+    print(summary_line)
+
+    if args.summary:
+        with args.summary.open("a", encoding="utf-8") as fh:
+            fh.write(f"\n**SDK coverage snapshot**: {summary_line}\n")
+
+    if args.check:
+        if not OUTPUT_PATH.is_file():
+            print(f"::error::{OUTPUT_PATH} does not exist. Run without --check to generate it.", file=sys.stderr)
+            return 1
+        existing = OUTPUT_PATH.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(
+                f"::error::{OUTPUT_PATH} is stale. Run "
+                "'python3 scripts/generate-sdk-coverage.py' and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"{OUTPUT_PATH} is up to date.")
+        return 0
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {OUTPUT_PATH}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_sdk_coverage.py
+++ b/scripts/tests/test_sdk_coverage.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "generate-sdk-coverage.py"
+OUTPUT_PATH = ROOT / "contracts" / "sdk-coverage.v1.json"
+FIXTURE_PATH = ROOT / "contracts" / "fixtures" / "capability-keys.fixture.json"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("generate_sdk_coverage", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FixtureTests(unittest.TestCase):
+    def test_pinned_fixture_has_the_canonical_shape(self) -> None:
+        module = _load_module()
+        payload = module.json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+        self.assertIn("capabilities", payload)
+        keys = module._extract_keys(payload)
+        self.assertGreaterEqual(len(keys), 100)
+        self.assertIn("serve.geoservices-featureserver", keys)
+        self.assertIn("admin.control-plane", keys)
+
+
+class ValidateEntriesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = _load_module()
+        self.canonical = frozenset({"a.one", "a.two", "a.three"})
+
+    def test_valid_entries_pass(self) -> None:
+        entries = [
+            {"key": "a.one", "status": "covered", "entrypoints": ["X.Y"]},
+            {"key": "a.two", "status": "partial", "entrypoints": ["X.Z"], "note": "stops here"},
+        ]
+        # Should not raise.
+        self.module._validate_entries(entries, self.canonical)
+
+    def test_unknown_key_fails_loudly(self) -> None:
+        entries = [{"key": "not.a.real.key", "status": "covered", "entrypoints": ["X.Y"]}]
+        with self.assertRaisesRegex(ValueError, "unknown capability key"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_partial_without_note_fails(self) -> None:
+        entries = [{"key": "a.one", "status": "partial", "entrypoints": ["X.Y"]}]
+        with self.assertRaisesRegex(ValueError, "no non-empty 'note'"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_partial_with_blank_note_fails(self) -> None:
+        entries = [{"key": "a.one", "status": "partial", "entrypoints": ["X.Y"], "note": "   "}]
+        with self.assertRaisesRegex(ValueError, "no non-empty 'note'"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_covered_with_note_fails(self) -> None:
+        entries = [{"key": "a.one", "status": "covered", "entrypoints": ["X.Y"], "note": "not allowed"}]
+        with self.assertRaisesRegex(ValueError, "notes are reserved for 'partial'"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_none_status_fails(self) -> None:
+        entries = [{"key": "a.one", "status": "none", "entrypoints": ["X.Y"]}]
+        with self.assertRaisesRegex(ValueError, "must be omitted entirely"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_duplicate_key_fails(self) -> None:
+        entries = [
+            {"key": "a.one", "status": "covered", "entrypoints": ["X.Y"]},
+            {"key": "a.one", "status": "covered", "entrypoints": ["X.Z"]},
+        ]
+        with self.assertRaisesRegex(ValueError, "duplicate coverage entry"):
+            self.module._validate_entries(entries, self.canonical)
+
+    def test_empty_entrypoints_fails(self) -> None:
+        entries = [{"key": "a.one", "status": "covered", "entrypoints": []}]
+        with self.assertRaisesRegex(ValueError, "non-empty list"):
+            self.module._validate_entries(entries, self.canonical)
+
+
+class RealInventoryTests(unittest.TestCase):
+    """Exercises the actual curated COVERAGE_ENTRIES against the pinned fixture."""
+
+    def test_real_entries_validate_against_pinned_fixture(self) -> None:
+        module = _load_module()
+        canonical_keys, source = module._load_canonical_keys()
+        # Force fixture resolution regardless of any ambient KEY_LIST_URL so this
+        # test is hermetic.
+        document = module._build_document(canonical_keys, source)
+        self.assertGreater(len(document["coverage"]), 0)
+
+        for entry in document["coverage"]:
+            self.assertIn(entry["status"], {"covered", "partial"})
+            self.assertEqual(entry["sinceVersion"], "unreleased")
+            self.assertTrue(entry["entrypoints"])
+            if entry["status"] == "partial":
+                self.assertTrue(entry.get("note", "").strip())
+            else:
+                self.assertNotIn("note", entry)
+
+    def test_no_duplicate_keys_in_curated_inventory(self) -> None:
+        module = _load_module()
+        keys = [e["key"] for e in module.COVERAGE_ENTRIES]
+        self.assertEqual(len(keys), len(set(keys)))
+
+
+class EndToEndCheckModeTests(unittest.TestCase):
+    def test_check_mode_passes_against_committed_snapshot(self) -> None:
+        # This assumes contracts/sdk-coverage.v1.json is checked in and current;
+        # CI's drift gate step is exactly this invocation.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--check"],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            0,
+            result.returncode,
+            msg=f"stdout={result.stdout!r} stderr={result.stderr!r}",
+        )
+
+    def test_check_mode_fails_when_output_is_stale(self) -> None:
+        original = OUTPUT_PATH.read_text(encoding="utf-8")
+        try:
+            OUTPUT_PATH.write_text(original + "\n", encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), "--check"],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("stale", result.stderr)
+        finally:
+            OUTPUT_PATH.write_text(original, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Publishes this SDK's producer snapshot for the cross-repo capability matrix: `contracts/sdk-coverage.v1.json`, generated from an inventory of what the SDK's own source actually implements, mapped to the canonical capability keys published by honua-io/honua-server#2893 (110 keys, consumed via `contracts/fixtures/capability-keys.fixture.json` / `KEY_LIST_URL`, never copied).

## Changes

- `scripts/generate-sdk-coverage.py` — the generator and validator:
  - Resolves the canonical key list from `KEY_LIST_URL` (env var) or the pinned `contracts/fixtures/capability-keys.fixture.json` mirror.
  - Curated `COVERAGE_ENTRIES` table mapping SDK client surfaces to capability keys.
  - Validation: unknown keys fail the build; `partial` requires a non-empty note saying where coverage stops; `covered` forbids a note; no `"none"` entries are ever emitted — untouched capabilities are simply omitted, never padded.
  - `--check` mode is the CI drift gate (fails if the committed snapshot doesn't match what the generator would produce right now).
- `contracts/sdk-coverage.v1.json` — the committed, generated snapshot: **28 covered + 13 partial of 110** canonical capability keys.
- `contracts/fixtures/capability-keys.fixture.json` — pinned mirror of the canonical key list for offline/CI use.
- `.github/workflows/ci.yml` — new `sdk-coverage` job: runs the `--check` drift gate on every push/PR, uploads `contracts/sdk-coverage.v1.json` as a build artifact on `trunk` pushes only.
- `docs/capability-coverage.md` (linked from `docs/README.md` and `docs/toc.yml`) — schema, field semantics, generation/update workflow.
- `scripts/tests/test_sdk_coverage.py` — unit tests for every validation rule (unknown key, missing/blank partial note, note-on-covered, duplicate key, empty entrypoints) plus an end-to-end `--check` smoke test against the real committed file. Picked up automatically by the existing `workflow-validation` job's `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` step.

## Decisions

- **`sinceVersion` is the literal `"unreleased"` marker for every entry.** This SDK is a source preview — no `Honua.Sdk.*` NuGet package has published yet (per honua-site's `data/sdk-availability.v1.json`: `availability: "Source preview"`, `publishedVersion: null`). Repo tags like `dotnet-sdk-v1.5.0` are pre-publish `release-please` source tags, not registry releases, so they're deliberately never used as a version boundary here.
- **No key-list forking.** The 110-key vocabulary is never redefined in this repo; the generator only references keys and fails loudly if a mapped key doesn't exist in the resolved canonical list (same `KEY_LIST_URL` + pinned-fixture pattern already used by honua-samples and honua-esri-assess).
- **Contract-only abstractions are `partial`, not `covered`.** `IHonuaElevationDataClient` / `IHonuaEnrichmentDataClient` ship as provider-neutral contracts in `Honua.Sdk.Abstractions` with no concrete HTTP-backed implementing class in this SDK yet — marked `partial` with a note rather than `covered` or silently omitted, since the shipped contract is real, reviewable signal even without a backing client.
- **Generic job submission counts for `process.geoprocessing`, not for each `analytics.*` key.** `IHonuaProcessesClient`/`IHonuaProcessGrpcClient` can invoke any registered GP tool generically by `processId`, which covers `process.geoprocessing` and `process.ogc-api-processes`. It would be padding to claim the specific `analytics.buffer-aggregate` / `analytics.clustering` / `analytics.viewshed` / etc. keys just because a generic submission path exists — those stay omitted since the SDK has no typed per-tool wrapper.
- **Migration toolkit (`import.geoserver`/`import.geoservices`) is `partial`.** `HonuaAdminMigrationClientExtensions.ScanMigrationSourceAsync` covers scan/inventory/manifest/parity-evidence/readiness-attestation generation only — there's no apply/cutover call in this SDK that actually loads a scanned source's data into Honua.
- **WFS is `partial`.** `IHonuaWfsClient` is WFS 2.0 read/query only (matches `docs/features/README.md`'s existing "WFS 2.0 ... read/query" framing) — no WFS-T Transaction support.
- **Scene 3D protocol keys are `partial`.** `HonuaSceneClient` discovers/resolves 3D Tiles and I3S endpoint URLs and capability tags, but doesn't parse or serve either protocol itself — that's explicitly out of scope per AGENTS.md ("Does Not Belong Here": renderer/display code).

## Test plan

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 29 tests pass (21 pre-existing + 8 new `test_sdk_coverage.py` test classes covering validation rules, the pinned fixture shape, the real curated inventory against the fixture, and an end-to-end `--check` smoke test including a deliberately-staled-then-restored file).
- `bash scripts/validate-package-inventory.sh` — passes unchanged (16 shipped packages).
- `python3 scripts/generate-sdk-coverage.py` / `--check` — verified idempotent (regenerating produces byte-identical output) and verified to fail loudly on: an unset/bad `KEY_LIST_URL`, an unknown capability key, a `partial` entry with no note, and a stale committed file.
- `actionlint` (same pinned image CI uses) — clean against the updated `.github/workflows/ci.yml`.
- No `.cs` source was touched, so the existing build/test/coverage/api-compat CI legs are unaffected by this change.

## Deferred

- **honua-evidence ingestion is not proven end-to-end.** This PR ships the producer side (validated, drift-gated, CI-published snapshot) but does not execute a live aggregate run pulling this artifact into honua-evidence (honua-io/honua-evidence#1). Flagged explicitly in `docs/capability-coverage.md`'s "Known gaps" section.

Related to #273. Not closing #273 outright — the third acceptance criterion (honua-evidence ingestion proven with one end-to-end aggregate run) is out of this SDK repo's control and stays open until that cross-repo run happens.