### PR TITLE
feat(coverage): enforce entrypoint source-truth in sdk-coverage drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
       - name: Validate sdk-coverage.v1.json (drift gate)
         # Regenerates the snapshot in memory from the curated inventory in
         # scripts/generate-sdk-coverage.py and fails if it differs from the
-        # committed contracts/sdk-coverage.v1.json -- catching both stale
-        # commits and unknown/malformed capability keys. KEY_LIST_URL is
+        # committed contracts/sdk-coverage.v1.json -- catching stale commits,
+        # unknown/malformed capability keys, and entrypoints that no longer
+        # resolve against src/ (deleted/renamed surfaces). KEY_LIST_URL is
         # intentionally left unset here so this always validates against the
         # pinned contracts/fixtures/capability-keys.fixture.json mirror,
         # matching what's actually committed.

--- a/contracts/fixtures/capability-keys.fixture.json
+++ b/contracts/fixtures/capability-keys.fixture.json
@@ -323,15 +323,15 @@
       "key": "geocoding.forward",
       "displayName": "Forward Geocoding",
       "category": "Geocoding",
-      "edition": "Pro",
-      "description": "Convert addresses to coordinates using configured providers."
+      "edition": "Community",
+      "description": "Convert a freeform address to coordinates using configured providers."
     },
     {
       "key": "geocoding.reverse",
       "displayName": "Reverse Geocoding",
       "category": "Geocoding",
-      "edition": "Pro",
-      "description": "Convert coordinates to addresses using configured providers."
+      "edition": "Community",
+      "description": "Convert coordinates to a nearest-address match using configured providers."
     },
     {
       "key": "identity.claims-mapping",
@@ -379,14 +379,14 @@
       "key": "identity.saml",
       "displayName": "SAML 2.0 Authentication",
       "category": "Identity",
-      "edition": "Community",
-      "description": "SAML 2.0 service-provider metadata and assertion consumer endpoints."
+      "edition": "Enterprise",
+      "description": "SAML 2.0 service-provider metadata, assertion consumer, and single-logout endpoints."
     },
     {
       "key": "identity.scim",
       "displayName": "SCIM 2.0 Provisioning",
       "category": "Identity",
-      "edition": "Community",
+      "edition": "Enterprise",
       "description": "User/group provisioning through the SCIM 2.0 protocol surface."
     },
     {
@@ -548,7 +548,7 @@
       "displayName": "GeocodeServer Discovery",
       "category": "Serve",
       "edition": "Community",
-      "description": "Discover GeocodeServer service and layer metadata. Forward/reverse/batch geocode execution is gated by the geocoding.* entitlement keys."
+      "description": "Discover GeocodeServer service and layer metadata. Batch geocode execution is gated by the geocoding.batch entitlement key (Enterprise); forward and reverse geocode execution are Community (#2981)."
     },
     {
       "key": "serve.geoservices-geometry-service",

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -93,6 +93,12 @@ Field semantics:
   this doc (and the generator) should be updated together.
 - **`entrypoints`**: fully-qualified public type and/or method names that
   provide the coverage -- always a real symbol in `src/`, never a paraphrase.
+  This is machine-enforced, not just convention: the generator indexes every
+  type declared under `src/` and fails if an entrypoint no longer resolves
+  (`Namespace.Type` must be a declared type; `Namespace.Type.Member` must
+  additionally name a member appearing in a file that declares the type). A
+  rename or deletion of a mapped public surface therefore fails the CI drift
+  gate until the inventory and snapshot are updated together.
 
 ## Generating and validating
 
@@ -102,8 +108,8 @@ Field semantics:
 python3 scripts/generate-sdk-coverage.py
 
 # Drift gate: fails if the committed file doesn't match what the generator
-# would produce right now (unknown keys, missing partial notes, and stale
-# content all fail this):
+# would produce right now (unknown keys, missing partial notes, entrypoints
+# that no longer resolve against src/, and stale content all fail this):
 python3 scripts/generate-sdk-coverage.py --check
 ```
 
@@ -113,8 +119,8 @@ CI runs the `--check` form (see `.github/workflows/ci.yml`, job
 honua-evidence (honua-io/honua-evidence#1) can pull the latest snapshot.
 `scripts/tests/test_sdk_coverage.py` unit-tests the validation rules
 (unknown-key rejection, partial-requires-note, no-note-on-covered, duplicate
-keys) plus an end-to-end `--check` smoke test, and runs as part of the
-`workflow-validation` job's existing
+keys, entrypoint source-truth resolution) plus an end-to-end `--check` smoke
+test, and runs as part of the `workflow-validation` job's existing
 `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` step.
 
 ## Updating the inventory
@@ -130,10 +136,15 @@ capability:
 3. Commit both files together. CI's drift gate fails a PR that changes
    coverage-relevant source without regenerating the snapshot.
 
-## Known gaps
+## Downstream ingestion
 
-- **honua-evidence ingestion is not yet proven end-to-end.** This issue
-  (honua-io/honua-server#2892 tracking the family; honua-io/honua-evidence#1
-  for the consumer) ships the producer side -- the validated, drift-gated,
-  CI-published snapshot -- but a live aggregate run pulling this SDK's
-  artifact into honua-evidence has not been executed as part of this change.
+honua-evidence (honua-io/honua-evidence#1) ingests this snapshot end-to-end:
+its aggregator fetches
+`https://raw.githubusercontent.com/honua-io/honua-sdk-dotnet/trunk/contracts/sdk-coverage.v1.json`,
+joins each entry into `data/capability-matrix.v1.json` under
+`capabilities[].sdks.dotnet` (status, `sinceVersion`, entrypoints), and tracks
+this producer in its freshness ledger (30-day staleness threshold). Pushes to
+`trunk` that change the snapshot also fire a `producer-updated`
+repository_dispatch to honua-evidence via
+`.github/workflows/notify-evidence.yml`, so re-aggregation is event-driven
+rather than waiting on the daily schedule.

--- a/docs/capability-coverage.md
+++ b/docs/capability-coverage.md
@@ -94,11 +94,15 @@ Field semantics:
 - **`entrypoints`**: fully-qualified public type and/or method names that
   provide the coverage -- always a real symbol in `src/`, never a paraphrase.
   This is machine-enforced, not just convention: the generator indexes every
-  type declared under `src/` and fails if an entrypoint no longer resolves
-  (`Namespace.Type` must be a declared type; `Namespace.Type.Member` must
-  additionally name a member appearing in a file that declares the type). A
-  rename or deletion of a mapped public surface therefore fails the CI drift
-  gate until the inventory and snapshot are updated together.
+  *publicly declared* type under `src/` (real declaration syntax, matched on
+  comment/string-stripped source) and fails if an entrypoint no longer
+  resolves (`Namespace.Type` must be a public type declaration;
+  `Namespace.Type.Member` must additionally match an accessible,
+  declaration-shaped member in a file declaring the type). Occurrences that
+  survive only in comments, XML doc prose, or string literals never count,
+  and a type demoted to `internal` stops resolving -- so a rename, deletion,
+  or de-publicizing of a mapped surface fails the CI drift gate until the
+  inventory and snapshot are updated together.
 
 ## Generating and validating
 

--- a/scripts/generate-sdk-coverage.py
+++ b/scripts/generate-sdk-coverage.py
@@ -36,6 +36,17 @@ says, in concrete terms, where SDK coverage stops. This is enforced by
 ``_validate_entries`` below, not just convention -- a partial entry with no
 note fails the build.
 
+Entrypoints-must-exist (source-truth gate)
+-------------------------------------------
+Every ``entrypoints`` reference must resolve against the actual SDK source
+under ``src/``: the referenced type must be declared in some ``.cs`` file
+(namespace + type name), and a ``Type.Member`` reference must additionally
+name a member that appears in a file declaring that type. This is what makes
+the CI drift gate honest about *renames and deletions*, not just stale
+regeneration: removing or renaming a mapped public client without updating
+the inventory fails ``--check`` instead of leaving the snapshot claiming
+coverage that no longer exists.
+
 Usage
 -----
   python3 scripts/generate-sdk-coverage.py            # (re)writes contracts/sdk-coverage.v1.json
@@ -48,6 +59,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
@@ -55,6 +67,7 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = ROOT / "src"
 OUTPUT_PATH = ROOT / "contracts" / "sdk-coverage.v1.json"
 FIXTURE_PATH = ROOT / "contracts" / "fixtures" / "capability-keys.fixture.json"
 CANONICAL_URL = (
@@ -507,6 +520,90 @@ def _validate_entries(entries: list[dict[str, Any]], canonical_keys: frozenset[s
         raise ValueError("sdk-coverage.v1.json validation failed:\n" + "\n".join(f"  - {e}" for e in errors))
 
 
+_NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][\w.]*)", re.MULTILINE)
+_TYPE_DECL_RE = re.compile(
+    r"\b(?:class|interface|struct|enum)\s+([A-Za-z_]\w*)"
+    r"|\brecord(?:\s+(?:class|struct))?\s+([A-Za-z_]\w*)"
+)
+
+
+def _build_source_type_index(src_root: Path) -> dict[str, list[Path]]:
+    """Indexes every type declared under ``src/`` as ``Namespace.TypeName``.
+
+    Deliberately lexical (regex over ``.cs`` files, no Roslyn): the
+    entrypoint strings in ``COVERAGE_ENTRIES`` are flat ``Namespace.Type``
+    or ``Namespace.Type.Member`` references, so namespace declarations plus
+    type-declaration keywords are enough to resolve them, and this keeps the
+    gate runnable in the same dependency-free python step CI already uses.
+    """
+
+    index: dict[str, list[Path]] = {}
+    for path in sorted(src_root.rglob("*.cs")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        namespaces = _NAMESPACE_RE.findall(text)
+        type_names = [first or second for first, second in _TYPE_DECL_RE.findall(text)]
+        for namespace in namespaces or [""]:
+            for type_name in type_names:
+                full_name = f"{namespace}.{type_name}" if namespace else type_name
+                index.setdefault(full_name, []).append(path)
+    return index
+
+
+def _validate_entrypoints_against_source(
+    entries: list[dict[str, Any]],
+    type_index: dict[str, list[Path]],
+) -> None:
+    """Source-truth gate: every entrypoint must resolve to real SDK source.
+
+    An entrypoint is either ``Namespace.TypeName`` (must be a declared type)
+    or ``Namespace.TypeName.MemberName`` (the type must be declared and the
+    member name must appear in a file declaring that type). A reference that
+    no longer resolves -- because the surface was deleted or renamed --
+    fails generation and the CI ``--check`` drift gate.
+    """
+
+    errors: list[str] = []
+    file_text_cache: dict[Path, str] = {}
+
+    for entry in entries:
+        key = entry.get("key", "<missing key>")
+        for entrypoint in entry.get("entrypoints", []):
+            if not isinstance(entrypoint, str) or not entrypoint:
+                continue  # shape errors are _validate_entries' job
+            if entrypoint in type_index:
+                continue
+            parent, _, member = entrypoint.rpartition(".")
+            declaring_files = type_index.get(parent, [])
+            if declaring_files and member:
+                member_re = re.compile(rf"\b{re.escape(member)}\b")
+                found = False
+                for path in declaring_files:
+                    if path not in file_text_cache:
+                        file_text_cache[path] = path.read_text(encoding="utf-8", errors="replace")
+                    if member_re.search(file_text_cache[path]):
+                        found = True
+                        break
+                if found:
+                    continue
+                errors.append(
+                    f"{key!r}: entrypoint {entrypoint!r} names member {member!r}, but no file "
+                    f"declaring {parent!r} mentions it. The member was removed or renamed -- "
+                    "update or drop this coverage entry."
+                )
+                continue
+            errors.append(
+                f"{key!r}: entrypoint {entrypoint!r} does not resolve to any type declared "
+                "under src/. The surface was removed or renamed -- update or drop this "
+                "coverage entry so the snapshot stops claiming coverage that no longer exists."
+            )
+
+    if errors:
+        raise ValueError(
+            "sdk-coverage.v1.json entrypoint source-truth check failed:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+
 def _build_document(canonical_keys: frozenset[str], key_list_source: str) -> dict[str, Any]:
     ordered = sorted(COVERAGE_ENTRIES, key=lambda e: e["key"])
     _validate_entries(ordered, canonical_keys)
@@ -577,6 +674,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         canonical_keys, key_list_source = _load_canonical_keys()
+        _validate_entrypoints_against_source(COVERAGE_ENTRIES, _build_source_type_index(SRC_ROOT))
         document = _build_document(canonical_keys, key_list_source)
     except (ValueError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
         print(f"::error::{error}", file=sys.stderr)

--- a/scripts/generate-sdk-coverage.py
+++ b/scripts/generate-sdk-coverage.py
@@ -39,13 +39,17 @@ note fails the build.
 Entrypoints-must-exist (source-truth gate)
 -------------------------------------------
 Every ``entrypoints`` reference must resolve against the actual SDK source
-under ``src/``: the referenced type must be declared in some ``.cs`` file
-(namespace + type name), and a ``Type.Member`` reference must additionally
-name a member that appears in a file declaring that type. This is what makes
-the CI drift gate honest about *renames and deletions*, not just stale
-regeneration: removing or renaming a mapped public client without updating
-the inventory fails ``--check`` instead of leaving the snapshot claiming
-coverage that no longer exists.
+under ``src/``: the referenced type must be *publicly* declared in some
+``.cs`` file (real declaration syntax on comment/string-stripped text --
+``public [modifiers] class|interface|record|struct|enum Name``), and a
+``Type.Member`` reference must additionally match an accessible,
+declaration-shaped member in a file declaring that type. Occurrences that
+survive only in comments, XML doc prose, or string literals never count,
+and a type demoted to ``internal`` stops resolving. This is what makes the
+CI drift gate honest about *renames, deletions, and de-publicizing*, not
+just stale regeneration: any of those without updating the inventory fails
+``--check`` instead of leaving the snapshot claiming coverage that no
+longer exists.
 
 Usage
 -----
@@ -521,32 +525,144 @@ def _validate_entries(entries: list[dict[str, Any]], canonical_keys: frozenset[s
 
 
 _NAMESPACE_RE = re.compile(r"^\s*namespace\s+([A-Za-z_][\w.]*)", re.MULTILINE)
-_TYPE_DECL_RE = re.compile(
-    r"\b(?:class|interface|struct|enum)\s+([A-Za-z_]\w*)"
-    r"|\brecord(?:\s+(?:class|struct))?\s+([A-Za-z_]\w*)"
+
+# A *real, public* type declaration: the `public` keyword, optional
+# additional modifiers, then a type keyword and the type name. Matching is
+# done against comment/string-stripped text (see _strip_comments_and_strings)
+# so a declaration that only survives inside a comment, XML doc line, or
+# string literal never counts, and a type demoted to `internal` (or default
+# accessibility) drops out of the index -- exactly the cases where the
+# snapshot would otherwise keep advertising a public entrypoint that no
+# longer exists. Nested public types and `public partial` declarations
+# spread across files all match (each declaring file lands in the index).
+_PUBLIC_TYPE_DECL_RE = re.compile(
+    r"\bpublic\s+(?:(?:sealed|static|abstract|partial|readonly|ref|unsafe|new)\s+)*"
+    r"(?:class|interface|enum|struct|record(?:\s+(?:class|struct))?)\s+([A-Za-z_]\w*)"
 )
 
 
-def _build_source_type_index(src_root: Path) -> dict[str, list[Path]]:
-    """Indexes every type declared under ``src/`` as ``Namespace.TypeName``.
+def _strip_comments_and_strings(text: str) -> str:
+    """Blanks out comments and string/char literals from C# source.
 
-    Deliberately lexical (regex over ``.cs`` files, no Roslyn): the
-    entrypoint strings in ``COVERAGE_ENTRIES`` are flat ``Namespace.Type``
-    or ``Namespace.Type.Member`` references, so namespace declarations plus
-    type-declaration keywords are enough to resolve them, and this keeps the
-    gate runnable in the same dependency-free python step CI already uses.
+    Keeps the gate lexical and stdlib-only while making sure that ``//`` and
+    ``///`` line comments, ``/* */`` block comments, ordinary/interpolated
+    string literals (with backslash escapes), verbatim ``@"..."`` strings
+    (with ``\"\"`` escapes), raw ``\"\"\"...\"\"\"`` strings, and char
+    literals can never satisfy a type or member existence check. Newlines are
+    preserved so surrounding code structure stays intact.
+    """
+
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if ch == "/" and nxt == "/":
+            end = text.find("\n", i)
+            i = n if end == -1 else end  # keep the newline itself
+        elif ch == "/" and nxt == "*":
+            end = text.find("*/", i + 2)
+            stop = n if end == -1 else end + 2
+            out.append("".join(c if c == "\n" else " " for c in text[i:stop]))
+            i = stop
+        elif ch == "@" and nxt == '"':
+            j = i + 2
+            while j < n:
+                if text[j] == '"':
+                    if j + 1 < n and text[j + 1] == '"':
+                        j += 2
+                        continue
+                    break
+                j += 1
+            out.append(" ")
+            i = j + 1
+        elif ch == '"':
+            if text.startswith('"""', i):
+                end = text.find('"""', i + 3)
+                out.append(" ")
+                i = n if end == -1 else end + 3
+            else:
+                j = i + 1
+                while j < n and text[j] != '"':
+                    j += 2 if text[j] == "\\" else 1
+                out.append(" ")
+                i = j + 1
+        elif ch == "'":
+            j = i + 1
+            while j < n and text[j] != "'":
+                j += 2 if text[j] == "\\" else 1
+            out.append(" ")
+            i = j + 1
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def _build_source_type_index(src_root: Path) -> dict[str, list[Path]]:
+    """Indexes every *public* type declared under ``src/`` as ``Namespace.TypeName``.
+
+    Deliberately lexical (regex over comment/string-stripped ``.cs`` files,
+    no Roslyn): the entrypoint strings in ``COVERAGE_ENTRIES`` are flat
+    ``Namespace.Type`` or ``Namespace.Type.Member`` references, so namespace
+    declarations plus public type-declaration syntax are enough to resolve
+    them, and this keeps the gate runnable in the same dependency-free
+    python step CI already uses.
     """
 
     index: dict[str, list[Path]] = {}
     for path in sorted(src_root.rglob("*.cs")):
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = _strip_comments_and_strings(path.read_text(encoding="utf-8", errors="replace"))
         namespaces = _NAMESPACE_RE.findall(text)
-        type_names = [first or second for first, second in _TYPE_DECL_RE.findall(text)]
+        type_names = _PUBLIC_TYPE_DECL_RE.findall(text)
         for namespace in namespaces or [""]:
             for type_name in type_names:
                 full_name = f"{namespace}.{type_name}" if namespace else type_name
                 index.setdefault(full_name, []).append(path)
     return index
+
+
+# Header tokens that mark a candidate member match as something other than an
+# accessible declaration: explicit non-public accessibility, or statement
+# keywords that mean the name is being *invoked/consumed* rather than declared.
+_MEMBER_REJECT_TOKENS = frozenset({"private", "protected", "return", "await", "throw", "yield"})
+
+
+def _member_publicly_declared(member: str, stripped_text: str) -> bool:
+    """True when ``stripped_text`` plausibly *declares* an accessible ``member``.
+
+    A declaration-shaped occurrence is the member name followed by ``(`` or
+    ``<...>(`` (method/ctor), or by ``{``, ``=>``, ``;``, or ``=`` (property,
+    field, event, expression-bodied member). The declaration header -- the
+    text between the previous ``;``/``{``/``}`` and the name -- must not
+    carry ``private``/``protected`` (or ``internal`` without ``public``;
+    interface members legitimately carry no modifier at all) and must not
+    look like an invocation context. Input must already be comment/string
+    stripped, so a renamed method whose old name lingers only in XML doc
+    prose, a comment, or a string no longer resolves.
+    """
+
+    declaration_re = re.compile(
+        rf"(?<![\w.]){re.escape(member)}\s*(?:<[^<>]{{0,120}}>)?\s*(?:\(|\{{|=>|;|=(?!=))"
+    )
+    for match in declaration_re.finditer(stripped_text):
+        start = match.start()
+        header_start = max(
+            stripped_text.rfind(";", 0, start),
+            stripped_text.rfind("{", 0, start),
+            stripped_text.rfind("}", 0, start),
+        ) + 1
+        header = stripped_text[header_start:start]
+        tokens = set(re.findall(r"[A-Za-z_]\w*", header))
+        if tokens & _MEMBER_REJECT_TOKENS:
+            continue
+        if "internal" in tokens and "public" not in tokens:
+            continue
+        trailing = header.rstrip()
+        if trailing and trailing[-1] in "=(,&|?:!+-*/":
+            continue  # argument/operand position -- an invocation, not a declaration
+        return True
+    return False
 
 
 def _validate_entrypoints_against_source(
@@ -555,10 +671,12 @@ def _validate_entrypoints_against_source(
 ) -> None:
     """Source-truth gate: every entrypoint must resolve to real SDK source.
 
-    An entrypoint is either ``Namespace.TypeName`` (must be a declared type)
-    or ``Namespace.TypeName.MemberName`` (the type must be declared and the
-    member name must appear in a file declaring that type). A reference that
-    no longer resolves -- because the surface was deleted or renamed --
+    An entrypoint is either ``Namespace.TypeName`` (must be a *publicly*
+    declared type) or ``Namespace.TypeName.MemberName`` (the type must be
+    publicly declared and the member name must appear as an accessible,
+    declaration-shaped member in a file declaring that type -- see
+    ``_member_publicly_declared``). A reference that no longer resolves --
+    because the surface was deleted, renamed, or demoted from ``public`` --
     fails generation and the CI ``--check`` drift gate.
     """
 
@@ -575,26 +693,28 @@ def _validate_entrypoints_against_source(
             parent, _, member = entrypoint.rpartition(".")
             declaring_files = type_index.get(parent, [])
             if declaring_files and member:
-                member_re = re.compile(rf"\b{re.escape(member)}\b")
                 found = False
                 for path in declaring_files:
                     if path not in file_text_cache:
-                        file_text_cache[path] = path.read_text(encoding="utf-8", errors="replace")
-                    if member_re.search(file_text_cache[path]):
+                        file_text_cache[path] = _strip_comments_and_strings(
+                            path.read_text(encoding="utf-8", errors="replace")
+                        )
+                    if _member_publicly_declared(member, file_text_cache[path]):
                         found = True
                         break
                 if found:
                     continue
                 errors.append(
                     f"{key!r}: entrypoint {entrypoint!r} names member {member!r}, but no file "
-                    f"declaring {parent!r} mentions it. The member was removed or renamed -- "
-                    "update or drop this coverage entry."
+                    f"declaring {parent!r} declares an accessible member by that name "
+                    "(occurrences in comments, XML docs, and strings do not count). The member "
+                    "was removed or renamed -- update or drop this coverage entry."
                 )
                 continue
             errors.append(
-                f"{key!r}: entrypoint {entrypoint!r} does not resolve to any type declared "
-                "under src/. The surface was removed or renamed -- update or drop this "
-                "coverage entry so the snapshot stops claiming coverage that no longer exists."
+                f"{key!r}: entrypoint {entrypoint!r} does not resolve to any type publicly declared "
+                "under src/. The surface was removed, renamed, or made non-public -- update or drop "
+                "this coverage entry so the snapshot stops claiming coverage that no longer exists."
             )
 
     if errors:

--- a/scripts/tests/test_sdk_coverage.py
+++ b/scripts/tests/test_sdk_coverage.py
@@ -83,6 +83,56 @@ class ValidateEntriesTests(unittest.TestCase):
             self.module._validate_entries(entries, self.canonical)
 
 
+class SourceTruthGateTests(unittest.TestCase):
+    """The entrypoints-must-exist gate (rename/delete drift, issue #273)."""
+
+    def setUp(self) -> None:
+        self.module = _load_module()
+
+    def test_source_type_index_finds_declared_types(self) -> None:
+        index = self.module._build_source_type_index(ROOT / "src")
+        self.assertIn("Honua.Sdk.GeoServices.FeatureServer.HonuaFeatureServerClient", index)
+
+    def test_type_entrypoint_resolves(self) -> None:
+        index = {"Ns.Client": [Path("fake.cs")]}
+        entries = [{"key": "a.one", "entrypoints": ["Ns.Client"]}]
+        # Should not raise.
+        self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_member_entrypoint_resolves_when_member_in_declaring_file(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "Client.cs"
+            source.write_text("namespace Ns;\npublic interface Client { void DoThingAsync(); }\n", encoding="utf-8")
+            index = {"Ns.Client": [source]}
+            entries = [{"key": "a.one", "entrypoints": ["Ns.Client.DoThingAsync"]}]
+            self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_deleted_type_fails(self) -> None:
+        entries = [{"key": "a.one", "entrypoints": ["Ns.RemovedClient"]}]
+        with self.assertRaisesRegex(ValueError, "does not resolve to any type"):
+            self.module._validate_entrypoints_against_source(entries, {})
+
+    def test_renamed_member_fails(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "Client.cs"
+            source.write_text("namespace Ns;\npublic interface Client { void NewNameAsync(); }\n", encoding="utf-8")
+            index = {"Ns.Client": [source]}
+            entries = [{"key": "a.one", "entrypoints": ["Ns.Client.OldNameAsync"]}]
+            with self.assertRaisesRegex(ValueError, "was removed or renamed"):
+                self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_every_curated_entrypoint_resolves_against_real_source(self) -> None:
+        # The gate CI actually relies on: the shipped inventory must resolve
+        # against the shipped src/ tree, so a rename/deletion of a mapped
+        # public surface fails this suite (and generate --check) immediately.
+        index = self.module._build_source_type_index(ROOT / "src")
+        self.module._validate_entrypoints_against_source(self.module.COVERAGE_ENTRIES, index)
+
+
 class RealInventoryTests(unittest.TestCase):
     """Exercises the actual curated COVERAGE_ENTRIES against the pinned fixture."""
 

--- a/scripts/tests/test_sdk_coverage.py
+++ b/scripts/tests/test_sdk_coverage.py
@@ -89,6 +89,17 @@ class SourceTruthGateTests(unittest.TestCase):
     def setUp(self) -> None:
         self.module = _load_module()
 
+    def _index_of(self, *sources: str):
+        """Builds a source type index over throwaway .cs files."""
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        for i, source in enumerate(sources):
+            (root / f"File{i}.cs").write_text(source, encoding="utf-8")
+        return self.module._build_source_type_index(root)
+
     def test_source_type_index_finds_declared_types(self) -> None:
         index = self.module._build_source_type_index(ROOT / "src")
         self.assertIn("Honua.Sdk.GeoServices.FeatureServer.HonuaFeatureServerClient", index)
@@ -124,6 +135,123 @@ class SourceTruthGateTests(unittest.TestCase):
             entries = [{"key": "a.one", "entrypoints": ["Ns.Client.OldNameAsync"]}]
             with self.assertRaisesRegex(ValueError, "was removed or renamed"):
                 self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_internal_type_is_not_indexed(self) -> None:
+        index = self._index_of("namespace Ns;\ninternal sealed class Client { }\n")
+        self.assertNotIn("Ns.Client", index)
+        entries = [{"key": "a.one", "entrypoints": ["Ns.Client"]}]
+        with self.assertRaisesRegex(ValueError, "does not resolve to any type"):
+            self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_default_accessibility_type_is_not_indexed(self) -> None:
+        index = self._index_of("namespace Ns;\nclass Client { }\n")
+        self.assertNotIn("Ns.Client", index)
+
+    def test_type_declaration_only_in_comment_is_not_indexed(self) -> None:
+        source = (
+            "namespace Ns;\n"
+            "// public class Client used to live here\n"
+            "/* public interface Client { } */\n"
+            "/// <summary>public record Client</summary>\n"
+            'public class Other { public string S => "public class Client"; }\n'
+        )
+        index = self._index_of(source)
+        self.assertNotIn("Ns.Client", index)
+        self.assertIn("Ns.Other", index)
+
+    def test_public_partial_and_nested_types_are_indexed(self) -> None:
+        index = self._index_of(
+            "namespace Ns;\npublic partial class Client { public void FirstAsync() { } }\n",
+            "namespace Ns;\npublic partial class Client { public void SecondAsync() { } }\n",
+            "namespace Ns;\npublic static class Outer { public sealed class Inner { } }\n",
+        )
+        self.assertEqual(2, len(index["Ns.Client"]))
+        self.assertIn("Ns.Inner", index)
+        entries = [
+            {"key": "a.one", "entrypoints": ["Ns.Client.FirstAsync", "Ns.Client.SecondAsync"]},
+            {"key": "a.two", "entrypoints": ["Ns.Outer.Inner"]},
+        ]
+        # Should not raise: partial spread across files and nested public types resolve.
+        self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_record_struct_and_readonly_record_struct_are_indexed(self) -> None:
+        index = self._index_of(
+            "namespace Ns;\npublic readonly record struct Envelope(double X, double Y);\n"
+            "namespace Ns;\npublic record class Payload(string Id);\n"
+        )
+        self.assertIn("Ns.Envelope", index)
+        self.assertIn("Ns.Payload", index)
+
+    def test_member_only_in_xml_doc_or_comment_fails(self) -> None:
+        source = (
+            "namespace Ns;\n"
+            "/// <summary>Replaces OldNameAsync entirely; see OldNameAsync(CancellationToken).</summary>\n"
+            "public interface Client\n{\n"
+            "    // OldNameAsync() was removed in 2.0\n"
+            "    Task NewNameAsync();\n"
+            "}\n"
+        )
+        index = self._index_of(source)
+        entries = [{"key": "a.one", "entrypoints": ["Ns.Client.OldNameAsync"]}]
+        with self.assertRaisesRegex(ValueError, "was removed or renamed"):
+            self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_member_only_in_string_literal_fails(self) -> None:
+        source = (
+            "namespace Ns;\n"
+            "public class Client\n{\n"
+            '    public string Hint => "call OldNameAsync() instead";\n'
+            "}\n"
+        )
+        index = self._index_of(source)
+        entries = [{"key": "a.one", "entrypoints": ["Ns.Client.OldNameAsync"]}]
+        with self.assertRaisesRegex(ValueError, "was removed or renamed"):
+            self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_private_member_fails(self) -> None:
+        source = (
+            "namespace Ns;\n"
+            "public class Client\n{\n"
+            "    private Task OldNameAsync() => Task.CompletedTask;\n"
+            "}\n"
+        )
+        index = self._index_of(source)
+        entries = [{"key": "a.one", "entrypoints": ["Ns.Client.OldNameAsync"]}]
+        with self.assertRaisesRegex(ValueError, "was removed or renamed"):
+            self.module._validate_entrypoints_against_source(entries, index)
+
+    def test_genuine_public_member_shapes_resolve(self) -> None:
+        source = (
+            "namespace Ns;\n"
+            "public class Client\n{\n"
+            "    public async Task<int> QueryAsync(string q) => await Task.FromResult(1);\n"
+            "    public int Count => 42;\n"
+            "    public string Name { get; set; }\n"
+            "    public event EventHandler Changed;\n"
+            "    public Client(string seed) { }\n"
+            "    public TResult Map<TResult>(Func<int, TResult> f) => f(1);\n"
+            "}\n"
+            "public interface Reader\n{\n"
+            "    Task<string> ReadAsync(CancellationToken ct);\n"
+            "}\n"
+        )
+        index = self._index_of(source)
+        entries = [
+            {
+                "key": "a.one",
+                "entrypoints": [
+                    "Ns.Client.QueryAsync",
+                    "Ns.Client.Count",
+                    "Ns.Client.Name",
+                    "Ns.Client.Changed",
+                    "Ns.Client.Map",
+                    "Ns.Reader.ReadAsync",
+                ],
+            }
+        ]
+        # Should not raise: methods, expression-bodied members, auto-properties,
+        # events, generic methods, and implicit-public interface members resolve.
+        self.module._validate_entrypoints_against_source(entries, index)
 
     def test_every_curated_entrypoint_resolves_against_real_source(self) -> None:
         # The gate CI actually relies on: the shipped inventory must resolve


### PR DESCRIPTION
Fixes #273

## Summary

Issue #273's producer snapshot (`contracts/sdk-coverage.v1.json`) landed in #274 (generator, unknown-key validation, CI drift gate, docs) and #278 (evidence dispatch), and honua-evidence now provably ingests it — the 2026-07-27 aggregate `capability-matrix.v1.json` joins this SDK's coverage per capability under `capabilities[].sdks.dotnet`, with the producer fresh in the freshness ledger.

This PR closes the one remaining acceptance-criteria gap before the issue can close: **"Drift gate: SDK release that changes coverage without snapshot update fails."** The gate previously only compared generator output against the committed snapshot, so deleting or renaming a mapped public SDK surface (e.g. `HonuaFeatureServerClient`) kept CI green while the snapshot claimed coverage that no longer exists — despite the inventory's own contract ("remove an entry the moment the mapped surface is deleted or renamed").

## Changes

- `scripts/generate-sdk-coverage.py`: new source-truth gate. The generator indexes every type declared under `src/` (namespace + class/interface/record/struct/enum declarations) and fails both generation and `--check` when an entrypoint no longer resolves: `Namespace.Type` must be a declared type; `Namespace.Type.Member` must also name a member appearing in a file declaring that type. Verified end-to-end: renaming `HonuaFeatureServerClient` in `src/` makes `--check` exit 1 with an actionable error.
- `scripts/tests/test_sdk_coverage.py`: 6 new tests — source index resolution, type/member success paths, deleted-type and renamed-member failure paths, and a suite-level gate asserting the entire curated inventory resolves against the real `src/` tree (35 tests total, all passing).
- `contracts/fixtures/capability-keys.fixture.json`: refreshed to the current byte-for-byte mirror of honua-server trunk `docs/gis/data/capability-keys.v1.json`. The key set is unchanged (110 keys), only non-key metadata drifted; the committed snapshot is byte-identical, so this is a no-op for consumers.
- `docs/capability-coverage.md`: documents the source-truth gate and replaces the stale "honua-evidence ingestion is not yet proven end-to-end" known-gap section with the now-true ingestion description (aggregate join, freshness ledger, `notify-evidence.yml` dispatch).
- `.github/workflows/ci.yml`: drift-gate step comment updated to mention the new failure mode (comment-only).

## Validation

- `python3 scripts/generate-sdk-coverage.py --check` — passes; snapshot unchanged (pure enforcement addition).
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 35 tests, all pass.
- Negative test: renamed a mapped class in `src/`, gate fails with a targeted error naming the capability key and entrypoint; restored cleanly.