### PR TITLE
docs: README refresh follow-ups - replace archived honua-server-admin references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,15 +197,15 @@ file placement, or app lifecycle hooks.
   issue before implementation starts.
 - If mobile/admin needs different runtime behavior, put the stable contract here
   and put the adapter/runtime issue in the consuming repo.
-- Keep migration issues cross-linked with `honua-mobile` and `honua-server-admin`.
+- Keep migration issues cross-linked with `honua-mobile` and `honua-console`.
 
 ## Companion Repos
 
 - `honua-mobile`: mobile runtime, MAUI adapters, native storage adapters,
   permissions, background sync scheduling, mobile UI, AR/VR, and display
   integration.
-- `honua-server-admin`: Blazor/MudBlazor operator UI, page composition, local
-  stubs, and admin workspace UX.
+- `honua-console`: admin/console UI, Studio map builder, style editor, and
+  operator workspace UX.
 - `honua-server`: server APIs and backend functionality that SDK clients depend
   on.
 


### PR DESCRIPTION
Fixes #271

## Summary
Doc-side follow-up from the README refresh (#270). Recon against current `trunk` confirmed one of the two listed items is already-honest documentation and the other was still stale.

## Changes Made
- `AGENTS.md`: replaced the archived `honua-server-admin` companion-repo entry with `honua-console` (active admin/console UI home) and updated the migration cross-link bullet to match.

## Recon notes
- README already documents the honest publishing state (GitHub Packages today, nuget.org gated on a stable `Geospatial.Grpc` release) — no README change needed.
- Verified `Honua.Sdk` still has 0 hits on nuget.org search, so the publish item remains open.

## Operator items remaining (not addressed here)
- Publish `Honua.Sdk` / `Honua.Sdk.Grpc` and the rest of the package set to nuget.org. This is a registry/release action gated on a stable `Geospatial.Grpc` release (tracked in the geospatial-grpc follow-up issue) and is operator-owned.
